### PR TITLE
[master] Remove double-close of pebble batch

### DIFF
--- a/storage/operation/badgerimpl/writer.go
+++ b/storage/operation/badgerimpl/writer.go
@@ -79,6 +79,7 @@ func (b *ReaderBatchWriter) Commit() error {
 // Close releases memory of the batch and no error is returned.
 // This can be called as a defer statement immediately after creating Batch
 // to reduce risk of unbounded memory consumption.
+// No errors are expected during normal operation.
 func (b *ReaderBatchWriter) Close() error {
 	// BadgerDB v2 docs for WriteBatch.Cancel():
 	//

--- a/storage/operation/pebbleimpl/writer.go
+++ b/storage/operation/pebbleimpl/writer.go
@@ -66,11 +66,10 @@ func (b *ReaderBatchWriter) AddCallback(callback func(error)) {
 }
 
 // Commit flushes the batch to the database.
-// No errors are expected during normal operation.
+// Commit may be called at most once per Batch.
 // ReaderBatchWriter can't be reused after Commit() is called.
+// No errors are expected during normal operation.
 func (b *ReaderBatchWriter) Commit() error {
-	defer b.batch.Close() // Release batch resource
-
 	err := b.batch.Commit(pebble.Sync)
 
 	b.callbacks.NotifyCallbacks(err)
@@ -79,15 +78,16 @@ func (b *ReaderBatchWriter) Commit() error {
 }
 
 // Close releases memory of the batch and no error is returned.
+// Close must be called exactly once per batch.
 // This can be called as a defer statement immediately after creating Batch
 // to reduce risk of unbounded memory consumption.
+// No errors are expected during normal operation.
 func (b *ReaderBatchWriter) Close() error {
 	// Pebble v2 docs for Batch.Close():
 	//
 	// "Close closes the batch without committing it."
 
-	b.batch.Close()
-	return nil
+	return b.batch.Close()
 }
 
 func WithReaderBatchWriter(db *pebble.DB, fn func(storage.ReaderBatchWriter) error) error {

--- a/storage/operations.go
+++ b/storage/operations.go
@@ -173,17 +173,20 @@ type DB interface {
 }
 
 // Batch is an interface for a batch of writes to a storage backend.
-// The batch is pending until it is committed.
-// Useful for dynamically adding writes to the batch
+// The batch is pending until it is committed. Useful for dynamically adding writes to the batch.
 type Batch interface {
 	ReaderBatchWriter
 
 	// Commit applies the batched updates to the database.
+	// Commit may be called at most once per Batch.
+	// No errors are expected during normal operation.
 	Commit() error
 
 	// Close releases memory of the batch.
+	// Close must be called exactly once per Batch.
 	// This can be called as a defer statement immediately after creating Batch
 	// to reduce risk of unbounded memory consumption.
+	// No errors are expected during normal operation.
 	Close() error
 }
 


### PR DESCRIPTION
Backport of #7488 


> This PR removes the call to `Close` from the `Commit` method of `ReaderBatchWriter`. The reason is that:
> - `WithReaderBatchWriter` defers `batch.Close` https://github.com/onflow/flow-go/blob/3701d49e46af01d11d43d1a94a7f91bb556d3808/storage/operation/pebbleimpl/writer.go#L95
> - `WithReaderBatchWriter` also calls `batch.Commit` https://github.com/onflow/flow-go/blob/3701d49e46af01d11d43d1a94a7f91bb556d3808/storage/operation/pebbleimpl/writer.go#L108
> 
> So currently (prior to this PR) we were closing each `Batch` _twice_ when using `WithReaderBatchWriter` in the happy path. 
> 
> We have seen some crashes originating from Pebble indicating unset fields (see [Notion document](https://www.notion.so/flowfoundation/EN-Pebble-Fatal-Errors-2025Q2-2091aee123248050abbce0f0da1e8b66?source=copy_link) for details).
> - One crash message indicating `Batch.db` is nil
> - One crash message indicating `Batch`'s seqnum is 0 when it is expected to be some large number
> 
> `Batch` does not document that it must be closed only once, however Pebble uses a sync pool to re-use `Batch` instances. 
> - `Batch.Close` will have no effect if the `Batch` is already zeroed (detected by observing a nil `Batch.db`), so most of the time double-closing a batch will have no effect.
> - In rare cases, the Batch may be re-used in between the two `Close`s. The hypothesis of this PR is that when this happens, the second `Close` will zero a Batch that is in-use by another goroutine, causing the various crash failures we've seen. This is consistent with the crashes occurring infrequently and the crashes all referring to an unexpected zero field.