### PR TITLE
[Util] Storage data migration with SSTables (~10x migration speed improvement)

### DIFF
--- a/cmd/util/cmd/db-migration/cmd.go
+++ b/cmd/util/cmd/db-migration/cmd.go
@@ -55,7 +55,7 @@ func run(*cobra.Command, []string) {
 
 	lg.Info().Msgf("starting migration from badger db to pebble db")
 
-	err := migration.RunMigration(flagBadgerDBdir, flagPebbleDBdir, migration.MigrationConfig{
+	err := migration.RunMigrationAndCompaction(flagBadgerDBdir, flagPebbleDBdir, migration.MigrationConfig{
 		BatchByteSize:          flagBatchByteSize,
 		ReaderWorkerCount:      flagReaderCount,
 		WriterWorkerCount:      flagWriterCount,

--- a/cmd/util/cmd/db-migration/cmd.go
+++ b/cmd/util/cmd/db-migration/cmd.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"github.com/docker/go-units"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/storage/migration"
+)
+
+var (
+	flagBadgerDBdir            string
+	flagPebbleDBdir            string
+	flagBatchByteSize          int
+	flagReaderCount            int
+	flagWriterCount            int
+	flagReaderShardPrefixBytes int
+)
+
+var Cmd = &cobra.Command{
+	Use:   "db-migration",
+	Short: "copy badger db to pebble db",
+	Run:   run,
+}
+
+func init() {
+	Cmd.Flags().StringVar(&flagBadgerDBdir, "datadir", "", "BadgerDB Dir to copy data from")
+	_ = Cmd.MarkFlagRequired("datadir")
+
+	Cmd.Flags().StringVar(&flagPebbleDBdir, "pebbledir", "", "PebbleDB Dir to copy data to")
+	_ = Cmd.MarkFlagRequired("pebbledir")
+
+	Cmd.Flags().IntVar(&flagBatchByteSize, "batch_byte_size", migration.DefaultMigrationConfig.BatchByteSize,
+		"the batch size in bytes to use for migration (32MB by default)")
+
+	Cmd.Flags().IntVar(&flagReaderCount, "reader_count", migration.DefaultMigrationConfig.ReaderWorkerCount,
+		"the number of reader workers to use for migration")
+
+	Cmd.Flags().IntVar(&flagWriterCount, "writer_count", migration.DefaultMigrationConfig.WriterWorkerCount,
+		"the number of writer workers to use for migration")
+
+	Cmd.Flags().IntVar(&flagReaderShardPrefixBytes, "reader_shard_prefix_bytes", migration.DefaultMigrationConfig.ReaderShardPrefixBytes,
+		"the number of prefix bytes used to assign iterator workload")
+}
+
+func run(*cobra.Command, []string) {
+	lg := log.With().
+		Str("badger_db_dir", flagBadgerDBdir).
+		Str("pebble_db_dir", flagPebbleDBdir).
+		Str("batch_byte_size", units.HumanSize(float64(flagBatchByteSize))).
+		Int("reader_count", flagReaderCount).
+		Int("writer_count", flagWriterCount).
+		Int("reader_shard_prefix_bytes", flagReaderShardPrefixBytes).
+		Logger()
+
+	lg.Info().Msgf("starting migration from badger db to pebble db")
+
+	err := migration.RunMigration(flagBadgerDBdir, flagPebbleDBdir, migration.MigrationConfig{
+		BatchByteSize:          flagBatchByteSize,
+		ReaderWorkerCount:      flagReaderCount,
+		WriterWorkerCount:      flagWriterCount,
+		ReaderShardPrefixBytes: flagReaderShardPrefixBytes,
+	})
+
+	if err != nil {
+		lg.Error().Err(err).Msg("migration failed")
+		return
+	}
+
+	lg.Info().Msgf("migration completed")
+}

--- a/cmd/util/cmd/db-migration/cmd.go
+++ b/cmd/util/cmd/db-migration/cmd.go
@@ -57,6 +57,17 @@ func run(*cobra.Command, []string) error {
 		Logger()
 
 	lg.Info().Msgf("starting migration from badger db to pebble db")
+	err := migration.RunMigrationAndCompaction(flagBadgerDBdir, flagPebbleDBdir, migration.MigrationConfig{
+		BatchByteSize:          flagBatchByteSize,
+		ReaderWorkerCount:      flagReaderCount,
+		WriterWorkerCount:      flagWriterCount,
+		ReaderShardPrefixBytes: flagReaderShardPrefixBytes,
+	})
+
+	if err != nil {
+		return fmt.Errorf("migration failed: %w", err)
+	}
+
 	pebbleDB, err := pebble.Open(flagPebbleDBdir, &pebble.Options{})
 	if err != nil {
 		return fmt.Errorf("failed to open PebbleDB: %w", err)
@@ -66,17 +77,6 @@ func run(*cobra.Command, []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read finalized height from PebbleDB: %w", err)
 	}
-
-	// err = migration.RunMigrationAndCompaction(flagBadgerDBdir, flagPebbleDBdir, migration.MigrationConfig{
-	// 	BatchByteSize:          flagBatchByteSize,
-	// 	ReaderWorkerCount:      flagReaderCount,
-	// 	WriterWorkerCount:      flagWriterCount,
-	// 	ReaderShardPrefixBytes: flagReaderShardPrefixBytes,
-	// })
-	//
-	// if err != nil {
-	// 	return fmt.Errorf("migration failed: %w", err)
-	// }
 
 	lg.Info().Msgf("finalized height: %d", height)
 	return nil

--- a/cmd/util/cmd/db-migration/cmd.go
+++ b/cmd/util/cmd/db-migration/cmd.go
@@ -3,7 +3,6 @@ package db
 import (
 	"fmt"
 
-	"github.com/cockroachdb/pebble"
 	"github.com/docker/go-units"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -68,16 +67,5 @@ func run(*cobra.Command, []string) error {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 
-	pebbleDB, err := pebble.Open(flagPebbleDBdir, &pebble.Options{})
-	if err != nil {
-		return fmt.Errorf("failed to open PebbleDB: %w", err)
-	}
-
-	height, err := migration.ReadFinalizedHeight(pebbleDB)
-	if err != nil {
-		return fmt.Errorf("failed to read finalized height from PebbleDB: %w", err)
-	}
-
-	lg.Info().Msgf("finalized height: %d", height)
 	return nil
 }

--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	checkpoint_collect_stats "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-collect-stats"
 	checkpoint_list_tries "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-list-tries"
 	checkpoint_trie_stats "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-trie-stats"
+	db_migration "github.com/onflow/flow-go/cmd/util/cmd/db-migration"
 	debug_script "github.com/onflow/flow-go/cmd/util/cmd/debug-script"
 	debug_tx "github.com/onflow/flow-go/cmd/util/cmd/debug-tx"
 	diff_states "github.com/onflow/flow-go/cmd/util/cmd/diff-states"
@@ -132,6 +133,7 @@ func addCommands() {
 	rootCmd.AddCommand(evm_state_exporter.Cmd)
 	rootCmd.AddCommand(verify_execution_result.Cmd)
 	rootCmd.AddCommand(verify_evm_offchain_replay.Cmd)
+	rootCmd.AddCommand(db_migration.Cmd)
 }
 
 func initConfig() {

--- a/storage/migration/migration.go
+++ b/storage/migration/migration.go
@@ -86,8 +86,6 @@ func readerWorker(
 ) error {
 	for prefix := range jobs {
 		err := db.View(func(txn *badger.Txn) error {
-			defer lgProgress(1)
-
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}

--- a/storage/migration/migration.go
+++ b/storage/migration/migration.go
@@ -139,6 +139,8 @@ func readerWorker(
 			return nil
 		})
 
+		lgProgress(1)
+
 		if err != nil {
 			return err
 		}

--- a/storage/migration/migration.go
+++ b/storage/migration/migration.go
@@ -16,6 +16,7 @@ import (
 )
 
 type MigrationConfig struct {
+	PebbleDir         string
 	BatchByteSize     int // the size of each batch to write to pebble
 	ReaderWorkerCount int // the number of workers to read from badger
 	WriterWorkerCount int // the number of workers to write to the pebble

--- a/storage/migration/migration_test.go
+++ b/storage/migration/migration_test.go
@@ -81,7 +81,7 @@ func runMigrationTestCase(t *testing.T, testData map[string]string, cfg Migratio
 }
 
 // Simple deterministic dataset
-func TestMigrationWithSimpleData(t *testing.T) {
+func TestMigrationWithSimpleData1(t *testing.T) {
 	data := map[string]string{
 		"a":      "a single key byte",
 		"z":      "a single key byte",

--- a/storage/migration/migration_test.go
+++ b/storage/migration/migration_test.go
@@ -45,7 +45,7 @@ func runMigrationTestCase(t *testing.T, testData map[string]string, cfg Migratio
 		}))
 
 		// Run migration
-		err := CopyFromBadgerToPebble(badgerDB, pebbleDB, cfg)
+		err := CopyFromBadgerToPebbleSSTables(badgerDB, pebbleDB, cfg)
 		require.NoError(t, err)
 
 		// Validate each key

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -62,9 +62,7 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 	// Step 2: Open Badger and Pebble DBs
 	log.Info().Msgf("Step 2/6 Opening BadgerDB and PebbleDB...")
 	badgerOptions := badger.DefaultOptions(badgerDir).
-		WithLogger(util.NewLogger(log.Logger.With().Str("db", "badger").Logger())).
-		WithNumCompactors(0).
-		WithNumLevelZeroTables(0)
+		WithLogger(util.NewLogger(log.Logger.With().Str("db", "badger").Logger()))
 	badgerDB, err := badger.Open(badgerOptions)
 	if err != nil {
 		return fmt.Errorf("failed to open BadgerDB: %w", err)
@@ -126,8 +124,6 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 
 	lg.Info().Str("file", completeMarkerPath).
 		Msgf("Step 6/6 Migration marker file written successfully.")
-
-	lg.Info().Str("file", completeMarkerPath).Msgf("Migration marker file written successfully.")
 
 	return nil
 }

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -48,7 +48,9 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 	}
 	defer badgerDB.Close()
 
-	pebbleDB, err := pebble.Open(pebbleDir, &pebble.Options{})
+	pebbleDB, err := pebble.Open(pebbleDir, &pebble.Options{
+		DisableAutomaticCompactions: true,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to open PebbleDB: %w", err)
 	}
@@ -67,7 +69,7 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 		Str("to-pebble-dir", pebbleDir).
 		Logger()
 
-	lg.Info().Msgf("Migration started. created mark file: %s", startMarkerPath)
+	lg.Info().Msgf("Step 3/7 Migration started. created mark file: %s", startMarkerPath)
 
 	// Step 4: Migrate data
 	if err := CopyFromBadgerToPebble(badgerDB, pebbleDB, cfg); err != nil {
@@ -76,7 +78,7 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 
 	validatingPrefixBytesCount := 2
 
-	lg.Info().Msgf("Migration from BadgerDB to PebbleDB completed successfully. "+
+	lg.Info().Msgf("Step 4/7 Migration from BadgerDB to PebbleDB completed successfully. "+
 		"Validating key consistency with %v prefix bytes...", validatingPrefixBytesCount)
 
 	// Step 5: Validate data
@@ -84,7 +86,7 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 		return fmt.Errorf("data validation failed: %w", err)
 	}
 
-	log.Info().Msgf("Data validation between BadgerDB and PebbleDB completed successfully.")
+	log.Info().Msgf("Step 5/7 Data validation between BadgerDB and PebbleDB completed successfully.")
 
 	// Step 6: Write MIGRATION_COMPLETED file with timestamp
 	endTime := time.Now().Format(time.RFC3339)
@@ -94,7 +96,17 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 		return fmt.Errorf("failed to write MIGRATION_COMPLETED file: %w", err)
 	}
 
-	lg.Info().Str("file", completeMarkerPath).Msgf("Migration marker file written successfully.")
+	lg.Info().Str("file", completeMarkerPath).
+		Msgf("Step 6/7 Migration marker file written successfully. Compacting pebbleDB...")
+
+	// Step 7: Compact the Pebble DB
+	// 1 byte prefix is enough
+	err = pebbleDB.Compact([]byte{0x00}, []byte{0xff}, true)
+	if err != nil {
+		return fmt.Errorf("fail to compact")
+	}
+
+	log.Info().Msgf("Step 7/7 Compaction completed. Migration completed.")
 
 	return nil
 }

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -83,6 +83,7 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 	lg.Info().Msgf("Step 3/7 Migration started. created mark file: %s", startMarkerPath)
 
 	// Step 4: Migrate data
+	cfg.PebbleDir = pebbleDir
 	if err := CopyFromBadgerToPebbleSSTables(badgerDB, pebbleDB, cfg); err != nil {
 		return fmt.Errorf("failed to migrate data from Badger to Pebble: %w", err)
 	}

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -1,0 +1,92 @@
+package migration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/dgraph-io/badger/v2"
+	"github.com/rs/zerolog/log"
+)
+
+var DefaultMigrationConfig = MigrationConfig{
+	BatchByteSize:          32_000_000, // 32 MB
+	ReaderWorkerCount:      2,
+	WriterWorkerCount:      2,
+	ReaderShardPrefixBytes: 2, // better to keep it as 2.
+}
+
+// RunMigration performs a complete migration of key-value data from a BadgerDB directory
+// to a PebbleDB directory and verifies the integrity of the migrated data.
+//
+// It executes the following steps:
+//
+//  1. Validates that the Badger directory exists and is non-empty.
+//     Ensures that the Pebble directory does not already contain data.
+//  2. Opens both databases and runs the migration using CopyFromBadgerToPebble with the given config.
+//  3. Writes a "MIGRATION_STARTED" marker file with a timestamp in the Pebble directory.
+//  4. After migration, performs validation by:
+//     - Generating a list of prefix shards (based on 2-byte prefixes)
+//     - Finding the min and max keys for each prefix group
+//     - Comparing the values of those keys between Badger and Pebble
+//  5. Writes a "MIGRATION_COMPLETED" marker file with a timestamp to signal successful completion.
+//
+// This function returns an error if any part of the process fails, including directory checks,
+// database operations, or validation mismatches.
+func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error {
+	// Step 1: Validate directories
+	if err := validateBadgerFolderExistPebbleFolderEmpty(badgerDir, pebbleDir); err != nil {
+		return fmt.Errorf("directory validation failed: %w", err)
+	}
+
+	// Step 2: Open Badger and Pebble DBs
+	badgerDB, err := badger.Open(badger.DefaultOptions(badgerDir).WithLogger(nil))
+	if err != nil {
+		return fmt.Errorf("failed to open BadgerDB: %w", err)
+	}
+	defer badgerDB.Close()
+
+	pebbleDB, err := pebble.Open(pebbleDir, &pebble.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to open PebbleDB: %w", err)
+	}
+	defer pebbleDB.Close()
+
+	// Step 3: Write MIGRATION_STARTED file with timestamp
+	startTime := time.Now().Format(time.RFC3339)
+	startMarkerPath := filepath.Join(pebbleDir, "MIGRATION_STARTED")
+	startContent := fmt.Sprintf("migration started at %s\n", startTime)
+	if err := os.WriteFile(startMarkerPath, []byte(startContent), 0644); err != nil {
+		return fmt.Errorf("failed to write MIGRATION_STARTED file: %w", err)
+	}
+
+	log.Info().Str("file", startMarkerPath).Msgf("Migration started.")
+
+	// Step 4: Migrate data
+	if err := CopyFromBadgerToPebble(badgerDB, pebbleDB, cfg); err != nil {
+		return fmt.Errorf("failed to migrate data from Badger to Pebble: %w", err)
+	}
+
+	log.Info().Msgf("Migration from BadgerDB to PebbleDB completed successfully. Validating...")
+
+	// Step 5: Validate data
+	if err := validateMinMaxKeyConsistency(badgerDB, pebbleDB, 2); err != nil {
+		return fmt.Errorf("data validation failed: %w", err)
+	}
+
+	log.Info().Msgf("Data validation between BadgerDB and PebbleDB completed successfully.")
+
+	// Step 6: Write MIGRATION_COMPLETED file with timestamp
+	endTime := time.Now().Format(time.RFC3339)
+	completeMarkerPath := filepath.Join(pebbleDir, "MIGRATION_COMPLETED")
+	completeContent := fmt.Sprintf("migration completed at %s\n", endTime)
+	if err := os.WriteFile(completeMarkerPath, []byte(completeContent), 0644); err != nil {
+		return fmt.Errorf("failed to write MIGRATION_COMPLETED file: %w", err)
+	}
+
+	log.Info().Str("file", completeMarkerPath).Msgf("Migration marker file written successfully.")
+
+	return nil
+}

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/flow-go/storage/operation"
+	"github.com/onflow/flow-go/storage/operation/pebbleimpl"
 	"github.com/onflow/flow-go/storage/util"
 	"github.com/rs/zerolog/log"
 )
@@ -128,4 +130,13 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 	lg.Info().Str("file", completeMarkerPath).Msgf("Migration marker file written successfully.")
 
 	return nil
+}
+
+func ReadFinalizedHeight(pebbleDB *pebble.DB) (uint64, error) {
+	var height uint64
+	err := operation.RetrieveFinalizedHeight(pebbleimpl.ToDB(pebbleDB).Reader(), &height)
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve finalized height: %w", err)
+	}
+	return height, nil
 }

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -125,7 +125,7 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 	}
 
 	lg.Info().Str("file", completeMarkerPath).
-		Msgf("Step 6/6 Migration marker file written successfully. Compacting pebbleDB...")
+		Msgf("Step 6/6 Migration marker file written successfully.")
 
 	lg.Info().Str("file", completeMarkerPath).Msgf("Migration marker file written successfully.")
 

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/dgraph-io/badger/v2"
-	"github.com/onflow/flow-go/storage/operation"
-	"github.com/onflow/flow-go/storage/operation/pebbleimpl"
 	"github.com/onflow/flow-go/storage/util"
 	"github.com/rs/zerolog/log"
 )
@@ -127,15 +125,7 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 	lg.Info().Str("file", completeMarkerPath).
 		Msgf("Step 6/6 Migration marker file written successfully. Compacting pebbleDB...")
 
-	lg.Info().Msgf("reading finalized height...")
-
-	var height uint64
-	err = operation.RetrieveFinalizedHeight(pebbleimpl.ToDB(pebbleDB).Reader(), &height)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve finalized height: %w", err)
-	}
-
-	log.Info().Msgf("Finalized height retrieved: %d", height)
+	lg.Info().Str("file", completeMarkerPath).Msgf("Migration marker file written successfully.")
 
 	return nil
 }

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -72,7 +72,7 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 	lg.Info().Msgf("Step 3/7 Migration started. created mark file: %s", startMarkerPath)
 
 	// Step 4: Migrate data
-	if err := CopyFromBadgerToPebble(badgerDB, pebbleDB, cfg); err != nil {
+	if err := CopyFromBadgerToPebbleSSTables(badgerDB, pebbleDB, cfg); err != nil {
 		return fmt.Errorf("failed to migrate data from Badger to Pebble: %w", err)
 	}
 

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -46,7 +46,6 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 	log.Info().Msgf("Step 2/7 Opening BadgerDB and PebbleDB...")
 	badgerOptions := badger.DefaultOptions(badgerDir).
 		WithLogger(util.NewLogger(log.Logger.With().Str("db", "badger").Logger())).
-		WithReadOnly(true).
 		WithNumCompactors(0).
 		WithNumLevelZeroTables(0)
 	badgerDB, err := badger.Open(badgerOptions)

--- a/storage/migration/runner.go
+++ b/storage/migration/runner.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/flow-go/storage/operation"
+	"github.com/onflow/flow-go/storage/operation/pebbleimpl"
 	"github.com/onflow/flow-go/storage/util"
 	"github.com/rs/zerolog/log"
 )
@@ -124,6 +126,16 @@ func RunMigration(badgerDir string, pebbleDir string, cfg MigrationConfig) error
 
 	lg.Info().Str("file", completeMarkerPath).
 		Msgf("Step 6/6 Migration marker file written successfully. Compacting pebbleDB...")
+
+	lg.Info().Msgf("reading finalized height...")
+
+	var height uint64
+	err = operation.RetrieveFinalizedHeight(pebbleimpl.ToDB(pebbleDB).Reader(), &height)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve finalized height: %w", err)
+	}
+
+	log.Info().Msgf("Finalized height retrieved: %d", height)
 
 	return nil
 }

--- a/storage/migration/runner_test.go
+++ b/storage/migration/runner_test.go
@@ -1,0 +1,75 @@
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMigration(t *testing.T) {
+	// Setup temporary directories
+	tmpDir := t.TempDir()
+	badgerDir := filepath.Join(tmpDir, "badger")
+	pebbleDir := filepath.Join(tmpDir, "pebble")
+
+	// Create and open BadgerDB with test data
+	opts := badger.DefaultOptions(badgerDir).WithLogger(nil)
+	badgerDB, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	testData := map[string]string{
+		"\x01\x02foo": "bar",
+		"\x01\x02baz": "qux",
+		"\x02\xffzip": "zap",
+		"\xff\xffzz":  "last",
+	}
+	err = badgerDB.Update(func(txn *badger.Txn) error {
+		for k, v := range testData {
+			err := txn.Set([]byte(k), []byte(v))
+			require.NoError(t, err)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, badgerDB.Close()) // Close so MigrateAndValidate can reopen it
+
+	// Define migration config
+	cfg := MigrationConfig{
+		BatchByteSize:          1024,
+		ReaderWorkerCount:      2,
+		WriterWorkerCount:      2,
+		ReaderShardPrefixBytes: 2,
+	}
+
+	// Run migration
+	err = RunMigration(badgerDir, pebbleDir, cfg)
+	require.NoError(t, err)
+
+	// Check marker files
+	startedPath := filepath.Join(pebbleDir, "MIGRATION_STARTED")
+	completedPath := filepath.Join(pebbleDir, "MIGRATION_COMPLETED")
+
+	startedContent, err := os.ReadFile(startedPath)
+	require.NoError(t, err)
+	require.Contains(t, string(startedContent), "migration started")
+
+	completedContent, err := os.ReadFile(completedPath)
+	require.NoError(t, err)
+	require.Contains(t, string(completedContent), "migration completed")
+
+	// Open PebbleDB to confirm migrated values
+	pebbleDB, err := pebble.Open(pebbleDir, &pebble.Options{})
+	require.NoError(t, err)
+	defer pebbleDB.Close()
+
+	for k, expected := range testData {
+		val, closer, err := pebbleDB.Get([]byte(k))
+		require.NoError(t, err)
+		require.Equal(t, expected, string(val))
+		require.NoError(t, closer.Close())
+	}
+}

--- a/storage/migration/sstables.go
+++ b/storage/migration/sstables.go
@@ -141,7 +141,9 @@ func createSSTableWriter(filePath string) (*sstable.Writer, error) {
 	}
 
 	writable := objstorageprovider.NewFileWritable(f)
-	sstWriter := sstable.NewWriter(writable, sstable.WriterOptions{})
+	sstWriter := sstable.NewWriter(writable, sstable.WriterOptions{
+		TableFormat: sstable.TableFormatPebblev4,
+	})
 
 	return sstWriter, nil
 }

--- a/storage/migration/sstables.go
+++ b/storage/migration/sstables.go
@@ -131,8 +131,6 @@ func writerSSTableWorker(ctx context.Context, db *pebble.DB, pebbleDir string, k
 			}
 
 			log.Info().Msgf("Ingested SSTable file: %s", filePath)
-
-			return nil
 		}
 	}
 }

--- a/storage/migration/sstables.go
+++ b/storage/migration/sstables.go
@@ -83,7 +83,7 @@ func CopyFromBadgerToPebbleSSTables(badgerDB *badger.DB, pebbleDB *pebble.DB, cf
 		writerWg.Add(1)
 		go func() {
 			defer writerWg.Done()
-			if err := writerSSTableWorker(ctx, pebbleDB, sstableDir, kvChan); err != nil {
+			if err := writerSSTableWorker(ctx, i, pebbleDB, sstableDir, kvChan); err != nil {
 				reportFirstError(err)
 			}
 		}()
@@ -99,7 +99,7 @@ func CopyFromBadgerToPebbleSSTables(badgerDB *badger.DB, pebbleDB *pebble.DB, cf
 	return firstErr
 }
 
-func writerSSTableWorker(ctx context.Context, db *pebble.DB, sstableDir string, kvChan <-chan KVPairs) error {
+func writerSSTableWorker(ctx context.Context, workerIndex int, db *pebble.DB, sstableDir string, kvChan <-chan KVPairs) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -109,7 +109,7 @@ func writerSSTableWorker(ctx context.Context, db *pebble.DB, sstableDir string, 
 				return nil
 			}
 
-			filePath := fmt.Sprintf("%s/prefix_%x.sst", sstableDir, kvGroup.Prefix)
+			filePath := fmt.Sprintf("%s/prefix_%x_worker_%v.sst", sstableDir, kvGroup.Prefix, workerIndex)
 			writer, err := createSSTableWriter(filePath)
 			if err != nil {
 				return err

--- a/storage/migration/sstables.go
+++ b/storage/migration/sstables.go
@@ -1,0 +1,154 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/flow-go/module/util"
+	"github.com/rs/zerolog/log"
+)
+
+// CopyFromBadgerToPebble copies all key-value pairs from a BadgerDB to a PebbleDB
+// using SSTable ingestion. It reads BadgerDB in prefix-sharded ranges and writes
+// those ranges into SSTable files, which are then ingested into Pebble.
+func CopyFromBadgerToPebbleSSTables(badgerDB *badger.DB, pebbleDB *pebble.DB, cfg MigrationConfig) error {
+	pebbleDir, err := os.MkdirTemp("", "flow-migration-temp-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	log.Info().Msgf("Created temporary directory for SSTables: %s", pebbleDir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		errOnce  sync.Once
+		firstErr error
+	)
+
+	// once running into an exception, cancel the context and report the first error
+	reportFirstError := func(err error) {
+		if err != nil {
+			errOnce.Do(func() {
+				firstErr = err
+				cancel()
+			})
+		}
+	}
+
+	// Step 1: Copy all keys shorter than prefix
+	keysShorterThanPrefix := GenerateKeysShorterThanPrefix(cfg.ReaderShardPrefixBytes)
+	if err := copyExactKeysFromBadgerToPebble(badgerDB, pebbleDB, keysShorterThanPrefix); err != nil {
+		return fmt.Errorf("failed to copy keys shorter than prefix: %w", err)
+	}
+	log.Info().Msgf("Copied %d keys shorter than %v bytes prefix", len(keysShorterThanPrefix), cfg.ReaderShardPrefixBytes)
+
+	// Step 2: Copy all keys with prefix by first generating prefix shards and then
+	// using reader and writer workers to copy the keys with the same prefix
+	prefixes := GeneratePrefixes(cfg.ReaderShardPrefixBytes)
+	prefixJobs := make(chan []byte, len(prefixes))
+	for _, prefix := range prefixes {
+		prefixJobs <- prefix
+	}
+	close(prefixJobs)
+
+	kvChan := make(chan KVPairs, cfg.ReaderWorkerCount*2)
+
+	lg := util.LogProgress(
+		log.Logger,
+		util.DefaultLogProgressConfig("migration keys from badger to pebble", len(prefixes)),
+	)
+
+	var readerWg sync.WaitGroup
+	for i := 0; i < cfg.ReaderWorkerCount; i++ {
+		readerWg.Add(1)
+		go func() {
+			defer readerWg.Done()
+			if err := readerWorker(ctx, lg, badgerDB, prefixJobs, kvChan, cfg.BatchByteSize); err != nil {
+				reportFirstError(err)
+			}
+		}()
+	}
+
+	var writerWg sync.WaitGroup
+	for i := 0; i < cfg.WriterWorkerCount; i++ {
+		writerWg.Add(1)
+		go func() {
+			defer writerWg.Done()
+			if err := writerSSTableWorker(ctx, pebbleDB, pebbleDir, kvChan); err != nil {
+				reportFirstError(err)
+			}
+		}()
+	}
+
+	// Close kvChan after readers complete
+	go func() {
+		readerWg.Wait()
+		close(kvChan)
+	}()
+
+	writerWg.Wait()
+	return firstErr
+}
+
+func writerSSTableWorker(ctx context.Context, db *pebble.DB, pebbleDir string, kvChan <-chan KVPairs) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case kvGroup, ok := <-kvChan:
+			if !ok {
+				return nil
+			}
+
+			filePath := fmt.Sprintf("%s/prefix_%x.sst", pebbleDir, kvGroup.Prefix)
+			writer, err := createSSTableWriter(pebbleDir)
+			if err != nil {
+				return err
+			}
+
+			for _, kv := range kvGroup.Pairs {
+				if err := writer.Set(kv.Key, kv.Value); err != nil {
+					return fmt.Errorf("fail to set key %x: %w", kv.Key, err)
+				}
+			}
+
+			if err := writer.Close(); err != nil {
+				return fmt.Errorf("fail to close writer: %w", err)
+			}
+
+			err = db.Ingest([]string{filePath})
+			if err != nil {
+				return fmt.Errorf("fail to ingest file %v: %w", filePath, err)
+			}
+
+			log.Info().Msgf("Ingested SSTable file: %s", filePath)
+
+			err = os.Remove(filePath)
+			if err != nil {
+				return fmt.Errorf("fail to remove file %v: %w", filePath, err)
+			}
+
+			return nil
+		}
+	}
+}
+func createSSTableWriter(filePath string) (*sstable.Writer, error) {
+	f, err := vfs.Default.Create(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	writable := objstorageprovider.NewFileWritable(f)
+	sstWriter := sstable.NewWriter(writable, sstable.WriterOptions{})
+
+	return sstWriter, nil
+}

--- a/storage/migration/sstables.go
+++ b/storage/migration/sstables.go
@@ -145,3 +145,12 @@ func createSSTableWriter(filePath string) (*sstable.Writer, error) {
 
 	return sstWriter, nil
 }
+
+func ForceCompactPebbleDB(pebbleDir string) error {
+	pebbleDB, err := pebble.Open(pebbleDir, &pebble.Options{})
+	if err != nil {
+		return err
+	}
+
+	return pebbleDB.Compact([]byte{0x00}, []byte{0xff}, true)
+}

--- a/storage/migration/sstables.go
+++ b/storage/migration/sstables.go
@@ -110,7 +110,7 @@ func writerSSTableWorker(ctx context.Context, db *pebble.DB, pebbleDir string, k
 			}
 
 			filePath := fmt.Sprintf("%s/prefix_%x.sst", pebbleDir, kvGroup.Prefix)
-			writer, err := createSSTableWriter(pebbleDir)
+			writer, err := createSSTableWriter(filePath)
 			if err != nil {
 				return err
 			}
@@ -131,11 +131,6 @@ func writerSSTableWorker(ctx context.Context, db *pebble.DB, pebbleDir string, k
 			}
 
 			log.Info().Msgf("Ingested SSTable file: %s", filePath)
-
-			err = os.Remove(filePath)
-			if err != nil {
-				return fmt.Errorf("fail to remove file %v: %w", filePath, err)
-			}
 
 			return nil
 		}

--- a/storage/migration/sstables_test.go
+++ b/storage/migration/sstables_test.go
@@ -1,0 +1,58 @@
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPebbleSSTableIngest(t *testing.T) {
+	// Create a temporary directory for the Pebble DB
+	dir, err := os.MkdirTemp("", "pebble-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// Open Pebble DB
+	db, err := pebble.Open(dir, &pebble.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create an SSTable with a few key-values
+	sstPath := filepath.Join(dir, "test.sst")
+	file, err := vfs.Default.Create(sstPath)
+	require.NoError(t, err)
+	writable := objstorageprovider.NewFileWritable(file)
+	writer := sstable.NewWriter(writable, sstable.WriterOptions{})
+	data := generateRandomKVData(500, 10, 50)
+
+	// Sort the keys to ensure strictly increasing order
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		require.NoError(t, writer.Set([]byte(k), []byte(data[k])))
+	}
+
+	require.NoError(t, writer.Close())
+
+	// Ingest the SSTable into Pebble DB
+	require.NoError(t, db.Ingest([]string{sstPath}))
+
+	// Verify the data exists
+	for _, k := range keys {
+		val, closer, err := db.Get([]byte(k))
+		require.NoError(t, err, "expected key %s to exist", k)
+		require.Equal(t, data[k], string(val))
+		closer.Close()
+	}
+}

--- a/storage/migration/validation.go
+++ b/storage/migration/validation.go
@@ -1,0 +1,128 @@
+package migration
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/flow-go/storage"
+)
+
+// validateBadgerFolderExistPebbleFolderEmpty checks if the Badger directory exists and is non-empty,
+// and if the Pebble directory does not exist or is empty.
+func validateBadgerFolderExistPebbleFolderEmpty(badgerDir string, pebbleDir string) error {
+	// Step 1.1: Ensure Badger directory exists and is non-empty
+	badgerEntries, err := os.ReadDir(badgerDir)
+	if err != nil || len(badgerEntries) == 0 {
+		return fmt.Errorf("badger directory invalid or empty: %w", err)
+	}
+
+	// Step 1.2: Ensure Pebble directory does not exist or is empty
+	if stat, err := os.Stat(pebbleDir); err == nil && stat.IsDir() {
+		pebbleEntries, err := os.ReadDir(pebbleDir)
+		if err != nil {
+			return fmt.Errorf("failed to read pebble directory: %w", err)
+		}
+		if len(pebbleEntries) > 0 {
+			return errors.New("pebble directory is not empty")
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("error checking pebble directory: %w", err)
+	} else {
+		// Create pebbleDir if it doesn't exist
+		if err := os.MkdirAll(pebbleDir, 0755); err != nil {
+			return fmt.Errorf("failed to create pebble directory: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func validateMinMaxKeyConsistency(badgerDB *badger.DB, pebbleDB *pebble.DB, prefixBytes int) error {
+	keys, err := collectValidationKeysByPrefix(badgerDB, prefixBytes)
+	if err != nil {
+		return fmt.Errorf("failed to collect validation keys: %w", err)
+	}
+	if err := compareValuesBetweenDBs(keys, badgerDB, pebbleDB); err != nil {
+		return fmt.Errorf("data mismatch found: %w", err)
+	}
+	return nil
+}
+
+func collectValidationKeysByPrefix(db *badger.DB, prefixBytes int) ([][]byte, error) {
+	prefixes := GeneratePrefixes(prefixBytes)
+	var allKeys [][]byte
+
+	err := db.View(func(txn *badger.Txn) error {
+		for _, prefix := range prefixes {
+			// Find min key
+			opts := badger.DefaultIteratorOptions
+			it := txn.NewIterator(opts)
+			it.Seek(prefix)
+			if it.ValidForPrefix(prefix) {
+				allKeys = append(allKeys, slices.Clone(it.Item().Key()))
+			}
+			it.Close()
+
+			// Find max key with reverse iterator
+			opts.Reverse = true
+			it = txn.NewIterator(opts)
+
+			// the upper bound is exclusive, so we need to seek to the upper bound
+			// when the prefix is [0xff,0xff], the end is nil, and we will iterate
+			// from the last key
+			end := storage.PrefixUpperBound(prefix)
+			it.Seek(end)
+			if it.ValidForPrefix(prefix) {
+				allKeys = append(allKeys, slices.Clone(it.Item().Key()))
+			}
+			it.Close()
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Deduplicate keys
+	keyMap := make(map[string][]byte, len(allKeys))
+	for _, k := range allKeys {
+		keyMap[string(k)] = k
+	}
+	uniqueKeys := make([][]byte, 0, len(keyMap))
+	for _, k := range keyMap {
+		uniqueKeys = append(uniqueKeys, k)
+	}
+
+	return uniqueKeys, nil
+}
+
+func compareValuesBetweenDBs(keys [][]byte, badgerDB *badger.DB, pebbleDB *pebble.DB) error {
+	for _, key := range keys {
+		var badgerVal []byte
+		err := badgerDB.View(func(txn *badger.Txn) error {
+			item, err := txn.Get(key)
+			if err != nil {
+				return err
+			}
+			badgerVal, err = item.ValueCopy(nil)
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("badger get error for key %x: %w", key, err)
+		}
+
+		pebbleVal, closer, err := pebbleDB.Get(key)
+		if err != nil {
+			return fmt.Errorf("pebble get error for key %x: %w", key, err)
+		}
+		if string(pebbleVal) != string(badgerVal) {
+			return fmt.Errorf("value mismatch for key %x: badger=%q pebble=%q", key, badgerVal, pebbleVal)
+		}
+		_ = closer.Close()
+	}
+	return nil
+}

--- a/storage/migration/validation.go
+++ b/storage/migration/validation.go
@@ -60,7 +60,13 @@ func validateMinMaxKeyConsistency(badgerDB *badger.DB, pebbleDB *pebble.DB, pref
 // An easy way to select keys is to go through each prefix, and find the min and max keys for each prefix using
 // the database iterator.
 func collectValidationKeysByPrefix(db *badger.DB, prefixBytes int) ([][]byte, error) {
-	prefixes := GeneratePrefixes(prefixBytes)
+	// this includes all prefixes that is shorter than or equal to prefixBytes
+	// for instance, if prefixBytes is 2, we will include all prefixes that is 1 byte or 2 bytes:
+	// [
+	//   [0x00], [0x01], [0x02], ..., [0xff], 												// 1 byte prefixes
+	//   [0x00, 0x00], [0x00, 0x01], [0x00, 0x02], ..., [0xff, 0xff] 	// 2 byte prefixes
+	// ]
+	prefixes := GenerateKeysShorterThanPrefix(prefixBytes + 1)
 	var allKeys [][]byte
 
 	err := db.View(func(txn *badger.Txn) error {

--- a/storage/migration/validation_test.go
+++ b/storage/migration/validation_test.go
@@ -1,0 +1,54 @@
+package migration
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectValidationKeysByPrefix(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		// Insert test keys
+		testKeys := []string{
+			"\x01\x02keyA", // group: 0x01, 0x02
+			"\x01\x02keyB",
+			"\x01\x03keyC", // group: 0x01, 0x03
+			"\x02\x00keyD", // group: 0x02, 0x00
+			"\x02\x00keyE", // group: 0x02, 0x00
+			"\x02\x00keyF", // group: 0x02, 0x00
+			"\xff\xfflast",
+		}
+		require.NoError(t, db.Update(func(txn *badger.Txn) error {
+			for _, k := range testKeys {
+				err := txn.Set([]byte(k), []byte("val_"+k))
+				require.NoError(t, err)
+			}
+			return nil
+		}))
+
+		// Run key collection
+		keys, err := collectValidationKeysByPrefix(db, 2)
+		require.NoError(t, err)
+
+		// Convert to string for easier comparison
+		var keyStrs []string
+		for _, k := range keys {
+			keyStrs = append(keyStrs, string(k))
+		}
+		sort.Strings(keyStrs)
+
+		// Expected keys are min and max for each 2-byte prefix group
+		expected := []string{
+			"\x01\x02keyA", "\x01\x02keyB", // same group have both min and max
+			"\x01\x03keyC", // only one key in this group
+			"\x02\x00keyD", // min key of 0x02,0x00
+			"\x02\x00keyF", // max key of 0x02,0x00
+			"\xff\xfflast", // last key in this prefix
+		}
+		sort.Strings(expected)
+		require.ElementsMatch(t, expected, keyStrs)
+	})
+}

--- a/storage/operation/heights.go
+++ b/storage/operation/heights.go
@@ -1,0 +1,7 @@
+package operation
+
+import "github.com/onflow/flow-go/storage"
+
+func RetrieveFinalizedHeight(r storage.Reader, height *uint64) error {
+	return RetrieveByKey(r, MakePrefix(codeFinalizedHeight), height)
+}


### PR DESCRIPTION
Close https://github.com/onflow/flow-go/issues/7395

The original implementation for migration is done by iterating and copying all the key-value pairs from badger to pebble.  https://github.com/onflow/flow-go/pull/7396 . The problem with this approach is that compactions are often triggered during the writes, and when the copying is done, another global compaction is automatically triggered after starting up the node with it. The copying took 1h40m, and the global compaction took 4-5h. 

The new implementation writes the key-value pairs directly to the sstables, which results in a much faster migration speed. It took 30 mins. After the migration, the global compaction is not triggered after starting up the node, which results in a 10x-12x migration speed improvement.