### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for Seal

### DIFF
--- a/cmd/bootstrap/run/seal.go
+++ b/cmd/bootstrap/run/seal.go
@@ -6,15 +6,25 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+// GenerateRootSeal generates a seal based on execution result
+//
+// All errors indicate the input cannot be converted to a valid event.
 func GenerateRootSeal(result *flow.ExecutionResult) (*flow.Seal, error) {
 	finalState, err := result.FinalStateCommitment()
 	if err != nil {
 		return nil, fmt.Errorf("generating root seal failed: %w", err)
 	}
-	seal := &flow.Seal{
-		BlockID:    result.BlockID,
-		ResultID:   result.ID(),
-		FinalState: finalState,
+	seal, err := flow.NewSeal(
+		flow.UntrustedSeal{
+			BlockID:                result.BlockID,
+			ResultID:               result.ID(),
+			FinalState:             finalState,
+			AggregatedApprovalSigs: nil,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not construct seal: %w", err)
 	}
+
 	return seal, nil
 }

--- a/engine/common/rpc/convert/blocks.go
+++ b/engine/common/rpc/convert/blocks.go
@@ -100,17 +100,26 @@ func BlockSealToMessage(s *flow.Seal) *entities.BlockSeal {
 }
 
 // MessageToBlockSeal converts a protobuf BlockSeal message to a flow.Seal.
+//
+// All errors indicate the input cannot be converted to a valid event.
 func MessageToBlockSeal(m *entities.BlockSeal) (*flow.Seal, error) {
 	finalState, err := MessageToStateCommitment(m.FinalState)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert message to block seal: %w", err)
 	}
-	return &flow.Seal{
-		BlockID:                MessageToIdentifier(m.BlockId),
-		ResultID:               MessageToIdentifier(m.ResultId),
-		FinalState:             finalState,
-		AggregatedApprovalSigs: MessagesToAggregatedSignatures(m.AggregatedApprovalSigs),
-	}, nil
+	seal, err := flow.NewSeal(
+		flow.UntrustedSeal{
+			BlockID:                MessageToIdentifier(m.BlockId),
+			ResultID:               MessageToIdentifier(m.ResultId),
+			FinalState:             finalState,
+			AggregatedApprovalSigs: MessagesToAggregatedSignatures(m.AggregatedApprovalSigs),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not construct seal: %w", err)
+	}
+
+	return seal, nil
 }
 
 // BlockSealsToMessages converts a slice of flow.Seal to a slice of protobuf BlockSeal messages.

--- a/model/flow/seal.go
+++ b/model/flow/seal.go
@@ -1,6 +1,8 @@
 package flow
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // A Seal is produced when an Execution Result (referenced by `ResultID`) for
 // particular block (referenced by `BlockID`) is committed into the chain.
@@ -34,11 +36,37 @@ import "encoding/json"
 // Therefore, to retrieve valid blocks from storage, it is required that
 // the Seal.ID includes all fields with independent degrees of freedom
 // (such as AggregatedApprovalSigs).
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type Seal struct {
 	BlockID                Identifier
 	ResultID               Identifier
 	FinalState             StateCommitment
 	AggregatedApprovalSigs []AggregatedSignature // one AggregatedSignature per chunk
+}
+
+// UntrustedSeal is an untrusted input-only representation of a Seal,
+// used for construction.
+//
+// This type exists to ensure that constructor functions are invoked explicitly
+// with named fields, which improves clarity and reduces the risk of incorrect field
+// ordering during construction.
+//
+// An instance of UntrustedSeal should be validated and converted into
+// a trusted Seal using NewSeal constructor.
+type UntrustedSeal Seal
+
+// NewSeal creates a new instance of Seal.
+// Construction Seal allowed only within the constructor.
+//
+// All errors indicate a valid Seal cannot be constructed from the input.
+func NewSeal(untrusted UntrustedSeal) (*Seal, error) {
+	return &Seal{
+		BlockID:                untrusted.BlockID,
+		ResultID:               untrusted.ResultID,
+		FinalState:             untrusted.FinalState,
+		AggregatedApprovalSigs: untrusted.AggregatedApprovalSigs,
+	}, nil
 }
 
 func (s Seal) Body() interface{} {

--- a/model/flow/seal.go
+++ b/model/flow/seal.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // A Seal is produced when an Execution Result (referenced by `ResultID`) for
@@ -61,6 +62,15 @@ type UntrustedSeal Seal
 //
 // All errors indicate a valid Seal cannot be constructed from the input.
 func NewSeal(untrusted UntrustedSeal) (*Seal, error) {
+	if untrusted.BlockID == ZeroID {
+		return nil, fmt.Errorf("block ID must not be zero")
+	}
+	if untrusted.ResultID == ZeroID {
+		return nil, fmt.Errorf("result ID must not be zero")
+	}
+	if untrusted.FinalState == *new(StateCommitment) {
+		return nil, fmt.Errorf("final state must not be empty")
+	}
 	return &Seal{
 		BlockID:                untrusted.BlockID,
 		ResultID:               untrusted.ResultID,

--- a/model/flow/seal_test.go
+++ b/model/flow/seal_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -23,4 +25,77 @@ func Test_SealID(t *testing.T) {
 	// They should not have changed
 	assert.NotEqual(t, id, seal.ID())
 	assert.NotEqual(t, cs, seal.Checksum())
+}
+
+// TestNewSeal verifies the behavior of the NewSeal constructor.
+// It ensures proper handling of both valid and invalid untrusted input fields.
+//
+// Test Cases:
+//
+// 1. Valid input:
+//   - Verifies that a properly populated UntrustedSeal results in a valid Seal.
+//
+// 2. Invalid input with zero block ID:
+//   - Ensures an error is returned when the BlockID is zero.
+//
+// 3. Invalid input with zero result ID:
+//   - Ensures an error is returned when the ResultID is zero.
+//
+// 4. Invalid input with empty final state:
+//   - Ensures an error is returned when the FinalState is empty.
+func TestNewSeal(t *testing.T) {
+	t.Run("valid input", func(t *testing.T) {
+		seal, err := flow.NewSeal(
+			flow.UntrustedSeal{
+				BlockID:                unittest.IdentifierFixture(),
+				ResultID:               unittest.IdentifierFixture(),
+				FinalState:             unittest.StateCommitmentFixture(),
+				AggregatedApprovalSigs: unittest.Seal.AggregatedSignatureFixtures(3),
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, seal)
+	})
+
+	t.Run("invalid input, block ID is zero", func(t *testing.T) {
+		seal, err := flow.NewSeal(
+			flow.UntrustedSeal{
+				BlockID:                flow.ZeroID,
+				ResultID:               unittest.IdentifierFixture(),
+				FinalState:             unittest.StateCommitmentFixture(),
+				AggregatedApprovalSigs: unittest.Seal.AggregatedSignatureFixtures(3),
+			},
+		)
+		require.Error(t, err)
+		require.Nil(t, seal)
+		assert.Contains(t, err.Error(), "block ID must not be zero")
+	})
+
+	t.Run("invalid input, result ID is zero", func(t *testing.T) {
+		seal, err := flow.NewSeal(
+			flow.UntrustedSeal{
+				BlockID:                unittest.IdentifierFixture(),
+				ResultID:               flow.ZeroID,
+				FinalState:             unittest.StateCommitmentFixture(),
+				AggregatedApprovalSigs: unittest.Seal.AggregatedSignatureFixtures(3),
+			},
+		)
+		require.Error(t, err)
+		require.Nil(t, seal)
+		assert.Contains(t, err.Error(), "result ID must not be zero")
+	})
+
+	t.Run("invalid input, final state is empty", func(t *testing.T) {
+		seal, err := flow.NewSeal(
+			flow.UntrustedSeal{
+				BlockID:                unittest.IdentifierFixture(),
+				ResultID:               unittest.IdentifierFixture(),
+				FinalState:             flow.StateCommitment{}, // empty
+				AggregatedApprovalSigs: unittest.Seal.AggregatedSignatureFixtures(3),
+			},
+		)
+		require.Error(t, err)
+		require.Nil(t, seal)
+		assert.Contains(t, err.Error(), "final state must not be empty")
+	})
 }


### PR DESCRIPTION
Closes: #7301

## Context
-  Added constructor `Seal` type.
-  Removed non-constructor mutations.
-  Added `UntrustedSeal` model.
-  Added unit tests for constructor.