### PR TITLE
[Malleability Immutable] ComputationResult refactoring

### DIFF
--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -290,7 +290,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 
 			computationResult2 := testutil.ComputationResultFixture(t)
 			computationResult2.ExecutableBlock = executableBlock
-			computationResult2.ExecutionResult.BlockID = header.ID()
+			computationResult2.ExecutionReceipt.ExecutionResult.BlockID = header.ID()
 
 			// re execute result
 			err = es.SaveExecutionResults(context.Background(), computationResult2)

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -316,7 +316,7 @@ func TestBlockExecutor_ExecuteBlock_VersionAwareChunk(t *testing.T) {
 		// (1+totalTransactionCount) /2 * totalTransactionCount
 		assert.LessOrEqual(t, vm.CallCount(), (1+3)/2*3)
 
-		return &result.ExecutionResult
+		return &result.ExecutionReceipt.ExecutionResult
 	}
 
 	// Versions before v1 should have nil ServiceEventCount field

--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -812,7 +812,7 @@ func executeBlockAndVerifyWithParameters(t *testing.T,
 		snapshot := res.ExecutionSnapshot()
 		valid, err := crypto.SPOCKVerifyAgainstData(
 			myIdentity.StakingPubKey,
-			computationResult.Spocks[i],
+			computationResult.ExecutionReceipt.Spocks[i],
 			snapshot.SpockSecret,
 			spockHasher)
 		require.NoError(t, err)
@@ -832,7 +832,7 @@ func executeBlockAndVerifyWithParameters(t *testing.T,
 	chdps := computationResult.AllChunkDataPacks()
 	require.Equal(t, len(chdps), len(receipt.Spocks))
 
-	er := &computationResult.ExecutionResult
+	er := &computationResult.ExecutionReceipt.ExecutionResult
 
 	verifier := chunks.NewChunkVerifier(vm, fvmContext, logger)
 

--- a/engine/execution/ingestion/core_test.go
+++ b/engine/execution/ingestion/core_test.go
@@ -183,7 +183,7 @@ type mockExecutor struct {
 func (m *mockExecutor) ExecuteBlock(_ context.Context, block *entity.ExecutableBlock) (*execution.ComputationResult, error) {
 	result := testutil.ComputationResultFixture(m.t)
 	result.ExecutableBlock = block
-	result.ExecutionResult.BlockID = block.BlockID()
+	result.ExecutionReceipt.ExecutionResult.BlockID = block.BlockID()
 	log.Info().Msgf("mockExecutor: block %v executed", block.Block.Header.Height)
 	return result, nil
 }

--- a/engine/execution/messages.go
+++ b/engine/execution/messages.go
@@ -5,11 +5,15 @@ import (
 	"github.com/onflow/flow-go/module/mempool/entity"
 )
 
+// ComputationResult captures artifacts of execution of block collections, collection attestation results and
+// the full execution receipt, as sent by the Execution Node.
+// CAUTION: This type is used to represent both a complete ComputationResult and a partially constructed ComputationResult.
+// TODO: Consider using a Builder type to represent the partially constructed model.
 type ComputationResult struct {
 	*BlockExecutionResult
 	*BlockAttestationResult
 
-	*flow.ExecutionReceipt
+	ExecutionReceipt *flow.ExecutionReceipt
 }
 
 func NewEmptyComputationResult(

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -356,7 +356,7 @@ func ExecutionResultFixture(t *testing.T,
 		}
 
 		chunkDataPacks = computationResult.AllChunkDataPacks()
-		result = &computationResult.ExecutionResult
+		result = &computationResult.ExecutionReceipt.ExecutionResult
 	})
 
 	return result, &ExecutionReceiptData{


### PR DESCRIPTION
Closes: #7274

This change is targeted at the `feature/malleability` branch, where `ExecutableBlock.ID` has already been renamed to `ExecutableBlock.BlockID`.

## Context 
This pull request is made following the suggestion in this [comment](https://github.com/onflow/flow-go/pull/7433#discussion_r2146114855) regarding `ComputationResult` malleability.
Immutability issue #7274 for this type should not have been made, since `ComputationResult` does not have a canonical `ID` (after renaming for `ExecutableBlock.ID` to `ExecutableBlock.BlockID`) and is not sent over the network.

## Changes
This pull request implements the second part of the suggested changes from the comment:
> Make `ComputationResult.ExecutionReceipt `a non-embedded field

