### PR TITLE
Remove non-constructor mutations of LightCollection

### DIFF
--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -225,7 +225,7 @@ func (s *Suite) mockCollectionsForBlock(block *flow.Block) {
 	for _, g := range block.Payload.Guarantees {
 		collection := unittest.CollectionFixture(1)
 		light := collection.Light()
-		s.collections.On("LightByID", g.CollectionID).Return(&light, nil).Twice()
+		s.collections.On("LightByID", g.CollectionID).Return(light, nil).Twice()
 	}
 }
 
@@ -395,7 +395,7 @@ func (s *Suite) TestOnCollection() {
 	light := collection.Light()
 
 	// we should store the light collection and index its transactions
-	s.collections.On("StoreLightAndIndexByTransaction", &light).Return(nil).Once()
+	s.collections.On("StoreLightAndIndexByTransaction", light).Return(nil).Once()
 
 	// for each transaction in the collection, we should store it
 	needed := make(map[flow.Identifier]struct{})
@@ -428,7 +428,7 @@ func (s *Suite) TestExecutionReceiptsAreIndexed() {
 	light := collection.Light()
 
 	// we should store the light collection and index its transactions
-	s.collections.On("StoreLightAndIndexByTransaction", &light).Return(nil).Once()
+	s.collections.On("StoreLightAndIndexByTransaction", light).Return(nil).Once()
 	block := flow.NewBlock(flow.HeaderBody{Height: 0}, flow.Payload{Guarantees: []*flow.CollectionGuarantee{}})
 	s.blocks.On("ByID", mock.Anything).Return(block, nil)
 
@@ -474,7 +474,7 @@ func (s *Suite) TestOnCollectionDuplicate() {
 	light := collection.Light()
 
 	// we should store the light collection and index its transactions
-	s.collections.On("StoreLightAndIndexByTransaction", &light).Return(storerr.ErrAlreadyExists).Once()
+	s.collections.On("StoreLightAndIndexByTransaction", light).Return(storerr.ErrAlreadyExists).Once()
 
 	// for each transaction in the collection, we should store it
 	needed := make(map[flow.Identifier]struct{})

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -646,7 +646,7 @@ func (s *Suite) TestProcessBackgroundCalls() {
 		guarantees := make([]*flow.CollectionGuarantee, collPerBlk)
 		for j := 0; j < collPerBlk; j++ {
 			coll := unittest.CollectionFixture(2).Light()
-			collMap[coll.ID()] = &coll
+			collMap[coll.ID()] = coll
 			cg := unittest.CollectionGuaranteeFixture(func(cg *flow.CollectionGuarantee) {
 				cg.CollectionID = coll.ID()
 				cg.ReferenceBlockID = refBlockID

--- a/engine/access/rest/http/routes/collections_test.go
+++ b/engine/access/rest/http/routes/collections_test.go
@@ -32,7 +32,7 @@ func TestGetCollections(t *testing.T) {
 	backend := &mock.API{}
 
 	t.Run("get by ID", func(t *testing.T) {
-		inputs := []flow.LightCollection{
+		inputs := []*flow.LightCollection{
 			unittest.CollectionFixture(1).Light(),
 			unittest.CollectionFixture(10).Light(),
 			unittest.CollectionFixture(100).Light(),

--- a/engine/access/rest/http/routes/collections_test.go
+++ b/engine/access/rest/http/routes/collections_test.go
@@ -41,7 +41,7 @@ func TestGetCollections(t *testing.T) {
 		for _, col := range inputs {
 			backend.Mock.
 				On("GetCollectionByID", mocks.Anything, col.ID()).
-				Return(&col, nil).
+				Return(col, nil).
 				Once()
 
 			txs := make([]string, len(col.Transactions))
@@ -82,7 +82,7 @@ func TestGetCollections(t *testing.T) {
 
 		backend.Mock.
 			On("GetCollectionByID", mocks.Anything, col.ID()).
-			Return(&col, nil).
+			Return(col, nil).
 			Once()
 
 		req := getCollectionReq(col.ID().String(), true)

--- a/engine/access/rpc/backend/backend_stream_transactions_test.go
+++ b/engine/access/rpc/backend/backend_stream_transactions_test.go
@@ -356,8 +356,8 @@ func (s *TransactionStatusSuite) addBlockWithTransaction(transaction *flow.Trans
 	s.sealedBlock = s.finalizedBlock
 	s.addNewFinalizedBlock(s.sealedBlock.ToHeader(), true, func(block *flow.Block) {
 		block = flow.NewBlock(block.Header, unittest.PayloadFixture(unittest.WithGuarantees(&guarantee)))
-		s.collections.On("LightByID", colID).Return(&light, nil).Maybe()
-		s.collections.On("LightByTransactionID", transaction.ID()).Return(&light, nil)
+		s.collections.On("LightByID", colID).Return(light, nil).Maybe()
+		s.collections.On("LightByTransactionID", transaction.ID()).Return(light, nil)
 		s.blocks.On("ByCollectionID", colID).Return(block, nil)
 	})
 }

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -891,7 +891,7 @@ func (suite *Suite) TestGetCollection() {
 
 	suite.collections.
 		On("LightByID", expected.ID()).
-		Return(&expected, nil).
+		Return(expected, nil).
 		Once()
 
 	params := suite.defaultBackendParams()
@@ -903,7 +903,7 @@ func (suite *Suite) TestGetCollection() {
 	suite.transactions.AssertExpectations(suite.T())
 	suite.checkResponse(actual, err)
 
-	suite.Equal(expected, *actual)
+	suite.Equal(expected, actual)
 	suite.assertAllExpectations()
 }
 
@@ -1064,7 +1064,7 @@ func (suite *Suite) TestTransactionStatusTransition() {
 		}, nil)
 
 	light := collection.Light()
-	suite.collections.On("LightByID", light.ID()).Return(&light, nil)
+	suite.collections.On("LightByID", light.ID()).Return(light, nil)
 
 	// transaction storage returns the corresponding transaction
 	suite.transactions.
@@ -1074,7 +1074,7 @@ func (suite *Suite) TestTransactionStatusTransition() {
 	// collection storage returns the corresponding collection
 	suite.collections.
 		On("LightByTransactionID", transactionBody.ID()).
-		Return(&light, nil)
+		Return(light, nil)
 
 	// block storage returns the corresponding block
 	suite.blocks.
@@ -1330,7 +1330,7 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 			})
 
 	light := collection.Light()
-	suite.collections.On("LightByID", mock.Anything).Return(&light, nil)
+	suite.collections.On("LightByID", mock.Anything).Return(light, nil)
 
 	// refBlock storage returns the corresponding refBlock
 	suite.blocks.
@@ -1773,7 +1773,7 @@ func (suite *Suite) TestGetTransactionResultEventEncodingVersion() {
 		Return(transactionBody, nil)
 
 	light := collection.Light()
-	suite.collections.On("LightByID", mock.Anything).Return(&light, nil)
+	suite.collections.On("LightByID", mock.Anything).Return(light, nil)
 
 	suite.snapshot.On("Head").Return(block.ToHeader(), nil)
 

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -1320,7 +1320,7 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 				return nil
 			}
 			collLight := collection.Light()
-			return &collLight
+			return collLight
 		},
 			func(txID flow.Identifier) error {
 				if currentState == flow.TransactionStatusPending {

--- a/engine/access/rpc/backend/backend_transactions_test.go
+++ b/engine/access/rpc/backend/backend_transactions_test.go
@@ -1294,7 +1294,7 @@ func (suite *Suite) TestTransactionResultFromStorage() {
 
 	// Set up the light collection and mock the behavior of the collections object
 	lightCol := col.Light()
-	suite.collections.On("LightByID", col.ID()).Return(&lightCol, nil)
+	suite.collections.On("LightByID", col.ID()).Return(lightCol, nil)
 
 	// Set up the events storage mock
 	totalEvents := 5
@@ -1370,7 +1370,7 @@ func (suite *Suite) TestTransactionByIndexFromStorage() {
 
 	// Set up the light collection and mock the behavior of the collections object
 	lightCol := col.Light()
-	suite.collections.On("LightByID", col.ID()).Return(&lightCol, nil)
+	suite.collections.On("LightByID", col.ID()).Return(lightCol, nil)
 
 	// Mock the behavior of the blocks and transactionResults objects
 	suite.blocks.
@@ -1457,7 +1457,7 @@ func (suite *Suite) TestTransactionResultsByBlockIDFromStorage() {
 		On("ByID", blockId).
 		Return(block, nil)
 	lightCol := col.Light()
-	suite.collections.On("LightByID", mock.Anything).Return(&lightCol, nil)
+	suite.collections.On("LightByID", mock.Anything).Return(lightCol, nil)
 
 	lightTxResults := make([]flow.LightTransactionResult, len(lightCol.Transactions))
 	for i, txID := range lightCol.Transactions {

--- a/engine/access/rpc/backend/retry_test.go
+++ b/engine/access/rpc/backend/retry_test.go
@@ -97,8 +97,8 @@ func (suite *Suite) TestSuccessfulTransactionsDontRetry() {
 	// transaction storage returns the corresponding transaction
 	suite.transactions.On("ByID", transactionBody.ID()).Return(transactionBody, nil)
 	// collection storage returns the corresponding collection
-	suite.collections.On("LightByTransactionID", transactionBody.ID()).Return(&light, nil)
-	suite.collections.On("LightByID", light.ID()).Return(&light, nil)
+	suite.collections.On("LightByTransactionID", transactionBody.ID()).Return(light, nil)
+	suite.collections.On("LightByID", light.ID()).Return(light, nil)
 	// block storage returns the corresponding block
 	suite.blocks.On("ByCollectionID", collection.ID()).Return(block, nil)
 

--- a/engine/common/rpc/convert/collections.go
+++ b/engine/common/rpc/convert/collections.go
@@ -53,7 +53,7 @@ func MessageToLightCollection(m *entities.Collection) (*flow.LightCollection, er
 
 	return flow.NewLightCollection(flow.UntrustedLightCollection{
 		Transactions: transactions,
-	})
+	}), nil
 }
 
 func FullCollectionToMessage(c *flow.Collection) ([]*entities.Transaction, error) {

--- a/engine/common/rpc/convert/collections.go
+++ b/engine/common/rpc/convert/collections.go
@@ -51,9 +51,9 @@ func MessageToLightCollection(m *entities.Collection) (*flow.LightCollection, er
 		transactions = append(transactions, MessageToIdentifier(txId))
 	}
 
-	return &flow.LightCollection{
+	return flow.NewLightCollection(flow.UntrustedLightCollection{
 		Transactions: transactions,
-	}, nil
+	})
 }
 
 func FullCollectionToMessage(c *flow.Collection) ([]*entities.Transaction, error) {

--- a/integration/internal/emulator/memstore.go
+++ b/integration/internal/emulator/memstore.go
@@ -221,7 +221,7 @@ func (b *Store) CommitBlock(
 	}
 
 	for _, col := range collections {
-		err := b.InsertCollection(*col)
+		err := b.InsertCollection(col)
 		if err != nil {
 			return err
 		}
@@ -358,8 +358,8 @@ func (b *Store) EventsByHeight(
 	return events, nil
 }
 
-func (b *Store) InsertCollection(col flowgo.LightCollection) error {
-	b.collections[col.ID()] = col
+func (b *Store) InsertCollection(col *flowgo.LightCollection) error {
+	b.collections[col.ID()] = *col
 	return nil
 }
 

--- a/integration/internal/emulator/tests/store_test.go
+++ b/integration/internal/emulator/tests/store_test.go
@@ -143,7 +143,7 @@ func TestCollections(t *testing.T) {
 		t.Run("should be able to get inserted collection", func(t *testing.T) {
 			storedCol, err := store.CollectionByID(context.Background(), col.ID())
 			require.NoError(t, err)
-			assert.Equal(t, col.Light(), storedCol)
+			assert.Equal(t, *col.Light(), storedCol)
 		})
 	})
 }

--- a/model/flow/collection.go
+++ b/model/flow/collection.go
@@ -46,19 +46,14 @@ func NewEmptyCollection() *Collection {
 }
 
 // Light returns a LightCollection, which contains only the list of transaction IDs from the Collection.
-// This method may panic if invoked on a malformed receiver Collection.
 func (c Collection) Light() *LightCollection {
 	txIDs := make([]Identifier, 0, len(c.Transactions))
 	for _, tx := range c.Transactions {
 		txIDs = append(txIDs, tx.ID())
 	}
-	lc, err := NewLightCollection(UntrustedLightCollection{
+	return NewLightCollection(UntrustedLightCollection{
 		Transactions: txIDs,
 	})
-	if err != nil {
-		panic(fmt.Sprintf("sanity check failed: creating light collection from collection: %v", err))
-	}
-	return lc
 }
 
 // ID returns a cryptographic commitment to the Collection.
@@ -92,11 +87,10 @@ type LightCollection struct {
 type UntrustedLightCollection LightCollection
 
 // NewLightCollection constructs a new LightCollection instance.
-// Any errors indicate the input cannot be used to construct a valid LightCollection.
-func NewLightCollection(untrusted UntrustedLightCollection) (*LightCollection, error) {
+func NewLightCollection(untrusted UntrustedLightCollection) *LightCollection {
 	return &LightCollection{
 		Transactions: untrusted.Transactions,
-	}, nil
+	}
 }
 
 // ID returns a cryptographic commitment to the LightCollection.

--- a/model/flow/collection_test.go
+++ b/model/flow/collection_test.go
@@ -37,6 +37,16 @@ func TestNewCollection(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, col)
 		assert.Len(t, col.Transactions, 1)
+
+		t.Run("convert to LightCollection", func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				light := col.Light()
+				assert.Equal(t, light.Len(), col.Len())
+				for i := range light.Len() {
+					assert.Equal(t, col.Transactions[i].ID(), light.Transactions[i])
+				}
+			})
+		})
 	})
 
 	t.Run("empty transaction list", func(t *testing.T) {
@@ -50,7 +60,7 @@ func TestNewCollection(t *testing.T) {
 		assert.Empty(t, col.Transactions)
 	})
 
-	t.Run("nil transaction in list", func(t *testing.T) {
+	t.Run("nil transaction list", func(t *testing.T) {
 		ub := flow.UntrustedCollection{
 			Transactions: nil,
 		}
@@ -70,5 +80,27 @@ func TestNewCollection(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, col)
 		assert.Contains(t, err.Error(), "transaction at index")
+	})
+}
+
+func TestNewLightCollection(t *testing.T) {
+	t.Run("valid untrusted light collection", func(t *testing.T) {
+		untrusted := flow.UntrustedLightCollection{
+			Transactions: []flow.Identifier{unittest.IdentifierFixture()},
+		}
+
+		col, err := flow.NewLightCollection(untrusted)
+		assert.NoError(t, err)
+		assert.NotNil(t, col)
+		assert.Len(t, col.Transactions, 1)
+	})
+
+	t.Run("valid empty untrusted light collection", func(t *testing.T) {
+		untrusted := flow.UntrustedLightCollection{}
+
+		col, err := flow.NewLightCollection(untrusted)
+		assert.NoError(t, err)
+		assert.NotNil(t, col)
+		assert.Len(t, col.Transactions, 0)
 	})
 }

--- a/model/flow/collection_test.go
+++ b/model/flow/collection_test.go
@@ -39,13 +39,11 @@ func TestNewCollection(t *testing.T) {
 		assert.Len(t, col.Transactions, 1)
 
 		t.Run("convert to LightCollection", func(t *testing.T) {
-			assert.NotPanics(t, func() {
-				light := col.Light()
-				assert.Equal(t, light.Len(), col.Len())
-				for i := range light.Len() {
-					assert.Equal(t, col.Transactions[i].ID(), light.Transactions[i])
-				}
-			})
+			light := col.Light()
+			assert.Equal(t, light.Len(), col.Len())
+			for i := range light.Len() {
+				assert.Equal(t, col.Transactions[i].ID(), light.Transactions[i])
+			}
 		})
 	})
 
@@ -83,23 +81,23 @@ func TestNewCollection(t *testing.T) {
 	})
 }
 
+// TestNewLightCollection tests creating a new LightCollection.
+// All possible inputs should produce a valid LightCollection, including nil/empty transaction lists.
 func TestNewLightCollection(t *testing.T) {
 	t.Run("valid untrusted light collection", func(t *testing.T) {
 		untrusted := flow.UntrustedLightCollection{
 			Transactions: []flow.Identifier{unittest.IdentifierFixture()},
 		}
 
-		col, err := flow.NewLightCollection(untrusted)
-		assert.NoError(t, err)
+		col := flow.NewLightCollection(untrusted)
 		assert.NotNil(t, col)
-		assert.Len(t, col.Transactions, 1)
+		assert.Equal(t, untrusted.Transactions, col.Transactions)
 	})
 
 	t.Run("valid empty untrusted light collection", func(t *testing.T) {
 		untrusted := flow.UntrustedLightCollection{}
 
-		col, err := flow.NewLightCollection(untrusted)
-		assert.NoError(t, err)
+		col := flow.NewLightCollection(untrusted)
 		assert.NotNil(t, col)
 		assert.Len(t, col.Transactions, 0)
 	})

--- a/module/state_synchronization/indexer/indexer_core.go
+++ b/module/state_synchronization/indexer/indexer_core.go
@@ -338,15 +338,15 @@ func HandleCollection(
 
 	light := collection.Light()
 
-	collectionExecutedMetric.CollectionFinalized(light)
-	collectionExecutedMetric.CollectionExecuted(light)
+	collectionExecutedMetric.CollectionFinalized(*light)
+	collectionExecutedMetric.CollectionExecuted(*light)
 
 	// FIX: we can't index guarantees here, as we might have more than one block
 	// with the same collection as long as it is not finalized
 
 	// store the light collection (collection minus the transaction body - those are stored separately)
 	// and add transaction ids as index
-	err := collections.StoreLightAndIndexByTransaction(&light)
+	err := collections.StoreLightAndIndexByTransaction(light)
 	if err != nil {
 		// ignore collection if already seen
 		if errors.Is(err, storage.ErrAlreadyExists) {

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -233,13 +233,13 @@ func (suite *MutatorSuite) TestBootstrap_Successful() {
 	err := suite.db.View(func(tx *badger.Txn) error {
 
 		// should insert collection
-		var collection flow.LightCollection
-		err := operation.RetrieveCollection(suite.genesis.Payload.Collection.ID(), &collection)(tx)
+		collection := new(flow.LightCollection)
+		err := operation.RetrieveCollection(suite.genesis.Payload.Collection.ID(), collection)(tx)
 		suite.Assert().Nil(err)
 		suite.Assert().Equal(suite.genesis.Payload.Collection.Light(), collection)
 
 		// should index collection
-		collection = flow.LightCollection{} // reset the collection
+		collection = new(flow.LightCollection) // reset the collection
 		err = operation.LookupCollectionPayload(suite.genesis.ID(), &collection.Transactions)(tx)
 		suite.Assert().Nil(err)
 		suite.Assert().Equal(suite.genesis.Payload.Collection.Light(), collection)

--- a/storage/badger/collections.go
+++ b/storage/badger/collections.go
@@ -28,7 +28,7 @@ func NewCollections(db *badger.DB, transactions *Transactions) *Collections {
 func (c *Collections) Store(collection *flow.Collection) error {
 	return operation.RetryOnConflictTx(c.db, transaction.Update, func(ttx *transaction.Tx) error {
 		light := collection.Light()
-		err := transaction.WithTx(operation.SkipDuplicates(operation.InsertCollection(&light)))(ttx)
+		err := transaction.WithTx(operation.SkipDuplicates(operation.InsertCollection(light)))(ttx)
 		if err != nil {
 			return fmt.Errorf("could not insert collection: %w", err)
 		}

--- a/storage/badger/collections_test.go
+++ b/storage/badger/collections_test.go
@@ -23,7 +23,7 @@ func TestCollections(t *testing.T) {
 		expected := unittest.CollectionFixture(3).Light()
 
 		// store the light collection and the transaction index
-		err := collections.StoreLightAndIndexByTransaction(&expected)
+		err := collections.StoreLightAndIndexByTransaction(expected)
 		require.NoError(t, err)
 
 		// retrieve the light collection by collection id
@@ -62,12 +62,12 @@ func TestCollections_IndexDuplicateTx(t *testing.T) {
 
 		// insert col1
 		col1Light := col1.Light()
-		err := collections.StoreLightAndIndexByTransaction(&col1Light)
+		err := collections.StoreLightAndIndexByTransaction(col1Light)
 		require.NoError(t, err)
 
 		// insert col2
 		col2Light := col2.Light()
-		err = collections.StoreLightAndIndexByTransaction(&col2Light)
+		err = collections.StoreLightAndIndexByTransaction(col2Light)
 		require.NoError(t, err)
 
 		// should be able to retrieve col2 by ID

--- a/storage/badger/collections_test.go
+++ b/storage/badger/collections_test.go
@@ -31,7 +31,7 @@ func TestCollections(t *testing.T) {
 		require.NoError(t, err)
 
 		// check if the light collection was indeed persisted
-		assert.Equal(t, &expected, actual)
+		assert.Equal(t, expected, actual)
 
 		expectedID := expected.ID()
 
@@ -73,7 +73,7 @@ func TestCollections_IndexDuplicateTx(t *testing.T) {
 		// should be able to retrieve col2 by ID
 		gotLightByCol2ID, err := collections.LightByID(col2.ID())
 		require.NoError(t, err)
-		assert.Equal(t, &col2Light, gotLightByCol2ID)
+		assert.Equal(t, col2Light, gotLightByCol2ID)
 
 		// should be able to retrieve col2 by the transaction which only appears in col2
 		_, err = collections.LightByTransactionID(col2Tx.ID())
@@ -82,6 +82,6 @@ func TestCollections_IndexDuplicateTx(t *testing.T) {
 		// col1 (not col2) should be indexed by the shared transaction (since col1 was inserted first)
 		gotLightByDupTxID, err := collections.LightByTransactionID(dupTx.ID())
 		require.NoError(t, err)
-		assert.Equal(t, &col1Light, gotLightByDupTxID)
+		assert.Equal(t, col1Light, gotLightByDupTxID)
 	})
 }

--- a/storage/badger/operation/collections_test.go
+++ b/storage/badger/operation/collections_test.go
@@ -25,8 +25,8 @@ func TestCollections(t *testing.T) {
 			err := db.Update(InsertCollection(expected))
 			require.NoError(t, err)
 
-			var actual flow.LightCollection
-			err = db.View(RetrieveCollection(expected.ID(), &actual))
+			actual := new(flow.LightCollection)
+			err = db.View(RetrieveCollection(expected.ID(), actual))
 			assert.NoError(t, err)
 
 			assert.Equal(t, expected, actual)
@@ -53,7 +53,7 @@ func TestCollections(t *testing.T) {
 				return nil
 			})
 
-			var actual flow.LightCollection
+			actual := new(flow.LightCollection)
 			err := db.View(LookupCollectionPayload(blockID, &actual.Transactions))
 			assert.NoError(t, err)
 

--- a/storage/badger/operation/collections_test.go
+++ b/storage/badger/operation/collections_test.go
@@ -22,7 +22,7 @@ func TestCollections(t *testing.T) {
 		})
 
 		t.Run("Save", func(t *testing.T) {
-			err := db.Update(InsertCollection(&expected))
+			err := db.Update(InsertCollection(expected))
 			require.NoError(t, err)
 
 			var actual flow.LightCollection
@@ -46,7 +46,7 @@ func TestCollections(t *testing.T) {
 			blockID := unittest.IdentifierFixture()
 
 			_ = db.Update(func(tx *badger.Txn) error {
-				err := InsertCollection(&expected)(tx)
+				err := InsertCollection(expected)(tx)
 				assert.NoError(t, err)
 				err = IndexCollectionPayload(blockID, expected.Transactions)(tx)
 				assert.NoError(t, err)

--- a/storage/badger/procedure/cluster.go
+++ b/storage/badger/procedure/cluster.go
@@ -156,7 +156,7 @@ func InsertClusterPayload(blockID flow.Identifier, payload *cluster.Payload) fun
 		// SkipDuplicates here is to ignore the error if the collection already exists
 		// This means the Insert operation is actually a Upsert operation.
 		// The upsert is ok, because the data is unique by its ID
-		err := operation.SkipDuplicates(operation.InsertCollection(&light))(tx)
+		err := operation.SkipDuplicates(operation.InsertCollection(light))(tx)
 		if err != nil {
 			return fmt.Errorf("could not insert payload collection: %w", err)
 		}

--- a/storage/operation/collections_test.go
+++ b/storage/operation/collections_test.go
@@ -26,7 +26,7 @@ func TestCollections(t *testing.T) {
 
 		t.Run("Save", func(t *testing.T) {
 			err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-				return operation.UpsertCollection(rw.Writer(), &expected)
+				return operation.UpsertCollection(rw.Writer(), expected)
 			})
 			require.NoError(t, err)
 
@@ -60,7 +60,7 @@ func TestCollections(t *testing.T) {
 			blockID := unittest.IdentifierFixture()
 
 			_ = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-				err := operation.UpsertCollection(rw.Writer(), &expected)
+				err := operation.UpsertCollection(rw.Writer(), expected)
 				assert.NoError(t, err)
 				err = operation.IndexCollectionPayload(rw.Writer(), blockID, expected.Transactions)
 				assert.NoError(t, err)

--- a/storage/operation/collections_test.go
+++ b/storage/operation/collections_test.go
@@ -30,8 +30,8 @@ func TestCollections(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			var actual flow.LightCollection
-			err = operation.RetrieveCollection(db.Reader(), expected.ID(), &actual)
+			actual := new(flow.LightCollection)
+			err = operation.RetrieveCollection(db.Reader(), expected.ID(), actual)
 			assert.NoError(t, err)
 
 			assert.Equal(t, expected, actual)
@@ -43,8 +43,8 @@ func TestCollections(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			var actual flow.LightCollection
-			err = operation.RetrieveCollection(db.Reader(), expected.ID(), &actual)
+			actual := new(flow.LightCollection)
+			err = operation.RetrieveCollection(db.Reader(), expected.ID(), actual)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, storage.ErrNotFound)
 
@@ -67,7 +67,7 @@ func TestCollections(t *testing.T) {
 				return nil
 			})
 
-			var actual flow.LightCollection
+			actual := new(flow.LightCollection)
 			err := operation.LookupCollectionPayload(db.Reader(), blockID, &actual.Transactions)
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)

--- a/storage/store/collections.go
+++ b/storage/store/collections.go
@@ -45,7 +45,7 @@ func (c *Collections) StoreLight(collection *flow.LightCollection) error {
 func (c *Collections) Store(collection *flow.Collection) error {
 	return c.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 		light := collection.Light()
-		err := operation.UpsertCollection(rw.Writer(), &light)
+		err := operation.UpsertCollection(rw.Writer(), light)
 		if err != nil {
 			return fmt.Errorf("could not insert collection: %w", err)
 		}

--- a/storage/store/collections_test.go
+++ b/storage/store/collections_test.go
@@ -34,7 +34,7 @@ func TestCollections(t *testing.T) {
 		require.NoError(t, err)
 
 		// check if the light collection was indeed persisted
-		assert.Equal(t, &expected, actual)
+		assert.Equal(t, expected, actual)
 
 		expectedID := expected.ID()
 
@@ -96,7 +96,7 @@ func TestCollections_IndexDuplicateTx(t *testing.T) {
 		// should be able to retrieve col2 by ID
 		gotLightByCol2ID, err := collections.LightByID(col2.ID())
 		require.NoError(t, err)
-		assert.Equal(t, &col2Light, gotLightByCol2ID)
+		assert.Equal(t, col2Light, gotLightByCol2ID)
 
 		// should be able to retrieve col2 by the transaction which only appears in col2
 		_, err = collections.LightByTransactionID(col2Tx.ID())
@@ -106,7 +106,7 @@ func TestCollections_IndexDuplicateTx(t *testing.T) {
 		// since col1 is the first collection to be indexed by the shared transaction (dupTx)
 		gotLightByDupTxID, err := collections.LightByTransactionID(dupTx.ID())
 		require.NoError(t, err)
-		assert.Equal(t, &col1Light, gotLightByDupTxID)
+		assert.Equal(t, col1Light, gotLightByDupTxID)
 	})
 }
 

--- a/storage/store/collections_test.go
+++ b/storage/store/collections_test.go
@@ -26,7 +26,7 @@ func TestCollections(t *testing.T) {
 		expected := unittest.CollectionFixture(3).Light()
 
 		// store the light collection and the transaction index
-		err := collections.StoreLightAndIndexByTransaction(&expected)
+		err := collections.StoreLightAndIndexByTransaction(expected)
 		require.NoError(t, err)
 
 		// retrieve the light collection by collection id
@@ -85,12 +85,12 @@ func TestCollections_IndexDuplicateTx(t *testing.T) {
 
 		// insert col1
 		col1Light := col1.Light()
-		err := collections.StoreLightAndIndexByTransaction(&col1Light)
+		err := collections.StoreLightAndIndexByTransaction(col1Light)
 		require.NoError(t, err)
 
 		// insert col2
 		col2Light := col2.Light()
-		err = collections.StoreLightAndIndexByTransaction(&col2Light)
+		err = collections.StoreLightAndIndexByTransaction(col2Light)
 		require.NoError(t, err)
 
 		// should be able to retrieve col2 by ID
@@ -138,7 +138,7 @@ func TestCollections_ConcurrentIndexByTx(t *testing.T) {
 				col := unittest.CollectionFixture(1)
 				col.Transactions[0] = sharedTx // Ensure it shares the same transaction
 				light := col.Light()
-				err := collections.StoreLightAndIndexByTransaction(&light)
+				err := collections.StoreLightAndIndexByTransaction(light)
 				errChan <- err
 			}
 		}()
@@ -151,7 +151,7 @@ func TestCollections_ConcurrentIndexByTx(t *testing.T) {
 				col := unittest.CollectionFixture(1)
 				col.Transactions[0] = sharedTx // Ensure it shares the same transaction
 				light := col.Light()
-				err := collections.StoreLightAndIndexByTransaction(&light)
+				err := collections.StoreLightAndIndexByTransaction(light)
 				errChan <- err
 			}
 		}()


### PR DESCRIPTION
This PR adds:
- `LightCollection` immutability
- Using pointer type by default for `LightCollection` (match other types)