### PR TITLE
[Storage] execution node support pebble based execution data store

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/ipfs/boxo/bitswap"
 	"github.com/ipfs/go-cid"
-	badgerds "github.com/ipfs/go-ds-badger2"
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
 	"github.com/rs/zerolog"
@@ -78,6 +77,8 @@ import (
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	exedataprovider "github.com/onflow/flow-go/module/executiondatasync/provider"
 	"github.com/onflow/flow-go/module/executiondatasync/pruner"
+	edstorage "github.com/onflow/flow-go/module/executiondatasync/storage"
+	execdatastorage "github.com/onflow/flow-go/module/executiondatasync/storage"
 	"github.com/onflow/flow-go/module/executiondatasync/tracker"
 	"github.com/onflow/flow-go/module/finalizedreader"
 	finalizer "github.com/onflow/flow-go/module/finalizer/consensus"
@@ -168,7 +169,7 @@ type ExecutionNode struct {
 	executionDataStore     execution_data.ExecutionDataStore
 	toTriggerCheckpoint    *atomic.Bool      // create the checkpoint trigger to be controlled by admin tool, and listened by the compactor
 	stopControl            *stop.StopControl // stop the node at given block height
-	executionDataDatastore *badgerds.Datastore
+	executionDataDatastore execdatastorage.DatastoreManager
 	executionDataPruner    *pruner.Pruner
 	executionDataBlobstore blobs.Blobstore
 	executionDataTracker   tracker.Storage
@@ -417,7 +418,7 @@ func (exeNode *ExecutionNode) LoadBlobService(
 	if node.ObserverMode {
 		edsChannel = channels.PublicExecutionDataService
 	}
-	bs, err := node.EngineRegistry.RegisterBlobService(edsChannel, exeNode.executionDataDatastore, opts...)
+	bs, err := node.EngineRegistry.RegisterBlobService(edsChannel, exeNode.executionDataDatastore.Datastore(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register blob service: %w", err)
 	}
@@ -710,19 +711,14 @@ func (exeNode *ExecutionNode) LoadAuthorizationCheckingFunction(
 
 func (exeNode *ExecutionNode) LoadExecutionDataDatastore(
 	node *NodeConfig,
-) error {
-	datastoreDir := filepath.Join(exeNode.exeConf.executionDataDir, "blobstore")
-	err := os.MkdirAll(datastoreDir, 0700)
+) (err error) {
+	exeNode.executionDataDatastore, err = edstorage.CreateDatastoreManager(
+		node.Logger, exeNode.exeConf.executionDataDir, exeNode.exeConf.executionDataDBMode)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not create execution data datastore manager: %w", err)
 	}
-	dsOpts := &badgerds.DefaultOptions
-	ds, err := badgerds.NewDatastore(datastoreDir, dsOpts)
-	if err != nil {
-		return err
-	}
-	exeNode.executionDataDatastore = ds
-	exeNode.builder.ShutdownFunc(ds.Close)
+
+	exeNode.builder.ShutdownFunc(exeNode.executionDataDatastore.Close)
 	return nil
 }
 
@@ -733,7 +729,7 @@ func (exeNode *ExecutionNode) LoadBlobservicePeerManagerDependencies(node *NodeC
 }
 
 func (exeNode *ExecutionNode) LoadExecutionDataGetter(node *NodeConfig) error {
-	exeNode.executionDataBlobstore = blobs.NewBlobstore(exeNode.executionDataDatastore)
+	exeNode.executionDataBlobstore = blobs.NewBlobstore(exeNode.executionDataDatastore.Datastore())
 	exeNode.executionDataStore = execution_data.NewExecutionDataStore(exeNode.executionDataBlobstore, execution_data.DefaultSerializer)
 	return nil
 }

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1384,6 +1384,8 @@ func (exeNode *ExecutionNode) LoadBootstrapper(node *NodeConfig) error {
 		return fmt.Errorf("could not query database to know whether database has been bootstrapped: %w", err)
 	}
 
+	node.Logger.Info().Msgf("execution database bootstrapped: %v, commit: %v", bootstrapped, commit)
+
 	// if the execution database does not exist, then we need to bootstrap the execution database.
 	if !bootstrapped {
 

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -14,6 +14,7 @@ import (
 	exepruner "github.com/onflow/flow-go/engine/execution/pruner"
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/module/mempool"
 	"github.com/onflow/flow-go/utils/grpcutils"
 
@@ -58,6 +59,7 @@ type ExecutionConfig struct {
 	importCheckpointWorkerCount           int
 	transactionExecutionMetricsEnabled    bool
 	transactionExecutionMetricsBufferSize uint
+	executionDataDBMode                   string
 
 	computationConfig        computation.ComputationConfig
 	receiptRequestWorkers    uint   // common provider engine workers
@@ -129,6 +131,10 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&exeConf.importCheckpointWorkerCount, "import-checkpoint-worker-count", 10, "number of workers to import checkpoint file during bootstrap")
 	flags.BoolVar(&exeConf.transactionExecutionMetricsEnabled, "tx-execution-metrics", true, "enable collection of transaction execution metrics")
 	flags.UintVar(&exeConf.transactionExecutionMetricsBufferSize, "tx-execution-metrics-buffer-size", 200, "buffer size for transaction execution metrics. The buffer size is the number of blocks that are kept in memory by the metrics provider engine")
+	flags.StringVar(&exeConf.executionDataDBMode,
+		"execution-data-db",
+		execution_data.ExecutionDataDBModeBadger.String(),
+		"[experimental] the DB type for execution datastore. One of [badger, pebble]")
 
 	flags.BoolVar(&exeConf.onflowOnlyLNs, "temp-onflow-only-lns", false, "do not use unless required. forces node to only request collections from onflow collection nodes")
 	flags.BoolVar(&exeConf.enableStorehouse, "enable-storehouse", false, "enable storehouse to store registers on disk, default is false")

--- a/cmd/util/cmd/read-badger/cmd/commits.go
+++ b/cmd/util/cmd/read-badger/cmd/commits.go
@@ -42,7 +42,7 @@ var commitsCmd = &cobra.Command{
 				return fmt.Errorf("could not get commit for block id: %v: %w", blockID, err)
 			}
 
-			log.Info().Msgf("commit: %x", commit)
+			log.Info().Msgf("commit: %v", commit)
 			return nil
 		})
 

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -337,7 +337,7 @@ func (s *state) StateCommitmentByBlockID(blockID flow.Identifier) (flow.StateCom
 func (s *state) ChunkDataPackByChunkID(chunkID flow.Identifier) (*flow.ChunkDataPack, error) {
 	chunkDataPack, err := s.chunkDataPacks.ByChunkID(chunkID)
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve stored chunk data pack: %w", err)
+		return nil, fmt.Errorf("could not retrieve chunk data pack: %w", err)
 	}
 
 	return chunkDataPack, nil

--- a/module/executiondatasync/storage/datastore_factory.go
+++ b/module/executiondatasync/storage/datastore_factory.go
@@ -27,7 +27,6 @@ func CreateDatastoreManager(
 	}
 
 	// parse the execution data DB mode
-	// TODO(leo): automatically parse the DB mode from the data in the database folder
 	executionDataDBMode, err := execution_data.ParseExecutionDataDBMode(executionDataDBModeStr)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse execution data DB mode: %w", err)
@@ -36,6 +35,7 @@ func CreateDatastoreManager(
 	// create the appropriate datastore manager based on the DB mode
 	var executionDatastoreManager DatastoreManager
 	if executionDataDBMode == execution_data.ExecutionDataDBModePebble {
+		logger.Info().Msgf("Using Pebble datastore for execution data at %s", datastoreDir)
 		executionDatastoreManager, err = NewPebbleDatastoreManager(
 			logger.With().Str("pebbledb", "endata").Logger(),
 			datastoreDir, nil)
@@ -43,6 +43,7 @@ func CreateDatastoreManager(
 			return nil, fmt.Errorf("could not create PebbleDatastoreManager for execution data: %w", err)
 		}
 	} else {
+		logger.Info().Msgf("Using Badger datastore for execution data at %s", datastoreDir)
 		executionDatastoreManager, err = NewBadgerDatastoreManager(datastoreDir, &badgerds.DefaultOptions)
 		if err != nil {
 			return nil, fmt.Errorf("could not create BadgerDatastoreManager for execution data: %w", err)

--- a/module/executiondatasync/storage/datastore_factory.go
+++ b/module/executiondatasync/storage/datastore_factory.go
@@ -1,0 +1,53 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	badgerds "github.com/ipfs/go-ds-badger2"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
+)
+
+// CreateDatastoreManager creates a new datastore manager of the specified type.
+// It supports both Badger and Pebble datastores.
+func CreateDatastoreManager(
+	logger zerolog.Logger,
+	executionDataDir string,
+	executionDataDBModeStr string,
+) (DatastoreManager, error) {
+
+	// create the datastore directory if it does not exist
+	datastoreDir := filepath.Join(executionDataDir, "blobstore")
+	err := os.MkdirAll(datastoreDir, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	// parse the execution data DB mode
+	// TODO(leo): automatically parse the DB mode from the data in the database folder
+	executionDataDBMode, err := execution_data.ParseExecutionDataDBMode(executionDataDBModeStr)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse execution data DB mode: %w", err)
+	}
+
+	// create the appropriate datastore manager based on the DB mode
+	var executionDatastoreManager DatastoreManager
+	if executionDataDBMode == execution_data.ExecutionDataDBModePebble {
+		executionDatastoreManager, err = NewPebbleDatastoreManager(
+			logger.With().Str("pebbledb", "endata").Logger(),
+			datastoreDir, nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not create PebbleDatastoreManager for execution data: %w", err)
+		}
+	} else {
+		executionDatastoreManager, err = NewBadgerDatastoreManager(datastoreDir, &badgerds.DefaultOptions)
+		if err != nil {
+			return nil, fmt.Errorf("could not create BadgerDatastoreManager for execution data: %w", err)
+		}
+	}
+
+	return executionDatastoreManager, nil
+}


### PR DESCRIPTION
Work towards https://github.com/onflow/flow-go/issues/7265

This PR:
- Updates execution node to support pebble based execution data. 
- Storage engine can be chosen by flag `--execution-data-db=pebble`, default is `--execution-data-db=badger`.
- Refactor access node to reuse the same logic for determine the storage engine for execution data.