### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for Collection and CollectionGuarantee structs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,12 @@ issues:
       linters:
         - unused
         - structwrite
+    - path: 'utils/unittest/*' # disable some linters on test files
+      linters:
+        - structwrite
+    - path: 'consensus/hotstuff/helper/*' # disable some linters on test files
+      linters:
+        - structwrite
     # typecheck currently not handling the way we do function inheritance well
     # disabling for now
     - path: 'cmd/access/node_build/*'

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -2123,7 +2123,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				node.State,
 				channels.RequestCollections,
 				filter.HasRole[flow.Identity](flow.RoleCollection),
-				func() flow.Entity { return &flow.Collection{} },
+				func() flow.Entity { return new(flow.Collection) },
 			)
 			if err != nil {
 				return nil, fmt.Errorf("could not create requester engine: %w", err)

--- a/cmd/bootstrap/run/cluster_qc_test.go
+++ b/cmd/bootstrap/run/cluster_qc_test.go
@@ -19,7 +19,7 @@ func TestGenerateClusterRootQC(t *testing.T) {
 			ParentID: flow.ZeroID,
 			View:     42,
 		},
-		cluster.EmptyPayload(flow.ZeroID),
+		cluster.NewEmptyPayload(flow.ZeroID),
 	)
 
 	orderedParticipants := model.ToIdentityList(participants).Sort(flow.Canonical[flow.Identity]).ToSkeleton()

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1125,7 +1125,7 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 		reqEng, err := requester.New(node.Logger, node.Metrics.Engine, node.EngineRegistry, node.Me, node.State,
 			channels.RequestCollections,
 			filter.Any,
-			func() flow.Entity { return &flow.Collection{} },
+			func() flow.Entity { return new(flow.Collection) },
 			// we are manually triggering batches in execution, but lets still send off a batch once a minute, as a safety net for the sake of retries
 			requester.WithBatchInterval(exeNode.exeConf.requestInterval),
 			// consistency of collection can be checked by checking hash, and hash comes from trusted source (blocks from consensus follower)

--- a/consensus/hotstuff/committees/cluster_committee_test.go
+++ b/consensus/hotstuff/committees/cluster_committee_test.go
@@ -88,9 +88,9 @@ func (suite *ClusterSuite) TestInvalidSigner() {
 	nonRootBlockID := unittest.IdentifierFixture()
 	rootBlockID := suite.root.ID()
 
-	refID := unittest.IdentifierFixture()            // reference block on main chain
-	payload := cluster.EmptyPayload(refID)           // payload referencing main chain
-	rootPayload := cluster.EmptyPayload(flow.ZeroID) // root cluster block payload
+	refID := unittest.IdentifierFixture()               // reference block on main chain
+	payload := cluster.NewEmptyPayload(refID)           // payload referencing main chain
+	rootPayload := cluster.NewEmptyPayload(flow.ZeroID) // root cluster block payload
 
 	suite.payloads.On("ByBlockID", nonRootBlockID).Return(&payload, nil)
 	suite.payloads.On("ByBlockID", rootBlockID).Return(&rootPayload, nil)

--- a/engine/common/rpc/convert/collections.go
+++ b/engine/common/rpc/convert/collections.go
@@ -79,9 +79,7 @@ func MessageToFullCollection(m []*entities.Transaction, chain flow.Chain) (*flow
 		transactions[i] = &t
 	}
 
-	return &flow.Collection{
-		Transactions: transactions,
-	}, nil
+	return flow.NewCollection(flow.UntrustedCollection{Transactions: transactions})
 }
 
 // CollectionGuaranteeToMessage converts a collection guarantee to a protobuf message

--- a/engine/common/rpc/convert/execution_data.go
+++ b/engine/common/rpc/convert/execution_data.go
@@ -238,7 +238,7 @@ func messageToTrustedCollection(
 ) (*flow.Collection, error) {
 	messages := m.GetTransactions()
 	if len(messages) == 0 {
-		return &flow.Collection{}, nil
+		return new(flow.Collection), nil
 	}
 
 	transactions := make([]*flow.TransactionBody, len(messages))
@@ -250,7 +250,12 @@ func messageToTrustedCollection(
 		transactions[i] = &transaction
 	}
 
-	return &flow.Collection{Transactions: transactions}, nil
+	collection, err := flow.NewCollection(flow.UntrustedCollection{Transactions: transactions})
+	if err != nil {
+		return nil, fmt.Errorf("could not construct collection: %w", err)
+	}
+
+	return collection, nil
 }
 
 // messageToTrustedTransaction converts a transaction message to a transaction body.

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -240,14 +240,14 @@ func (e *blockComputer) queueTransactionRequests(
 			isSystemTransaction: false,
 		}
 
-		for i, txnBody := range collection.Collection.Transactions {
+		for i, txnBody := range collection.Transactions {
 			requestQueue <- newTransactionRequest(
 				collectionInfo,
 				collectionCtx,
 				collectionLogger,
 				txnIndex,
 				txnBody,
-				i == len(collection.Collection.Transactions)-1)
+				i == len(collection.Transactions)-1)
 			txnIndex += 1
 		}
 	}
@@ -266,12 +266,12 @@ func (e *blockComputer) queueTransactionRequests(
 		Int("num_txs", numTxns).
 		Logger()
 
-	collection, err := flow.NewCollection(flow.UntrustedCollection{
-		Transactions: []*flow.TransactionBody{systemTxnBody},
-	})
-	if err != nil {
-		return fmt.Errorf("could not construct system collection: %w", err)
-	}
+	//collection, err := flow.NewCollection(flow.UntrustedCollection{
+	//	Transactions: []*flow.TransactionBody{systemTxnBody},
+	//})
+	//if err != nil {
+	//	return fmt.Errorf("could not construct system collection: %w", err)
+	//}
 
 	systemCollectionInfo := collectionInfo{
 		blockId:         blockId,
@@ -279,7 +279,8 @@ func (e *blockComputer) queueTransactionRequests(
 		blockHeight:     blockHeader.Height,
 		collectionIndex: len(rawCollections),
 		CompleteCollection: &entity.CompleteCollection{
-			Collection: collection,
+			//Collection: collection,
+			Transactions: []*flow.TransactionBody{systemTxnBody},
 		},
 		isSystemTransaction: true,
 	}
@@ -298,7 +299,7 @@ func (e *blockComputer) queueTransactionRequests(
 func numberOfTransactionsInBlock(collections []*entity.CompleteCollection) int {
 	numTxns := 1 // there's one system transaction per block
 	for _, collection := range collections {
-		numTxns += len(collection.Collection.Transactions)
+		numTxns += len(collection.Transactions)
 	}
 
 	return numTxns

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -796,7 +796,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		expectedResults := make([]flow.TransactionResult, 0)
 		for _, c := range block.CompleteCollections {
-			for _, t := range c.Collection.Transactions {
+			for _, t := range c.Transactions {
 				txResult := flow.TransactionResult{
 					TransactionID: t.ID(),
 					ErrorMessage: fvmErrors.NewInvalidAddressErrorf(
@@ -869,7 +869,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 			transactions := []*flow.TransactionBody{}
 			for _, col := range block.Collections() {
-				transactions = append(transactions, col.Collection.Transactions...)
+				transactions = append(transactions, col.Transactions...)
 			}
 
 			// events to emit for each iteration/transaction
@@ -1118,7 +1118,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		normalTransactions := map[common.Location]struct{}{}
 		for _, col := range block.Collections() {
-			for _, txn := range col.Collection.Transactions {
+			for _, txn := range col.Transactions {
 				loc := common.TransactionLocation(txn.ID())
 				normalTransactions[loc] = struct{}{}
 			}
@@ -1664,8 +1664,9 @@ func generateCollection(
 	guarantee := &flow.CollectionGuarantee{CollectionID: collection.ID()}
 
 	return &entity.CompleteCollection{
-		Guarantee:  guarantee,
-		Collection: &collection,
+		Guarantee: guarantee,
+		//Collection: &collection,
+		Transactions: transactions,
 	}
 }
 

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -796,7 +796,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		expectedResults := make([]flow.TransactionResult, 0)
 		for _, c := range block.CompleteCollections {
-			for _, t := range c.Transactions {
+			for _, t := range c.Collection.Transactions {
 				txResult := flow.TransactionResult{
 					TransactionID: t.ID(),
 					ErrorMessage: fvmErrors.NewInvalidAddressErrorf(
@@ -869,7 +869,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 			transactions := []*flow.TransactionBody{}
 			for _, col := range block.Collections() {
-				transactions = append(transactions, col.Transactions...)
+				transactions = append(transactions, col.Collection.Transactions...)
 			}
 
 			// events to emit for each iteration/transaction
@@ -1118,7 +1118,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		normalTransactions := map[common.Location]struct{}{}
 		for _, col := range block.Collections() {
-			for _, txn := range col.Transactions {
+			for _, txn := range col.Collection.Transactions {
 				loc := common.TransactionLocation(txn.ID())
 				normalTransactions[loc] = struct{}{}
 			}
@@ -1664,8 +1664,8 @@ func generateCollection(
 	guarantee := &flow.CollectionGuarantee{CollectionID: collection.ID()}
 
 	return &entity.CompleteCollection{
-		Guarantee:    guarantee,
-		Transactions: transactions,
+		Guarantee:  guarantee,
+		Collection: &collection,
 	}
 }
 

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -170,9 +170,9 @@ func (collector *resultCollector) commitCollection(
 	txResults := execColRes.TransactionResults()
 	convertedTxResults := execution_data.ConvertTransactionResults(txResults)
 
-	col := collection.Collection()
+	col := collection.Collection
 	chunkExecData := &execution_data.ChunkExecutionData{
-		Collection:         &col,
+		Collection:         col,
 		Events:             events,
 		TrieUpdate:         trieUpdate,
 		TransactionResults: convertedTxResults,
@@ -188,7 +188,7 @@ func (collector *resultCollector) commitCollection(
 
 	collector.metrics.ExecutionChunkDataPackGenerated(
 		len(proof),
-		len(collection.Transactions))
+		len(collection.Collection.Transactions))
 
 	spock, err := collector.signer.SignFunc(
 		collectionExecutionSnapshot.SpockSecret,

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -170,9 +170,10 @@ func (collector *resultCollector) commitCollection(
 	txResults := execColRes.TransactionResults()
 	convertedTxResults := execution_data.ConvertTransactionResults(txResults)
 
-	col := collection.Collection
+	//col := collection.Collection
+	col := collection.Collection()
 	chunkExecData := &execution_data.ChunkExecutionData{
-		Collection:         col,
+		Collection:         &col,
 		Events:             events,
 		TrieUpdate:         trieUpdate,
 		TransactionResults: convertedTxResults,
@@ -188,7 +189,7 @@ func (collector *resultCollector) commitCollection(
 
 	collector.metrics.ExecutionChunkDataPackGenerated(
 		len(proof),
-		len(collection.Collection.Transactions))
+		len(collection.Transactions))
 
 	spock, err := collector.signer.SignFunc(
 		collectionExecutionSnapshot.SpockSecret,

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -273,8 +273,8 @@ func createBlock(b *testing.B, parentBlock *flow.Block, accs *testAccounts, colN
 		collections[c] = collection
 		guarantees[c] = guarantee
 		completeCollections[guarantee.CollectionID] = &entity.CompleteCollection{
-			Guarantee:  guarantee,
-			Collection: collection,
+			Guarantee:    guarantee,
+			Transactions: transactions,
 		}
 	}
 

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -273,8 +273,8 @@ func createBlock(b *testing.B, parentBlock *flow.Block, accs *testAccounts, colN
 		collections[c] = collection
 		guarantees[c] = guarantee
 		completeCollections[guarantee.CollectionID] = &entity.CompleteCollection{
-			Guarantee:    guarantee,
-			Transactions: transactions,
+			Guarantee:  guarantee,
+			Collection: collection,
 		}
 	}
 

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -110,8 +110,10 @@ func TestComputeBlockWithStorage(t *testing.T) {
 		Block: block,
 		CompleteCollections: map[flow.Identifier]*entity.CompleteCollection{
 			guarantee.CollectionID: {
-				Guarantee:    &guarantee,
-				Transactions: transactions,
+				Guarantee: &guarantee,
+				Collection: &flow.Collection{
+					Transactions: transactions,
+				},
 			},
 		},
 		StartState: unittest.StateCommitmentPointerFixture(),
@@ -805,8 +807,10 @@ func Test_EventEncodingFailsOnlyTxAndCarriesOn(t *testing.T) {
 		Block: block,
 		CompleteCollections: map[flow.Identifier]*entity.CompleteCollection{
 			guarantee.CollectionID: {
-				Guarantee:    &guarantee,
-				Transactions: transactions,
+				Guarantee: &guarantee,
+				Collection: &flow.Collection{
+					Transactions: transactions,
+				},
 			},
 		},
 		StartState: unittest.StateCommitmentPointerFixture(),

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -110,10 +110,11 @@ func TestComputeBlockWithStorage(t *testing.T) {
 		Block: block,
 		CompleteCollections: map[flow.Identifier]*entity.CompleteCollection{
 			guarantee.CollectionID: {
-				Guarantee: &guarantee,
-				Collection: &flow.Collection{
-					Transactions: transactions,
-				},
+				Guarantee:    &guarantee,
+				Transactions: transactions,
+				//Collection: &flow.Collection{
+				//	Transactions: transactions,
+				//},
 			},
 		},
 		StartState: unittest.StateCommitmentPointerFixture(),
@@ -807,10 +808,11 @@ func Test_EventEncodingFailsOnlyTxAndCarriesOn(t *testing.T) {
 		Block: block,
 		CompleteCollections: map[flow.Identifier]*entity.CompleteCollection{
 			guarantee.CollectionID: {
-				Guarantee: &guarantee,
-				Collection: &flow.Collection{
-					Transactions: transactions,
-				},
+				Guarantee:    &guarantee,
+				Transactions: transactions,
+				//Collection: &flow.Collection{
+				//	Transactions: transactions,
+				//},
 			},
 		},
 		StartState: unittest.StateCommitmentPointerFixture(),

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -104,8 +104,9 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 		Block: block,
 		CompleteCollections: map[flow.Identifier]*entity.CompleteCollection{
 			guarantee.CollectionID: {
-				Guarantee:  &guarantee,
-				Collection: &col,
+				Guarantee:    &guarantee,
+				Transactions: transactions,
+				//Collection:   &col,
 			},
 		},
 		StartState: unittest.StateCommitmentPointerFixture(),
@@ -513,8 +514,9 @@ func createTestBlockAndRun(
 		Block: block,
 		CompleteCollections: map[flow.Identifier]*entity.CompleteCollection{
 			guarantee.CollectionID: {
-				Guarantee:  &guarantee,
-				Collection: &col,
+				Guarantee: &guarantee,
+				//Collection: &col,
+				Transactions: col.Transactions,
 			},
 		},
 		StartState: unittest.StateCommitmentPointerFixture(),

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -104,8 +104,8 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 		Block: block,
 		CompleteCollections: map[flow.Identifier]*entity.CompleteCollection{
 			guarantee.CollectionID: {
-				Guarantee:    &guarantee,
-				Transactions: transactions,
+				Guarantee:  &guarantee,
+				Collection: &col,
 			},
 		},
 		StartState: unittest.StateCommitmentPointerFixture(),
@@ -513,8 +513,8 @@ func createTestBlockAndRun(
 		Block: block,
 		CompleteCollections: map[flow.Identifier]*entity.CompleteCollection{
 			guarantee.CollectionID: {
-				Guarantee:    &guarantee,
-				Transactions: col.Transactions,
+				Guarantee:  &guarantee,
+				Collection: &col,
 			},
 		},
 		StartState: unittest.StateCommitmentPointerFixture(),

--- a/engine/execution/ingestion/block_queue/queue.go
+++ b/engine/execution/ingestion/block_queue/queue.go
@@ -223,7 +223,8 @@ func (q *BlockQueue) HandleCollection(collection *flow.Collection) ([]*entity.Ex
 	}
 
 	// update collection
-	colInfo.Collection.Collection = collection
+	//nolint:structwrite
+	colInfo.Collection.Transactions = collection.Transactions
 
 	// check if any block, which includes this collection, became executable
 	executables := make([]*entity.ExecutableBlock, 0, len(colInfo.IncludedIn))

--- a/engine/execution/ingestion/block_queue/queue.go
+++ b/engine/execution/ingestion/block_queue/queue.go
@@ -223,7 +223,7 @@ func (q *BlockQueue) HandleCollection(collection *flow.Collection) ([]*entity.Ex
 	}
 
 	// update collection
-	colInfo.Collection.Transactions = collection.Transactions
+	colInfo.Collection.Collection = collection
 
 	// check if any block, which includes this collection, became executable
 	executables := make([]*entity.ExecutableBlock, 0, len(colInfo.IncludedIn))

--- a/engine/execution/ingestion/uploader/retryable_uploader_wrapper.go
+++ b/engine/execution/ingestion/uploader/retryable_uploader_wrapper.go
@@ -214,8 +214,8 @@ func (b *BadgerRetryableUploaderWrapper) reconstructComputationResult(
 		}
 
 		completeCollections[collectionID] = &entity.CompleteCollection{
-			Guarantee:    guarantees[inx],
-			Transactions: collection.Transactions,
+			Guarantee:  guarantees[inx],
+			Collection: collection,
 		}
 	}
 

--- a/engine/execution/ingestion/uploader/retryable_uploader_wrapper.go
+++ b/engine/execution/ingestion/uploader/retryable_uploader_wrapper.go
@@ -214,8 +214,9 @@ func (b *BadgerRetryableUploaderWrapper) reconstructComputationResult(
 		}
 
 		completeCollections[collectionID] = &entity.CompleteCollection{
-			Guarantee:  guarantees[inx],
-			Collection: collection,
+			Guarantee: guarantees[inx],
+			//Collection: collection,
+			Transactions: collection.Transactions,
 		}
 	}
 

--- a/engine/execution/ingestion/uploader/retryable_uploader_wrapper_test.go
+++ b/engine/execution/ingestion/uploader/retryable_uploader_wrapper_test.go
@@ -210,9 +210,10 @@ func Test_ReconstructComputationResultFromStorage(t *testing.T) {
 		Guarantee: &flow.CollectionGuarantee{
 			CollectionID: testCollectionID,
 		},
-		Collection: &flow.Collection{
-			Transactions: []*flow.TransactionBody{testTransactionBody},
-		},
+		Transactions: []*flow.TransactionBody{testTransactionBody},
+		//Collection: &flow.Collection{
+		//	Transactions: []*flow.TransactionBody{testTransactionBody},
+		//},
 	}
 
 	expectedTestEvents := make([]*flow.Event, len(testEvents))

--- a/engine/execution/ingestion/uploader/retryable_uploader_wrapper_test.go
+++ b/engine/execution/ingestion/uploader/retryable_uploader_wrapper_test.go
@@ -210,7 +210,9 @@ func Test_ReconstructComputationResultFromStorage(t *testing.T) {
 		Guarantee: &flow.CollectionGuarantee{
 			CollectionID: testCollectionID,
 		},
-		Transactions: []*flow.TransactionBody{testTransactionBody},
+		Collection: &flow.Collection{
+			Transactions: []*flow.TransactionBody{testTransactionBody},
+		},
 	}
 
 	expectedTestEvents := make([]*flow.Event, len(testEvents))

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -650,7 +650,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ide
 		node.Log, node.Metrics, node.Net, node.Me, node.State,
 		channels.RequestCollections,
 		filter.HasRole[flow.Identity](flow.RoleCollection),
-		func() flow.Entity { return &flow.Collection{} },
+		func() flow.Entity { return new(flow.Collection) },
 	)
 	require.NoError(t, err)
 

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -309,8 +309,9 @@ func ExecutionResultFixture(t *testing.T,
 
 		completeColls := make(map[flow.Identifier]*entity.CompleteCollection)
 		completeColls[guarantee.CollectionID] = &entity.CompleteCollection{
-			Guarantee:  guarantee,
-			Collection: &collection,
+			Guarantee: guarantee,
+			//Collection: &collection,
+			Transactions: collection.Transactions,
 		}
 
 		for i := 1; i < chunkCount; i++ {
@@ -327,8 +328,9 @@ func ExecutionResultFixture(t *testing.T,
 			guarantees = append(guarantees, guarantee)
 
 			completeColls[guarantee.CollectionID] = &entity.CompleteCollection{
-				Guarantee:  guarantee,
-				Collection: &collection,
+				Guarantee:    guarantee,
+				Transactions: collection.Transactions,
+				//Collection: &collection,
 			}
 		}
 

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -309,8 +309,8 @@ func ExecutionResultFixture(t *testing.T,
 
 		completeColls := make(map[flow.Identifier]*entity.CompleteCollection)
 		completeColls[guarantee.CollectionID] = &entity.CompleteCollection{
-			Guarantee:    guarantee,
-			Transactions: collection.Transactions,
+			Guarantee:  guarantee,
+			Collection: &collection,
 		}
 
 		for i := 1; i < chunkCount; i++ {
@@ -327,8 +327,8 @@ func ExecutionResultFixture(t *testing.T,
 			guarantees = append(guarantees, guarantee)
 
 			completeColls[guarantee.CollectionID] = &entity.CompleteCollection{
-				Guarantee:    guarantee,
-				Transactions: collection.Transactions,
+				Guarantee:  guarantee,
+				Collection: &collection,
 			}
 		}
 

--- a/model/cluster/block.go
+++ b/model/cluster/block.go
@@ -14,7 +14,7 @@ func Genesis() *Block {
 		ParentID:  flow.ZeroID,
 	}
 
-	block := NewBlock(headerBody, EmptyPayload(flow.ZeroID))
+	block := NewBlock(headerBody, NewEmptyPayload(flow.ZeroID))
 	return &block
 }
 

--- a/model/cluster/payload.go
+++ b/model/cluster/payload.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -32,25 +34,27 @@ type Payload struct {
 	ReferenceBlockID flow.Identifier
 }
 
-// EmptyPayload returns a payload with an empty collection and the given
+// NewEmptyPayload returns a payload with an empty collection and the given
 // reference block ID.
-func EmptyPayload(refID flow.Identifier) Payload {
-	return PayloadFromTransactions(refID)
-}
-
-// PayloadFromTransactions creates a payload given a reference block ID and a
-// list of transaction hashes.
-func PayloadFromTransactions(refID flow.Identifier, transactions ...*flow.TransactionBody) Payload {
-	// avoid a nil transaction list
-	if len(transactions) == 0 {
-		transactions = []*flow.TransactionBody{}
-	}
+func NewEmptyPayload(refID flow.Identifier) Payload {
 	return Payload{
-		Collection: flow.Collection{
-			Transactions: transactions,
-		},
+		Collection:       flow.NewEmptyCollection(),
 		ReferenceBlockID: refID,
 	}
+}
+
+// NewPayload creates a payload given a reference block ID and a
+// list of transaction hashes.
+func NewPayload(refID flow.Identifier, transactions []*flow.TransactionBody) (*Payload, error) {
+	collection, err := flow.NewCollection(flow.UntrustedCollection{Transactions: transactions})
+	if err != nil {
+		return nil, fmt.Errorf("could not construct payload: %w", err)
+	}
+
+	return &Payload{
+		Collection:       *collection,
+		ReferenceBlockID: refID,
+	}, err
 }
 
 // Hash returns the hash of the payload.

--- a/model/flow/collection.go
+++ b/model/flow/collection.go
@@ -1,10 +1,48 @@
 package flow
 
+import "fmt"
+
 // Collection is an ordered list of transactions.
 // Collections form a part of the payload of cluster blocks, produced by Collection Nodes.
 // Every Collection maps 1-1 to a Chunk, which is used for transaction execution.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type Collection struct {
 	Transactions []*TransactionBody
+}
+
+// UntrustedCollection is an untrusted input-only representation of an Collection,
+// used for construction.
+//
+// This type exists to ensure that constructor functions are invoked explicitly
+// with named fields, which improves clarity and reduces the risk of incorrect field
+// ordering during construction.
+//
+// An instance of UntrustedCollection should be validated and converted into
+// a trusted Collection using NewCollection constructor.
+type UntrustedCollection Collection
+
+// NewCollection creates a new instance of Collection.
+// Construction Collection allowed only within the constructor
+//
+// All errors indicate a valid Collection cannot be constructed from the input.
+func NewCollection(untrusted UntrustedCollection) (*Collection, error) {
+	for i, tx := range untrusted.Transactions {
+		if tx == nil {
+			return nil, fmt.Errorf("transaction at index %d is nil", i)
+		}
+	}
+
+	return &Collection{
+		Transactions: untrusted.Transactions,
+	}, nil
+}
+
+// NewEmptyCollection creates a new empty instance of Collection.
+func NewEmptyCollection() Collection {
+	return Collection{
+		Transactions: []*TransactionBody{},
+	}
 }
 
 // Light returns a LightCollection, which contains only the list of transaction IDs from the Collection.

--- a/model/flow/collection_test.go
+++ b/model/flow/collection_test.go
@@ -3,6 +3,8 @@ package flow_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -28,4 +30,51 @@ func TestCollectionID_Malleability(t *testing.T) {
 // the [flow.IDEntity] interface, is resistant to tampering.
 func TestCollectionGuaranteeID_Malleability(t *testing.T) {
 	unittest.RequireEntityNonMalleable(t, unittest.CollectionGuaranteeFixture())
+}
+
+func TestNewCollection(t *testing.T) {
+	t.Run("valid untrusted collection", func(t *testing.T) {
+		tx := unittest.TransactionBodyFixture()
+		ub := flow.UntrustedCollection{
+			Transactions: []*flow.TransactionBody{&tx},
+		}
+
+		col, err := flow.NewCollection(ub)
+		assert.NoError(t, err)
+		assert.NotNil(t, col)
+		assert.Len(t, col.Transactions, 1)
+	})
+
+	t.Run("empty transaction list", func(t *testing.T) {
+		ub := flow.UntrustedCollection{
+			Transactions: []*flow.TransactionBody{},
+		}
+
+		col, err := flow.NewCollection(ub)
+		assert.NoError(t, err)
+		assert.NotNil(t, col)
+		assert.Empty(t, col.Transactions)
+	})
+
+	t.Run("nil transaction in list", func(t *testing.T) {
+		ub := flow.UntrustedCollection{
+			Transactions: nil,
+		}
+
+		col, err := flow.NewCollection(ub)
+		assert.NoError(t, err)
+		assert.NotNil(t, col)
+		assert.Empty(t, col.Transactions)
+	})
+
+	t.Run("nil transaction in list", func(t *testing.T) {
+		ub := flow.UntrustedCollection{
+			Transactions: []*flow.TransactionBody{nil},
+		}
+
+		col, err := flow.NewCollection(ub)
+		assert.Error(t, err)
+		assert.Nil(t, col)
+		assert.Contains(t, err.Error(), "transaction at index")
+	})
 }

--- a/module/builder/collection/builder.go
+++ b/module/builder/collection/builder.go
@@ -485,8 +485,11 @@ func (b *Builder) buildPayload(buildCtx *blockBuildContext) (*cluster.Payload, e
 	}
 
 	// build the payload from the transactions
-	payload := cluster.PayloadFromTransactions(minRefID, transactions...)
-	return &payload, nil
+	payload, err := cluster.NewPayload(minRefID, transactions)
+	if err != nil {
+		return nil, fmt.Errorf("could not build the payload from the transactions : %w", err)
+	}
+	return payload, nil
 }
 
 // buildHeader constructs the header for the cluster block being built.

--- a/module/builder/collection/builder_test.go
+++ b/module/builder/collection/builder_test.go
@@ -199,7 +199,9 @@ func (suite *BuilderSuite) FinalizeBlock(block model.Block) {
 func (suite *BuilderSuite) Payload(transactions ...*flow.TransactionBody) model.Payload {
 	final, err := suite.protoState.Final().Head()
 	suite.Require().NoError(err)
-	return model.PayloadFromTransactions(final.ID(), transactions...)
+	payload, err := model.NewPayload(final.ID(), transactions)
+	suite.Require().NoError(err)
+	return *payload
 }
 
 // ProtoStateRoot returns the root block of the protocol state.

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -339,8 +339,12 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 	// ChunkExecutionData. Create the collection here using the transaction body from the
 	// transactions list
 	if systemChunk {
-		cedCollection = &flow.Collection{
+		cedCollection, err = flow.NewCollection(flow.UntrustedCollection{
 			Transactions: []*flow.TransactionBody{transactions[0].Transaction},
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("could not construct system collection: %w", err)
 		}
 	}
 

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -85,11 +85,13 @@ func TestFinalizer(t *testing.T) {
 			assert.True(t, pool.Add(tx1.ID(), &tx1))
 
 			// create a new block on genesis
-			block := unittest.ClusterBlockWithParentAndPayload(genesis, model.PayloadFromTransactions(refBlock.ID(), &tx1))
+			payload, err := model.NewPayload(refBlock.ID(), []*flow.TransactionBody{&tx1})
+			require.NoError(t, err)
+			block := unittest.ClusterBlockWithParentAndPayload(genesis, *payload)
 			insert(block)
 
 			// finalize the block
-			err := finalizer.MakeFinal(block.ID())
+			err = finalizer.MakeFinal(block.ID())
 			assert.NoError(t, err)
 
 			// finalize the block again - this should be a no-op
@@ -105,7 +107,7 @@ func TestFinalizer(t *testing.T) {
 			finalizer := collection.NewFinalizer(db, pool, pusher, metrics)
 
 			// create a new block that isn't connected to a parent
-			block := unittest.ClusterBlockWithParentAndPayload(genesis, model.EmptyPayload(refBlock.ID()))
+			block := unittest.ClusterBlockWithParentAndPayload(genesis, model.NewEmptyPayload(refBlock.ID()))
 			block.Header.ParentID = unittest.IdentifierFixture()
 			insert(block)
 
@@ -122,7 +124,7 @@ func TestFinalizer(t *testing.T) {
 			finalizer := collection.NewFinalizer(db, pool, pusher, metrics)
 
 			// create a block with empty payload on genesis
-			block := unittest.ClusterBlockWithParentAndPayload(genesis, model.EmptyPayload(refBlock.ID()))
+			block := unittest.ClusterBlockWithParentAndPayload(genesis, model.NewEmptyPayload(refBlock.ID()))
 			insert(block)
 
 			// finalize the block
@@ -153,7 +155,9 @@ func TestFinalizer(t *testing.T) {
 			assert.True(t, pool.Add(tx2.ID(), &tx2))
 
 			// create a block containing tx1 on top of genesis
-			block := unittest.ClusterBlockWithParentAndPayload(genesis, model.PayloadFromTransactions(refBlock.ID(), &tx1))
+			payload, err := model.NewPayload(refBlock.ID(), []*flow.TransactionBody{&tx1})
+			require.NoError(t, err)
+			block := unittest.ClusterBlockWithParentAndPayload(genesis, *payload)
 			insert(block)
 
 			// block should be passed to pusher
@@ -166,7 +170,7 @@ func TestFinalizer(t *testing.T) {
 			}).Once()
 
 			// finalize the block
-			err := finalizer.MakeFinal(block.ID())
+			err = finalizer.MakeFinal(block.ID())
 			assert.NoError(t, err)
 
 			// tx1 should have been removed from mempool
@@ -197,11 +201,15 @@ func TestFinalizer(t *testing.T) {
 			assert.True(t, pool.Add(tx2.ID(), &tx2))
 
 			// create a block containing tx1 on top of genesis
-			block1 := unittest.ClusterBlockWithParentAndPayload(genesis, model.PayloadFromTransactions(refBlock.ID(), &tx1))
+			payload, err := model.NewPayload(refBlock.ID(), []*flow.TransactionBody{&tx1})
+			require.NoError(t, err)
+			block1 := unittest.ClusterBlockWithParentAndPayload(genesis, *payload)
 			insert(block1)
 
 			// create a block containing tx2 on top of block1
-			block2 := unittest.ClusterBlockWithParentAndPayload(block1, model.PayloadFromTransactions(refBlock.ID(), &tx2))
+			payload, err = model.NewPayload(refBlock.ID(), []*flow.TransactionBody{&tx2})
+			require.NoError(t, err)
+			block2 := unittest.ClusterBlockWithParentAndPayload(block1, *payload)
 			insert(block2)
 
 			// both blocks should be passed to pusher
@@ -221,7 +229,7 @@ func TestFinalizer(t *testing.T) {
 			}).Once()
 
 			// finalize block2 (should indirectly finalize block1 as well)
-			err := finalizer.MakeFinal(block2.ID())
+			err = finalizer.MakeFinal(block2.ID())
 			assert.NoError(t, err)
 
 			// tx1 and tx2 should have been removed from mempool
@@ -250,11 +258,15 @@ func TestFinalizer(t *testing.T) {
 			assert.True(t, pool.Add(tx2.ID(), &tx2))
 
 			// create a block containing tx1 on top of genesis
-			block1 := unittest.ClusterBlockWithParentAndPayload(genesis, model.PayloadFromTransactions(refBlock.ID(), &tx1))
+			payload, err := model.NewPayload(refBlock.ID(), []*flow.TransactionBody{&tx1})
+			require.NoError(t, err)
+			block1 := unittest.ClusterBlockWithParentAndPayload(genesis, *payload)
 			insert(block1)
 
 			// create a block containing tx2 on top of block1
-			block2 := unittest.ClusterBlockWithParentAndPayload(block1, model.PayloadFromTransactions(refBlock.ID(), &tx2))
+			payload, err = model.NewPayload(refBlock.ID(), []*flow.TransactionBody{&tx2})
+			require.NoError(t, err)
+			block2 := unittest.ClusterBlockWithParentAndPayload(block1, *payload)
 			insert(block2)
 
 			// block should be passed to pusher
@@ -267,7 +279,7 @@ func TestFinalizer(t *testing.T) {
 			}).Once()
 
 			// finalize block1 (should NOT finalize block2)
-			err := finalizer.MakeFinal(block1.ID())
+			err = finalizer.MakeFinal(block1.ID())
 			assert.NoError(t, err)
 
 			// tx1 should have been removed from mempool
@@ -298,11 +310,15 @@ func TestFinalizer(t *testing.T) {
 			assert.True(t, pool.Add(tx2.ID(), &tx2))
 
 			// create a block containing tx1 on top of genesis
-			block1 := unittest.ClusterBlockWithParentAndPayload(genesis, model.PayloadFromTransactions(refBlock.ID(), &tx1))
+			payload, err := model.NewPayload(refBlock.ID(), []*flow.TransactionBody{&tx1})
+			require.NoError(t, err)
+			block1 := unittest.ClusterBlockWithParentAndPayload(genesis, *payload)
 			insert(block1)
 
 			// create a block containing tx2 on top of genesis (conflicting with block1)
-			block2 := unittest.ClusterBlockWithParentAndPayload(genesis, model.PayloadFromTransactions(refBlock.ID(), &tx2))
+			payload, err = model.NewPayload(refBlock.ID(), []*flow.TransactionBody{&tx2})
+			require.NoError(t, err)
+			block2 := unittest.ClusterBlockWithParentAndPayload(genesis, *payload)
 			insert(block2)
 
 			// block should be passed to pusher
@@ -315,7 +331,7 @@ func TestFinalizer(t *testing.T) {
 			}).Once()
 
 			// finalize block1
-			err := finalizer.MakeFinal(block1.ID())
+			err = finalizer.MakeFinal(block1.ID())
 			assert.NoError(t, err)
 
 			// tx1 should have been removed from mempool

--- a/module/mempool/entity/executableblock.go
+++ b/module/mempool/entity/executableblock.go
@@ -9,10 +9,10 @@ import (
 // receives the guarantee from the block, and queries the transactions by
 // the guarantee from the collection node.
 // when receiving a collection from collection node, the execution node will
-// update the Transactions field of a CompleteCollection and make it complete.
+// update the Collection field of a CompleteCollection and make it complete.
 type CompleteCollection struct {
-	Guarantee    *flow.CollectionGuarantee
-	Transactions []*flow.TransactionBody
+	Guarantee  *flow.CollectionGuarantee
+	Collection *flow.Collection
 }
 
 // ExecutableBlock represents a block that can be executed by the VM
@@ -29,12 +29,8 @@ type ExecutableBlock struct {
 	Executing           bool // flag used to indicate if block is being executed, to avoid re-execution
 }
 
-func (c CompleteCollection) Collection() flow.Collection {
-	return flow.Collection{Transactions: c.Transactions}
-}
-
 func (c CompleteCollection) IsCompleted() bool {
-	return len(c.Transactions) > 0
+	return len(c.Collection.Transactions) > 0
 }
 
 // BlockID lazy loads the Block.ID() into the private blockID field on the first call, and returns
@@ -80,7 +76,7 @@ func (b *ExecutableBlock) CollectionAt(index int) *flow.Collection {
 	if cc == nil {
 		return nil
 	}
-	return &flow.Collection{Transactions: cc.Transactions}
+	return cc.Collection
 }
 
 // HasAllTransactions returns whether all the transactions for all collections

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -154,7 +154,10 @@ func (suite *MutatorSuite) Payload(transactions ...*flow.TransactionBody) model.
 			minRefID = refBlock.ID()
 		}
 	}
-	return model.PayloadFromTransactions(minRefID, transactions...)
+	payload, err := model.NewPayload(minRefID, transactions)
+	suite.Assert().NoError(err)
+
+	return *payload
 }
 
 // ProposalWithParent returns a valid block proposal with the given parent and the given payload.
@@ -389,7 +392,7 @@ func (suite *MutatorSuite) TestExtend_WithExpiredReferenceBlock() {
 	}
 
 	// set genesis as reference block
-	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.EmptyPayload(suite.protoGenesis.ID()))
+	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.NewEmptyPayload(suite.protoGenesis.ID()))
 	err := suite.state.Extend(&proposal)
 	suite.Assert().Nil(err)
 }
@@ -398,7 +401,7 @@ func (suite *MutatorSuite) TestExtend_WithReferenceBlockFromClusterChain() {
 	// TODO skipping as this isn't implemented yet
 	unittest.SkipUnless(suite.T(), unittest.TEST_TODO, "skipping as this isn't implemented yet")
 	// set genesis from cluster chain as reference block
-	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.EmptyPayload(suite.genesis.ID()))
+	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.NewEmptyPayload(suite.genesis.ID()))
 	err := suite.state.Extend(&proposal)
 	suite.Assert().Error(err)
 }
@@ -414,7 +417,7 @@ func (suite *MutatorSuite) TestExtend_WithReferenceBlockFromDifferentEpoch() {
 	nextEpochHeader, err := suite.protoState.AtHeight(heights.FinalHeight() + 1).Head()
 	require.NoError(suite.T(), err)
 
-	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.EmptyPayload(nextEpochHeader.ID()))
+	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.NewEmptyPayload(nextEpochHeader.ID()))
 	err = suite.state.Extend(&proposal)
 	suite.Assert().Error(err)
 	suite.Assert().True(state.IsInvalidExtensionError(err))
@@ -429,7 +432,7 @@ func (suite *MutatorSuite) TestExtend_WithUnfinalizedReferenceBlock() {
 	err := suite.protoState.ExtendCertified(context.Background(), unittest.NewCertifiedBlock(unfinalized))
 	suite.Require().NoError(err)
 
-	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.EmptyPayload(unfinalized.ID()))
+	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.NewEmptyPayload(unfinalized.ID()))
 	err = suite.state.Extend(&proposal)
 	suite.Assert().Error(err)
 	suite.Assert().True(state.IsUnverifiableExtensionError(err))
@@ -454,7 +457,7 @@ func (suite *MutatorSuite) TestExtend_WithOrphanedReferenceBlock() {
 	suite.Require().NoError(err)
 
 	// test referencing the orphaned block
-	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.EmptyPayload(orphaned.ID()))
+	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.NewEmptyPayload(orphaned.ID()))
 	err = suite.state.Extend(&proposal)
 	suite.Assert().Error(err)
 	suite.Assert().True(state.IsInvalidExtensionError(err))

--- a/state/cluster/badger/snapshot_test.go
+++ b/state/cluster/badger/snapshot_test.go
@@ -106,7 +106,11 @@ func (suite *SnapshotSuite) Payload(transactions ...*flow.TransactionBody) model
 			minRefID = refBlock.ID()
 		}
 	}
-	return model.PayloadFromTransactions(minRefID, transactions...)
+
+	payload, err := model.NewPayload(minRefID, transactions)
+	suite.Assert().NoError(err)
+
+	return *payload
 }
 
 // ProposalWithParentAndPayload returns a valid block proposal with the given parent and payload.
@@ -177,7 +181,7 @@ func (suite *SnapshotSuite) TestEmptyCollection() {
 	t := suite.T()
 
 	// create a block with an empty collection
-	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.EmptyPayload(flow.ZeroID))
+	proposal := suite.ProposalWithParentAndPayload(suite.genesis, model.NewEmptyPayload(flow.ZeroID))
 	suite.InsertBlock(proposal)
 
 	snapshot := suite.state.AtBlockID(proposal.Block.ID())

--- a/state/cluster/root_block.go
+++ b/state/cluster/root_block.go
@@ -14,7 +14,7 @@ func CanonicalClusterID(epoch uint64, participants flow.IdentifierList) flow.Cha
 }
 
 // these globals are filled by the static initializer
-var rootBlockPayload = cluster.EmptyPayload(flow.ZeroID)
+var rootBlockPayload = cluster.NewEmptyPayload(flow.ZeroID)
 
 // CanonicalRootBlock returns the canonical root block for the given
 // cluster in the given epoch. It contains an empty collection referencing

--- a/storage/badger/collections.go
+++ b/storage/badger/collections.go
@@ -46,8 +46,8 @@ func (c *Collections) Store(collection *flow.Collection) error {
 
 func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 	var (
-		light      flow.LightCollection
-		collection flow.Collection
+		light flow.LightCollection
+		txs   []*flow.TransactionBody
 	)
 
 	err := c.db.View(func(btx *badger.Txn) error {
@@ -56,13 +56,14 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 			return fmt.Errorf("could not retrieve collection: %w", err)
 		}
 
+		txs = make([]*flow.TransactionBody, 0, len(light.Transactions))
 		for _, txID := range light.Transactions {
 			tx, err := c.transactions.ByID(txID)
 			if err != nil {
 				return fmt.Errorf("could not retrieve transaction: %w", err)
 			}
 
-			collection.Transactions = append(collection.Transactions, tx)
+			txs = append(txs, tx)
 		}
 
 		return nil
@@ -71,7 +72,12 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 		return nil, err
 	}
 
-	return &collection, nil
+	collection, err := flow.NewCollection(flow.UntrustedCollection{Transactions: txs})
+	if err != nil {
+		return nil, fmt.Errorf("could not construct collection: %w", err)
+	}
+
+	return collection, nil
 }
 
 func (c *Collections) LightByID(colID flow.Identifier) (*flow.LightCollection, error) {

--- a/storage/badger/procedure/cluster.go
+++ b/storage/badger/procedure/cluster.go
@@ -219,7 +219,10 @@ func RetrieveClusterPayload(blockID flow.Identifier, payload *cluster.Payload) f
 			colTransactions = append(colTransactions, &nextTx)
 		}
 
-		*payload = cluster.PayloadFromTransactions(refID, colTransactions...)
+		payload, err = cluster.NewPayload(refID, colTransactions)
+		if err != nil {
+			return fmt.Errorf("could not build the payload from the transactions: %w", err)
+		}
 
 		return nil
 	}

--- a/storage/store/collections.go
+++ b/storage/store/collections.go
@@ -64,8 +64,8 @@ func (c *Collections) Store(collection *flow.Collection) error {
 // ByID retrieves a collection by its ID.
 func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 	var (
-		light      flow.LightCollection
-		collection flow.Collection
+		light flow.LightCollection
+		txs   []*flow.TransactionBody
 	)
 
 	err := operation.RetrieveCollection(c.db.Reader(), colID, &light)
@@ -73,16 +73,22 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 		return nil, fmt.Errorf("could not retrieve collection: %w", err)
 	}
 
+	txs = make([]*flow.TransactionBody, 0, len(light.Transactions))
 	for _, txID := range light.Transactions {
 		tx, err := c.transactions.ByID(txID)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve transaction %v: %w", txID, err)
 		}
 
-		collection.Transactions = append(collection.Transactions, tx)
+		txs = append(txs, tx)
 	}
 
-	return &collection, nil
+	collection, err := flow.NewCollection(flow.UntrustedCollection{Transactions: txs})
+	if err != nil {
+		return nil, fmt.Errorf("could not construct collection: %w", err)
+	}
+
+	return collection, nil
 }
 
 // LightByID retrieves a light collection by its ID.

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -718,9 +718,10 @@ func CompleteCollectionFixture() *entity.CompleteCollection {
 			ReferenceBlockID: FixedReferenceBlockID(),
 			SignerIndices:    SignerIndicesFixture(1),
 		},
-		Collection: &flow.Collection{
-			Transactions: []*flow.TransactionBody{&txBody},
-		},
+		Transactions: []*flow.TransactionBody{&txBody},
+		//Collection: &flow.Collection{
+		//	Transactions: []*flow.TransactionBody{&txBody},
+		//},
 	}
 }
 
@@ -732,9 +733,10 @@ func CompleteCollectionFromTransactions(txs []*flow.TransactionBody) *entity.Com
 			ReferenceBlockID: IdentifierFixture(),
 			SignerIndices:    SignerIndicesFixture(3),
 		},
-		Collection: &flow.Collection{
-			Transactions: txs,
-		},
+		Transactions: txs,
+		//Collection: &flow.Collection{
+		//	Transactions: txs,
+		//},
 	}
 }
 

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -566,8 +566,11 @@ func ClusterPayloadFixture(n int) *cluster.Payload {
 		tx := TransactionBodyFixture()
 		transactions[i] = &tx
 	}
-	payload := cluster.PayloadFromTransactions(flow.ZeroID, transactions...)
-	return &payload
+	payload, err := cluster.NewPayload(flow.ZeroID, transactions)
+	if err != nil {
+		panic(err)
+	}
+	return payload
 }
 
 func ClusterBlockFixture() cluster.Block {
@@ -715,7 +718,9 @@ func CompleteCollectionFixture() *entity.CompleteCollection {
 			ReferenceBlockID: FixedReferenceBlockID(),
 			SignerIndices:    SignerIndicesFixture(1),
 		},
-		Transactions: []*flow.TransactionBody{&txBody},
+		Collection: &flow.Collection{
+			Transactions: []*flow.TransactionBody{&txBody},
+		},
 	}
 }
 
@@ -727,7 +732,9 @@ func CompleteCollectionFromTransactions(txs []*flow.TransactionBody) *entity.Com
 			ReferenceBlockID: IdentifierFixture(),
 			SignerIndices:    SignerIndicesFixture(3),
 		},
-		Transactions: txs,
+		Collection: &flow.Collection{
+			Transactions: txs,
+		},
 	}
 }
 


### PR DESCRIPTION
Closes: #7281,  #7283 .

## Context 

This PR introduces constructor functions for the following structs: `Collection`, and `CollectionGuarantee` structs. In addition, it removes all direct field assignments on these types outside of their constructors, enforcing immutability by construction.