### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for Locator

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,9 @@ issues:
       linters:
         - unused
         - structwrite
+    - path: 'utils/unittest/*' # disable some linters on test files
+      linters:
+        - structwrite
     # typecheck currently not handling the way we do function inheritance well
     # disabling for now
     - path: 'cmd/access/node_build/*'

--- a/engine/verification/assigner/engine.go
+++ b/engine/verification/assigner/engine.go
@@ -123,9 +123,14 @@ func (e *Engine) processChunk(chunk *flow.Chunk, resultID flow.Identifier, block
 		Uint64("block_height", blockHeight).
 		Logger()
 
-	locator := &chunks.Locator{
-		ResultID: resultID,
-		Index:    chunk.Index,
+	locator, err := chunks.NewLocator(
+		chunks.UntrustedLocator{
+			ResultID: resultID,
+			Index:    chunk.Index,
+		},
+	)
+	if err != nil {
+		return false, fmt.Errorf("could not construct locator: %w", err)
 	}
 
 	// pushes chunk locator to the chunks queue

--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -201,7 +201,7 @@ func (e *Engine) processAssignedChunk(chunk *flow.Chunk, result *flow.ExecutionR
 		ExecutionResult: result,
 		BlockHeight:     blockHeight,
 	}
-	added := e.pendingChunks.Add(status.ChunkLocatorID(), status)
+	added := e.pendingChunks.Add(chunkLocatorID, status)
 	if !added {
 		return false, blockHeight, nil
 	}
@@ -277,7 +277,7 @@ func (e *Engine) HandleChunkDataPack(originID flow.Identifier, response *verific
 		e.metrics.OnVerifiableChunkSentToVerifier()
 
 		// we need to report that the job has been finished eventually
-		e.chunkConsumerNotifier.Notify(status.ChunkLocatorID())
+		e.chunkConsumerNotifier.Notify(response.Locator.ID())
 		lg.Info().Msg("verifiable chunk pushed to verifier engine")
 	}
 
@@ -320,11 +320,22 @@ func (e *Engine) handleChunkDataPackWithTracing(
 // handleValidatedChunkDataPack receives a validated chunk data pack, removes its status from the memory, and pushes a verifiable chunk for it to
 // verifier engine.
 // Boolean return value determines whether verifiable chunk pushed to verifier or not.
-func (e *Engine) handleValidatedChunkDataPack(ctx context.Context,
+func (e *Engine) handleValidatedChunkDataPack(
+	ctx context.Context,
 	status *verification.ChunkStatus,
-	chunkDataPack *flow.ChunkDataPack) (bool, error) {
+	chunkDataPack *flow.ChunkDataPack,
+) (bool, error) {
+	locator, err := chunks.NewLocator(
+		chunks.UntrustedLocator{
+			ResultID: status.ExecutionResult.ID(),
+			Index:    status.ChunkIndex,
+		},
+	)
+	if err != nil {
+		return false, fmt.Errorf("could not construct locator: %w", err)
+	}
 
-	removed := e.pendingChunks.Remove(status.ChunkLocatorID())
+	removed := e.pendingChunks.Remove(locator.ID())
 	if !removed {
 		// we deduplicate the chunk data responses at this point, reaching here means a
 		// duplicate chunk data response is under process concurrently, so we give up
@@ -334,7 +345,7 @@ func (e *Engine) handleValidatedChunkDataPack(ctx context.Context,
 
 	// pushes chunk data pack to verifier, and waits for it to be verified.
 	chunk := status.ExecutionResult.Chunks[status.ChunkIndex]
-	err := e.pushToVerifierWithTracing(ctx, chunk, status.ExecutionResult, chunkDataPack)
+	err = e.pushToVerifierWithTracing(ctx, chunk, status.ExecutionResult, chunkDataPack)
 	if err != nil {
 		return false, fmt.Errorf("could not push the chunk to verifier engine")
 	}
@@ -478,20 +489,28 @@ func (e *Engine) NotifyChunkDataPackSealed(chunkIndex uint64, resultID flow.Iden
 		Logger()
 
 	// we need to report that the job has been finished eventually
-	status, exists := e.pendingChunks.Get(chunks.ChunkLocatorID(resultID, chunkIndex))
+	locator, err := chunks.NewLocator(
+		chunks.UntrustedLocator{
+			ResultID: resultID,
+			Index:    chunkIndex,
+		},
+	)
+	if err != nil {
+		e.log.Fatal().Err(err).Msg("could not construct locator")
+	}
+	status, exists := e.pendingChunks.Get(locator.ID())
 	if !exists {
 		lg.Debug().
 			Msg("could not fetch pending status for sealed chunk from mempool, dropping chunk data")
 		return
 	}
 
-	chunkLocatorID := status.ChunkLocatorID()
 	lg = lg.With().
 		Uint64("block_height", status.BlockHeight).
 		Hex("result_id", logging.ID(status.ExecutionResult.ID())).Logger()
-	removed := e.pendingChunks.Remove(chunkLocatorID)
+	removed := e.pendingChunks.Remove(locator.ID())
 
-	e.chunkConsumerNotifier.Notify(chunkLocatorID)
+	e.chunkConsumerNotifier.Notify(locator.ID())
 	lg.Info().
 		Bool("removed", removed).
 		Msg("discards fetching chunk of an already sealed block and notified consumer")
@@ -574,11 +593,18 @@ func (e *Engine) requestChunkDataPack(chunkIndex uint64, chunkID flow.Identifier
 		return fmt.Errorf("could not fetch execution node ids at block %x: %w", blockID, err)
 	}
 
-	request := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
+	locator, err := chunks.NewLocator(
+		chunks.UntrustedLocator{
 			ResultID: resultID,
 			Index:    chunkIndex,
 		},
+	)
+	if err != nil {
+		return fmt.Errorf("could not construct locator: %w", err)
+	}
+
+	request := &verification.ChunkDataPackRequest{
+		Locator: *locator,
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID:   chunkID,
 			Height:    header.Height,

--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -496,6 +496,7 @@ func (e *Engine) NotifyChunkDataPackSealed(chunkIndex uint64, resultID flow.Iden
 			Index:    chunkIndex,
 		},
 	)
+	// TODO: update this engine to use SignallerContext and throw an exception here
 	if err != nil {
 		e.log.Fatal().Err(err).Msg("could not construct locator")
 	}

--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -243,7 +243,8 @@ func (e *Engine) HandleChunkDataPack(originID flow.Identifier, response *verific
 	e.metrics.OnChunkDataPackArrivedAtFetcher()
 
 	// make sure we still need it
-	status, exists := e.pendingChunks.Get(response.Locator.ID())
+	locatorID := response.Locator.ID()
+	status, exists := e.pendingChunks.Get(locatorID)
 	if !exists {
 		lg.Debug().Msg("could not fetch pending status from mempool, dropping chunk data")
 		return
@@ -277,7 +278,7 @@ func (e *Engine) HandleChunkDataPack(originID flow.Identifier, response *verific
 		e.metrics.OnVerifiableChunkSentToVerifier()
 
 		// we need to report that the job has been finished eventually
-		e.chunkConsumerNotifier.Notify(response.Locator.ID())
+		e.chunkConsumerNotifier.Notify(locatorID)
 		lg.Info().Msg("verifiable chunk pushed to verifier engine")
 	}
 

--- a/engine/verification/requester/requester_test.go
+++ b/engine/verification/requester/requester_test.go
@@ -120,18 +120,13 @@ func TestHandleChunkDataPack_HappyPath(t *testing.T) {
 
 	// we remove pending request on receiving this response
 	locators := chunks.LocatorMap{}
-	locators[chunks.ChunkLocatorID(request.ResultID, request.Index)] = &chunks.Locator{
-		ResultID: request.ResultID,
-		Index:    request.Index,
-	}
+	locator := unittest.ChunkLocatorFixture(request.ResultID, request.Index)
+	locators[locator.ID()] = locator
 	s.pendingRequests.On("PopAll", response.ChunkDataPack.ChunkID).Return(locators, true).Once()
 
 	s.handler.On("HandleChunkDataPack", originID, &verification.ChunkDataPackResponse{
-		Locator: chunks.Locator{
-			ResultID: request.ResultID,
-			Index:    request.Index,
-		},
-		Cdp: &response.ChunkDataPack,
+		Locator: *unittest.ChunkLocatorFixture(request.ResultID, request.Index),
+		Cdp:     &response.ChunkDataPack,
 	}).Return().Once()
 	s.metrics.On("OnChunkDataPackResponseReceivedFromNetworkByRequester").Return().Once()
 	s.metrics.On("OnChunkDataPackSentToFetcher").Return().Once()
@@ -616,7 +611,7 @@ func mockChunkDataPackHandler(t *testing.T, handler *mockfetcher.ChunkDataPackHa
 			require.True(t, requests.ContainsChunkID(response.Cdp.ChunkID))
 
 			// invocation should be distinct per chunk ID
-			locatorID := chunks.ChunkLocatorID(response.ResultID, response.Index)
+			locatorID := unittest.ChunkLocatorFixture(response.ResultID, response.Index).ID()
 			_, ok = handledLocators[locatorID]
 			require.False(t, ok)
 
@@ -647,7 +642,7 @@ func mockNotifyBlockSealedHandler(t *testing.T, handler *mockfetcher.ChunkDataPa
 			require.True(t, requests.ContainsLocator(resultID, chunkIndex))
 
 			// invocation should be distinct per chunk ID
-			locatorID := chunks.ChunkLocatorID(resultID, chunkIndex)
+			locatorID := unittest.ChunkLocatorFixture(resultID, chunkIndex).ID()
 			_, ok = seen[locatorID]
 			require.False(t, ok)
 			seen[locatorID] = struct{}{}

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -341,10 +341,7 @@ func MockChunkAssignmentFixture(t *testing.T,
 
 			for _, chunk := range receipt.ExecutionResult.Chunks {
 				if isAssigned(chunk.Index, len(receipt.ExecutionResult.Chunks)) {
-					locatorID := chunks.Locator{
-						ResultID: receipt.ExecutionResult.ID(),
-						Index:    chunk.Index,
-					}.ID()
+					locatorID := unittest.ChunkLocatorFixture(receipt.ExecutionResult.ID(), chunk.Index).ID()
 					expectedLocatorIds = append(expectedLocatorIds, locatorID)
 					expectedChunkIds = append(expectedChunkIds, chunk.ID())
 					require.NoError(t, a.Add(chunk.Index, verIds.NodeIDs()))

--- a/model/chunks/chunkLocator.go
+++ b/model/chunks/chunkLocator.go
@@ -1,14 +1,46 @@
 package chunks
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-go/model/flow"
 )
 
 // Locator is used to locate a chunk by providing the execution result the chunk belongs to as well as the chunk index within that execution result.
 // Since a chunk is unique by the result ID and its index in the result's chunk list.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type Locator struct {
 	ResultID flow.Identifier // execution result id that chunk belongs to
 	Index    uint64          // index of chunk in the execution result
+}
+
+// UntrustedLocator is an untrusted input-only representation of a Locator,
+// used for construction.
+//
+// This type exists to ensure that constructor functions are invoked explicitly
+// with named fields, which improves clarity and reduces the risk of incorrect field
+// ordering during construction.
+//
+// An instance of UntrustedLocator should be validated and converted into
+// a trusted Locator using NewLocator constructor.
+type UntrustedLocator Locator
+
+// NewEpochStateContainer creates a new instance of Locator.
+// Construction Locator allowed only within the constructor.
+//
+// All errors indicate a valid Locator cannot be constructed from the input.
+
+// NewLocator creates a new instance of Locator.
+// Construction Locator allowed only within the constructor.
+func NewLocator(untrusted UntrustedLocator) (*Locator, error) {
+	if untrusted.ResultID == flow.ZeroID {
+		return nil, fmt.Errorf("ResultID must not be zero")
+	}
+	return &Locator{
+		ResultID: untrusted.ResultID,
+		Index:    untrusted.Index,
+	}, nil
 }
 
 // ID returns a unique id for chunk locator.
@@ -19,15 +51,6 @@ func (c Locator) ID() flow.Identifier {
 // Checksum provides a cryptographic commitment for a chunk locator content.
 func (c Locator) Checksum() flow.Identifier {
 	return flow.MakeID(c)
-}
-
-// ChunkLocatorID is a util function that returns identifier of corresponding chunk locator to
-// the specified result and chunk index.
-func ChunkLocatorID(resultID flow.Identifier, chunkIndex uint64) flow.Identifier {
-	return Locator{
-		ResultID: resultID,
-		Index:    chunkIndex,
-	}.ID()
 }
 
 // LocatorMap maps keeps chunk locators based on their locator id.

--- a/model/chunks/chunkLocator.go
+++ b/model/chunks/chunkLocator.go
@@ -26,13 +26,10 @@ type Locator struct {
 // a trusted Locator using NewLocator constructor.
 type UntrustedLocator Locator
 
-// NewEpochStateContainer creates a new instance of Locator.
+// NewLocator creates a new instance of Locator.
 // Construction Locator allowed only within the constructor.
 //
 // All errors indicate a valid Locator cannot be constructed from the input.
-
-// NewLocator creates a new instance of Locator.
-// Construction Locator allowed only within the constructor.
 func NewLocator(untrusted UntrustedLocator) (*Locator, error) {
 	if untrusted.ResultID == flow.ZeroID {
 		return nil, fmt.Errorf("ResultID must not be zero")

--- a/model/chunks/chunkLocator_test.go
+++ b/model/chunks/chunkLocator_test.go
@@ -55,7 +55,7 @@ func TestNewLocator(t *testing.T) {
 	})
 
 	t.Run("invalid input with zero ResultID", func(t *testing.T) {
-		_, err := chunks.NewLocator(
+		locator, err := chunks.NewLocator(
 			chunks.UntrustedLocator{
 				ResultID: flow.ZeroID,
 				Index:    1,
@@ -63,5 +63,6 @@ func TestNewLocator(t *testing.T) {
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "ResultID must not be zero")
+		require.Nil(t, locator)
 	})
 }

--- a/model/chunks/chunkLocator_test.go
+++ b/model/chunks/chunkLocator_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/model/chunks"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -27,4 +29,42 @@ func TestChunkLocatorConvert(t *testing.T) {
 // TestChunkLocatorMalleability verifies that the chunk locator which implements the [flow.IDEntity] interface is not malleable.
 func TestChunkLocatorMalleability(t *testing.T) {
 	unittest.RequireEntityNonMalleable(t, unittest.ChunkLocatorFixture(unittest.IdentifierFixture(), rand.Uint64()))
+}
+
+// TestNewLocator tests the NewLocator constructor with valid and invalid inputs.
+//
+// Valid Case:
+//
+// 1. Valid input with non-zero ResultID and any index:
+//   - Should successfully construct a Locator.
+//
+// Invalid Case:
+//
+// 2. Invalid input with zero ResultID:
+//   - Should return an error indicating ResultID must not be zero.
+func TestNewLocator(t *testing.T) {
+	t.Run("valid input with non-zero ResultID", func(t *testing.T) {
+		resultID := unittest.IdentifierFixture()
+		index := uint64(5)
+
+		locator, err := chunks.NewLocator(
+			chunks.UntrustedLocator{
+				ResultID: resultID,
+				Index:    index,
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, locator)
+	})
+
+	t.Run("invalid input with zero ResultID", func(t *testing.T) {
+		_, err := chunks.NewLocator(
+			chunks.UntrustedLocator{
+				ResultID: flow.ZeroID,
+				Index:    10,
+			},
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "ResultID must not be zero")
+	})
 }

--- a/model/chunks/chunkLocator_test.go
+++ b/model/chunks/chunkLocator_test.go
@@ -44,13 +44,10 @@ func TestChunkLocatorMalleability(t *testing.T) {
 //   - Should return an error indicating ResultID must not be zero.
 func TestNewLocator(t *testing.T) {
 	t.Run("valid input with non-zero ResultID", func(t *testing.T) {
-		resultID := unittest.IdentifierFixture()
-		index := uint64(5)
-
 		locator, err := chunks.NewLocator(
 			chunks.UntrustedLocator{
-				ResultID: resultID,
-				Index:    index,
+				ResultID: unittest.IdentifierFixture(),
+				Index:    1,
 			},
 		)
 		require.NoError(t, err)
@@ -61,7 +58,7 @@ func TestNewLocator(t *testing.T) {
 		_, err := chunks.NewLocator(
 			chunks.UntrustedLocator{
 				ResultID: flow.ZeroID,
-				Index:    10,
+				Index:    1,
 			},
 		)
 		require.Error(t, err)

--- a/model/verification/chunkStatus.go
+++ b/model/verification/chunkStatus.go
@@ -1,7 +1,6 @@
 package verification
 
 import (
-	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -14,10 +13,6 @@ type ChunkStatus struct {
 
 func (s ChunkStatus) Chunk() *flow.Chunk {
 	return s.ExecutionResult.Chunks[s.ChunkIndex]
-}
-
-func (s ChunkStatus) ChunkLocatorID() flow.Identifier {
-	return chunks.ChunkLocatorID(s.ExecutionResult.ID(), s.ChunkIndex)
 }
 
 type ChunkStatusList []*ChunkStatus

--- a/module/mempool/stdmap/chunk_requests_test.go
+++ b/module/mempool/stdmap/chunk_requests_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/engine/verification/requester"
-	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/verification"
 	"github.com/onflow/flow-go/module/mempool"
@@ -204,10 +203,7 @@ func TestAddingDuplicateChunkIDs(t *testing.T) {
 	// adding another request for the same tuple of (chunkID, resultID, chunkIndex)
 	// is deduplicated.
 	require.False(t, requests.Add(&verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
-			ResultID: thisReq.ResultID,
-			Index:    thisReq.Index,
-		},
+		Locator: *unittest.ChunkLocatorFixture(thisReq.ResultID, thisReq.Index),
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID: thisReq.ChunkID,
 		},
@@ -215,10 +211,7 @@ func TestAddingDuplicateChunkIDs(t *testing.T) {
 
 	// adding another request for the same chunk ID but different result ID is stored.
 	otherReq := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
-			ResultID: unittest.IdentifierFixture(),
-			Index:    thisReq.Index,
-		},
+		Locator: *unittest.ChunkLocatorFixture(unittest.IdentifierFixture(), thisReq.Index),
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID:   thisReq.ChunkID,
 			Agrees:    unittest.IdentifierListFixture(2),

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -1683,10 +1683,7 @@ func ChunkDataPackRequestFixture(opts ...func(*verification.ChunkDataPackRequest
 	ChunkDataPackRequest {
 
 	req := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
-			ResultID: IdentifierFixture(),
-			Index:    0,
-		},
+		Locator: *ChunkLocatorFixture(IdentifierFixture(), 0),
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID:   IdentifierFixture(),
 			Height:    0,


### PR DESCRIPTION
Closes: #7276

This PR targets `feature/malleability` because `Locator` had many usages in a struct on master (`inMemChunkStatus`) that is already removed in `feature/malleability` during the `mempool` refactoring.

## Context
-  Added constructor `Locator` type.
-  Removed non-constructor mutations.
-  Removed `ChunkLocatorID` util function and replaced usages to `constructor` and `ID()` method.
-  Added `UntrustedLocator` model.
-  Added unit tests for constructor.
