### PR TITLE
[DataAvailability] Refactor processing pipeline for results forest

### DIFF
--- a/engine/access/ingestion2/execution_result_container.go
+++ b/engine/access/ingestion2/execution_result_container.go
@@ -32,9 +32,7 @@ type ExecutionResultContainer struct {
 //   - *ExecutionResultContainer: the newly created container
 //   - error: any error that occurred during creation
 //
-// Expected Errors:
-//   - ErrInvalidBlock: when the block ID doesn't match the result's block ID
-//   - All other errors are unexpected and potential indicators of corrupted internal state
+// No errors are expected during normal operation.
 //
 // Concurrency safety:
 //   - Not safe for concurrent access
@@ -62,9 +60,7 @@ func NewExecutionResultContainer(result *flow.ExecutionResult, header *flow.Head
 //   - uint: number of receipts added (0 or 1)
 //   - error: any error that occurred during the operation
 //
-// Expected Errors:
-//   - ErrInvalidReceipt: when the receipt is for a different result
-//   - All other errors are unexpected and potential indicators of corrupted internal state
+// No errors are expected during normal operation.
 //
 // Concurrency safety:
 //   - Not safe for concurrent access
@@ -90,9 +86,7 @@ func (c *ExecutionResultContainer) AddReceipt(receipt *flow.ExecutionReceipt) (u
 //   - uint: total number of receipts added
 //   - error: any error that occurred during the operation
 //
-// Expected Errors:
-//   - ErrInvalidReceipt: when any receipt is for a different result
-//   - All other errors are unexpected and potential indicators of corrupted internal state
+// No errors are expected during normal operation.
 //
 // Concurrency safety:
 //   - Not safe for concurrent access

--- a/engine/access/ingestion2/execution_result_container.go
+++ b/engine/access/ingestion2/execution_result_container.go
@@ -1,0 +1,178 @@
+package ingestion2
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/executiondatasync/optimistic_sync"
+)
+
+// ExecutionResultContainer represents a set of ExecutionReceipts all committing to the same
+// ExecutionResult. As an ExecutionResult contains the Block ID, all results with the same
+// ID must be for the same block. For optimized storage, we only store the result once.
+// Mathematically, an ExecutionResultContainer struct represents an Equivalence Class of
+// Execution Receipts.
+// Not safe for concurrent access.
+type ExecutionResultContainer struct {
+	receipts    map[flow.Identifier]*flow.ExecutionReceiptMeta // map from ExecutionReceipt.ID -> ExecutionReceiptMeta
+	result      *flow.ExecutionResult
+	resultID    flow.Identifier // precomputed ID of result to avoid expensive hashing on each call
+	blockHeader *flow.Header    // header of the block which the result is for
+	pipeline    optimistic_sync.Pipeline
+}
+
+// NewExecutionResultContainer creates a new instance of ExecutionResultContainer.
+//
+// Parameters:
+//   - result: the execution result to store
+//   - header: the block header associated with the result
+//   - pipeline: the pipeline to process the result
+//
+// Returns:
+//   - *ExecutionResultContainer: the newly created container
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - ErrInvalidBlock: when the block ID doesn't match the result's block ID
+//   - All other errors are unexpected and potential indicators of corrupted internal state
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func NewExecutionResultContainer(result *flow.ExecutionResult, header *flow.Header, pipeline optimistic_sync.Pipeline) (*ExecutionResultContainer, error) {
+	// sanity check: initial result must be for block
+	if header.ID() != result.BlockID {
+		return nil, fmt.Errorf("initial result is for different block")
+	}
+
+	return &ExecutionResultContainer{
+		receipts:    make(map[flow.Identifier]*flow.ExecutionReceiptMeta),
+		result:      result,
+		resultID:    result.ID(),
+		blockHeader: header,
+		pipeline:    pipeline,
+	}, nil
+}
+
+// AddReceipt adds the given execution receipt to the container.
+//
+// Parameters:
+//   - receipt: the execution receipt to add
+//
+// Returns:
+//   - uint: number of receipts added (0 or 1)
+//   - error: any error that occurred during the operation
+//
+// Expected Errors:
+//   - ErrInvalidReceipt: when the receipt is for a different result
+//   - All other errors are unexpected and potential indicators of corrupted internal state
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func (c *ExecutionResultContainer) AddReceipt(receipt *flow.ExecutionReceipt) (uint, error) {
+	if receipt.ExecutionResult.ID() != c.resultID {
+		return 0, fmt.Errorf("cannot add receipt for different result")
+	}
+
+	receiptID := receipt.ID()
+	if c.Has(receiptID) {
+		return 0, nil
+	}
+	c.receipts[receiptID] = receipt.Meta()
+	return 1, nil
+}
+
+// AddReceipts adds multiple execution receipts to the container.
+//
+// Parameters:
+//   - receipts: variadic list of execution receipts to add
+//
+// Returns:
+//   - uint: total number of receipts added
+//   - error: any error that occurred during the operation
+//
+// Expected Errors:
+//   - ErrInvalidReceipt: when any receipt is for a different result
+//   - All other errors are unexpected and potential indicators of corrupted internal state
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func (c *ExecutionResultContainer) AddReceipts(receipts ...*flow.ExecutionReceipt) (uint, error) {
+	receiptsAdded := uint(0)
+	for i := 0; i < len(receipts); i++ {
+		added, err := c.AddReceipt(receipts[i])
+		if err != nil {
+			return receiptsAdded, fmt.Errorf("failed to add receipt (%x) to equivalence class: %w", receipts[i].ID(), err)
+		}
+		receiptsAdded += added
+	}
+	return receiptsAdded, nil
+}
+
+// Has checks if a receipt with the given ID exists in the container.
+//
+// Parameters:
+//   - receiptID: the ID of the receipt to check
+//
+// Returns:
+//   - bool: true if the receipt exists, false otherwise
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func (c *ExecutionResultContainer) Has(receiptID flow.Identifier) bool {
+	_, found := c.receipts[receiptID]
+	return found
+}
+
+// Size returns the number of receipts in the container.
+//
+// Returns:
+//   - uint: the number of receipts stored
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func (c *ExecutionResultContainer) Size() uint {
+	return uint(len(c.receipts))
+}
+
+// Pipeline returns the pipeline associated with this container.
+//
+// Returns:
+//   - *Pipeline: the associated pipeline, or nil if no pipeline is set
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func (c *ExecutionResultContainer) Pipeline() optimistic_sync.Pipeline {
+	return c.pipeline
+}
+
+/* Methods implementing LevelledForest's Vertex interface */
+
+// VertexID returns the ID of this vertex in the forest.
+//
+// Returns:
+//   - flow.Identifier: the result ID
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func (c *ExecutionResultContainer) VertexID() flow.Identifier { return c.resultID }
+
+// Level returns the view of the block associated with this result.
+//
+// Returns:
+//   - uint64: the block view
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func (c *ExecutionResultContainer) Level() uint64 { return c.blockHeader.View }
+
+// Parent returns the parent result ID and its block view.
+//
+// Returns:
+//   - flow.Identifier: the parent result ID
+//   - uint64: the parent block view
+//
+// Concurrency safety:
+//   - Not safe for concurrent access
+func (c *ExecutionResultContainer) Parent() (flow.Identifier, uint64) {
+	return c.result.PreviousResultID, c.blockHeader.ParentView
+}

--- a/engine/access/ingestion2/results_forest.go
+++ b/engine/access/ingestion2/results_forest.go
@@ -74,7 +74,7 @@ func NewResultsForest(
 //   - error: any error that occurred during the operation
 //
 // Expected Errors:
-//   - ErrInvalidBlock: when the block ID doesn't match the result's block ID
+//   - ErrMaxSizeExceeded: when adding a new container would exceed the maximum size
 //   - All other errors are unexpected and potential indicators of corrupted internal state
 //
 // Concurrency safety:
@@ -112,7 +112,7 @@ func (rf *ResultsForest) AddResult(result *flow.ExecutionResult, header *flow.He
 //   - error: any error that occurred during the operation
 //
 // Expected Errors:
-//   - ErrInvalidBlock: when the block ID doesn't match the receipt's block ID
+//   - ErrMaxSizeExceeded: when adding a new container would exceed the maximum size
 //   - All other errors are unexpected and potential indicators of corrupted internal state
 //
 // Concurrency safety:
@@ -156,7 +156,6 @@ func (rf *ResultsForest) AddReceipt(receipt *flow.ExecutionReceipt, header *flow
 //   - error: any error that occurred during the operation
 //
 // Expected Errors:
-//   - ErrInvalidBlock: when the block ID doesn't match the result's block ID
 //   - ErrMaxSizeExceeded: when adding a new container would exceed the maximum size
 //   - All other errors are unexpected and potential indicators of corrupted internal state
 //
@@ -221,9 +220,7 @@ func (rf *ResultsForest) HasReceipt(receipt *flow.ExecutionReceipt) bool {
 // Returns:
 //   - error: any error that occurred during the operation
 //
-// Expected Errors:
-//   - mempool.BelowPrunedThresholdError: when limit is lower than the current lowest view
-//   - All other errors are unexpected and potential indicators of corrupted internal state
+// No errors are expected during normal operation.
 //
 // Concurrency safety:
 //   - Not safe for concurrent access, caller must hold lock
@@ -324,9 +321,7 @@ func (rf *ResultsForest) iterateChildren(resultID flow.Identifier, fn func(*Exec
 // Returns:
 //   - error: any error that occurred during the operation
 //
-// Expected Errors:
-//   - ErrMissingAncestor: when a required ancestor result is not found in the forest
-//   - All other errors are unexpected and potential indicators of corrupted internal state
+// No errors are expected during normal operation.
 //
 // Concurrency safety:
 //   - Safe for concurrent access

--- a/engine/access/ingestion2/results_forest.go
+++ b/engine/access/ingestion2/results_forest.go
@@ -1,0 +1,514 @@
+package ingestion2
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/executiondatasync/optimistic_sync"
+	"github.com/onflow/flow-go/module/forest"
+	"github.com/onflow/flow-go/storage"
+	"github.com/rs/zerolog"
+)
+
+var (
+	// ErrMaxSizeExceeded is returned when adding a new container would exceed the maximum size
+	ErrMaxSizeExceeded = fmt.Errorf("adding new result would exceed maximum size")
+)
+
+// ResultsForest is a mempool holding execution results and receipts, which is aware of the tree structure
+// formed by the results. The mempool supports pruning by view: only results
+// descending from the latest sealed and finalized result are relevant. Hence, we
+// can prune all results for blocks _below_ the latest block with a finalized seal.
+// Results of sufficient view for forks that conflict with the finalized fork are
+// retained. However, such orphaned forks do not grow anymore and their results
+// will be progressively flushed out with increasing sealed-finalized view.
+//
+// Safe for concurrent access. Internally, the mempool utilizes the LevelledForrest.
+type ResultsForest struct {
+	log                         zerolog.Logger
+	forest                      forest.LevelledForest
+	maxSize                     uint64
+	lastSealedResultID          flow.Identifier
+	latestPersistedSealedResult storage.LatestPersistedSealedResult
+	mu                          sync.RWMutex
+}
+
+// NewResultsForest creates a new instance of ResultsForest.
+//
+// Parameters:
+//   - log: logger instance
+//   - maxSize: the maximum number of containers allowed in the forest
+//   - latestPersistedSealedResult: the latest persisted sealed result
+//
+// Returns:
+//   - *ResultsForest: the newly created forest
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func NewResultsForest(
+	log zerolog.Logger,
+	maxSize uint64,
+	latestPersistedSealedResult storage.LatestPersistedSealedResult,
+) *ResultsForest {
+	resultID, _ := latestPersistedSealedResult.Latest()
+	return &ResultsForest{
+		log:                         log.With().Str("component", "results_forest").Logger(),
+		forest:                      *forest.NewLevelledForest(0),
+		maxSize:                     maxSize,
+		lastSealedResultID:          resultID,
+		latestPersistedSealedResult: latestPersistedSealedResult,
+		mu:                          sync.RWMutex{},
+	}
+}
+
+// AddResult adds an execution result to the forest without any receipts.
+//
+// Parameters:
+//   - result: the execution result to add
+//   - header: the block header associated with the result
+//   - pipeline: the pipeline to process the result
+//
+// Returns:
+//   - error: any error that occurred during the operation
+//
+// Expected Errors:
+//   - ErrInvalidBlock: when the block ID doesn't match the result's block ID
+//   - All other errors are unexpected and potential indicators of corrupted internal state
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) AddResult(result *flow.ExecutionResult, header *flow.Header, pipeline optimistic_sync.Pipeline) error {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	// drop receipts for block views lower than the lowest view.
+	if header.View < rf.forest.LowestLevel {
+		return nil
+	}
+
+	// sanity check: result must be for block
+	if header.ID() != result.BlockID {
+		return fmt.Errorf("receipt is for different block")
+	}
+
+	_, err := rf.getOrCreateExecutionResultContainer(result, header, pipeline)
+	if err != nil {
+		return fmt.Errorf("failed to get container for result (%s): %w", result.ID(), err)
+	}
+	return nil
+}
+
+// AddReceipt adds the given execution receipt to the forest.
+//
+// Parameters:
+//   - receipt: the execution receipt to add
+//   - header: the block header associated with the receipt
+//   - pipeline: the pipeline to process the receipt
+//
+// Returns:
+//   - bool: true if the receipt was added, false if it already existed
+//   - error: any error that occurred during the operation
+//
+// Expected Errors:
+//   - ErrInvalidBlock: when the block ID doesn't match the receipt's block ID
+//   - All other errors are unexpected and potential indicators of corrupted internal state
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) AddReceipt(receipt *flow.ExecutionReceipt, header *flow.Header, pipeline optimistic_sync.Pipeline) (bool, error) {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	// drop receipts for block views lower than the lowest view.
+	if header.View < rf.forest.LowestLevel {
+		return false, nil
+	}
+
+	// sanity check: result must be for block
+	if header.ID() != receipt.ExecutionResult.BlockID {
+		return false, fmt.Errorf("receipt is for different block")
+	}
+
+	container, err := rf.getOrCreateExecutionResultContainer(&receipt.ExecutionResult, header, pipeline)
+	if err != nil {
+		return false, fmt.Errorf("failed to get container for result (%s): %w", receipt.ExecutionResult.ID(), err)
+	}
+
+	added, err := container.AddReceipt(receipt)
+	if err != nil {
+		return false, fmt.Errorf("failed to add receipt to its container: %w", err)
+	}
+
+	return added > 0, nil
+}
+
+// getOrCreateExecutionResultContainer retrieves or creates the container for the given result.
+//
+// Parameters:
+//   - result: the execution result
+//   - block: the block header associated with the result
+//   - pipeline: the pipeline to process the result
+//
+// Returns:
+//   - *ExecutionResultContainer: the container for the result
+//   - error: any error that occurred during the operation
+//
+// Expected Errors:
+//   - ErrInvalidBlock: when the block ID doesn't match the result's block ID
+//   - ErrMaxSizeExceeded: when adding a new container would exceed the maximum size
+//   - All other errors are unexpected and potential indicators of corrupted internal state
+//
+// Concurrency safety:
+//   - Not safe for concurrent access, caller must hold read lock
+func (rf *ResultsForest) getOrCreateExecutionResultContainer(result *flow.ExecutionResult, block *flow.Header, pipeline optimistic_sync.Pipeline) (*ExecutionResultContainer, error) {
+	// First try to get existing container
+	container, found := rf.getContainer(result.ID())
+	if found {
+		return container, nil
+	}
+
+	// Check if adding new container would exceed max size
+	if rf.forest.GetSize() >= rf.maxSize {
+		return nil, ErrMaxSizeExceeded
+	}
+
+	container, err := NewExecutionResultContainer(result, block, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("constructing container for receipt failed: %w", err)
+	}
+
+	// Verify and add to forest
+	err = rf.forest.VerifyVertex(container)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store receipt's container: %w", err)
+	}
+	rf.forest.AddVertex(container)
+
+	return container, nil
+}
+
+// HasReceipt checks if a receipt exists in the forest.
+//
+// Parameters:
+//   - receipt: the execution receipt to check
+//
+// Returns:
+//   - bool: true if the receipt exists, false otherwise
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) HasReceipt(receipt *flow.ExecutionReceipt) bool {
+	resultID := receipt.ExecutionResult.ID()
+	receiptID := receipt.ID()
+
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+
+	vertex, found := rf.forest.GetVertex(resultID)
+	if !found {
+		return false
+	}
+	return vertex.(*ExecutionResultContainer).Has(receiptID)
+}
+
+// pruneUpToView prunes all results for all blocks with view up to but not including the given limit.
+//
+// Parameters:
+//   - limit: the view up to which to prune (exclusive)
+//
+// Returns:
+//   - error: any error that occurred during the operation
+//
+// Expected Errors:
+//   - mempool.BelowPrunedThresholdError: when limit is lower than the current lowest view
+//   - All other errors are unexpected and potential indicators of corrupted internal state
+//
+// Concurrency safety:
+//   - Not safe for concurrent access, caller must hold lock
+func (rf *ResultsForest) pruneUpToView(level uint64) error {
+	err := rf.forest.PruneUpToLevel(level)
+	if err != nil {
+		return fmt.Errorf("pruning Levelled Forest up to view (aka level) %d failed: %w", level, err)
+	}
+
+	return nil
+}
+
+// Size returns the number of receipts stored in the forest.
+//
+// Returns:
+//   - uint: the number of receipts stored
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) Size() uint {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return uint(rf.forest.GetSize())
+}
+
+// LowestView returns the lowest view where results are still stored in the mempool.
+//
+// Returns:
+//   - uint64: the lowest view
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) LowestView() uint64 {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return rf.forest.LowestLevel
+}
+
+// GetContainer retrieves the ExecutionResultContainer for the given result ID.
+//
+// Parameters:
+//   - resultID: the ID of the result to retrieve
+//
+// Returns:
+//   - *ExecutionResultContainer: the container for the result, or nil if not found
+//   - bool: true if the container was found, false otherwise
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) GetContainer(resultID flow.Identifier) (*ExecutionResultContainer, bool) {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return rf.getContainer(resultID)
+}
+
+// getContainer retrieves the ExecutionResultContainer for the given result ID.
+//
+// Parameters:
+//   - resultID: the ID of the result to retrieve
+//
+// Returns:
+//   - *ExecutionResultContainer: the container for the result, or nil if not found
+//   - bool: true if the container was found, false otherwise
+//
+// Concurrency safety:
+//   - Not safe for concurrent access, caller must hold read lock
+func (rf *ResultsForest) getContainer(resultID flow.Identifier) (*ExecutionResultContainer, bool) {
+	container, ok := rf.forest.GetVertex(resultID)
+	if !ok {
+		return nil, false
+	}
+	return container.(*ExecutionResultContainer), true
+}
+
+// iterateChildren iterates over all children of the given result ID and calls the provided function on each child.
+//
+// Parameters:
+//   - resultID: the ID of the result whose children to iterate
+//   - fn: function to call on each child, return false to stop iteration
+//
+// Concurrency safety:
+//   - Not safe for concurrent access, caller must hold read lock
+func (rf *ResultsForest) iterateChildren(resultID flow.Identifier, fn func(*ExecutionResultContainer) bool) {
+	siblings := rf.forest.GetChildren(resultID)
+	for siblings.HasNext() {
+		sibling := siblings.NextVertex().(*ExecutionResultContainer)
+		if !fn(sibling) {
+			return
+		}
+	}
+}
+
+// OnResultSealed marks the execution result as sealed and updates the state of related pipelines.
+//
+// Parameters:
+//   - resultID: the ID of the result that was sealed
+//
+// Returns:
+//   - error: any error that occurred during the operation
+//
+// Expected Errors:
+//   - ErrMissingAncestor: when a required ancestor result is not found in the forest
+//   - All other errors are unexpected and potential indicators of corrupted internal state
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) OnResultSealed(resultID flow.Identifier) error {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	// Get the container for the newly sealed result
+	sealedResult, found := rf.getContainer(resultID)
+	if !found {
+		// the sealed result may not be loaded yet. we can ignore this notification for now and
+		// handle it during a future call.
+		return nil
+	}
+
+	unsealedContainers, err := rf.findUnsealedContainersInPath(sealedResult)
+	if err != nil {
+		return err
+	}
+
+	for _, container := range unsealedContainers {
+		rf.markResultSealed(container)
+	}
+
+	rf.lastSealedResultID = resultID
+
+	return nil
+}
+
+// findUnsealedContainersInPath finds all unsealed containers in the path from the current container
+// to the last sealed container (exclusive). The returned containers are sorted by block header view
+// in ascending order. Returns an error if any ancestor is not found in the forest.
+//
+// Parameters:
+//   - current: the current container
+//
+// Returns:
+//   - []*ExecutionResultContainer: list of unsealed containers sorted by view in ascending order
+//   - error: any error that occurred during the operation
+//
+// No errors are expected during normal operation. An error indicates the forest's internal state is
+// corrupted.
+//
+// Concurrency safety:
+//   - Not safe for concurrent access, caller must hold read lock
+func (rf *ResultsForest) findUnsealedContainersInPath(current *ExecutionResultContainer) ([]*ExecutionResultContainer, error) {
+	unsealedContainers := []*ExecutionResultContainer{current}
+
+	for {
+		parentID, _ := current.Parent()
+		if parentID == rf.lastSealedResultID {
+			break
+		}
+
+		parent, found := rf.getContainer(parentID)
+		if !found {
+			return nil, fmt.Errorf("ancestor result %s of %s not found in forest", parentID, current.resultID)
+		}
+
+		unsealedContainers = append(unsealedContainers, parent)
+		current = parent
+	}
+
+	// Sort containers by view in ascending order
+	sort.Slice(unsealedContainers, func(i, j int) bool {
+		return unsealedContainers[i].blockHeader.View < unsealedContainers[j].blockHeader.View
+	})
+
+	return unsealedContainers, nil
+}
+
+// markResultSealed marks a result as sealed and updates its siblings' pipelines to abandoned.
+//
+// Parameters:
+//   - container: the container to mark as sealed
+//
+// Concurrency safety:
+//   - Not safe for concurrent access, caller must hold read lock
+func (rf *ResultsForest) markResultSealed(container *ExecutionResultContainer) {
+	container.Pipeline().SetSealed()
+
+	// Mark siblings' pipelines as abandoned
+	parentID, _ := container.Parent()
+	rf.iterateChildren(parentID, func(sibling *ExecutionResultContainer) bool {
+		if sibling.resultID != container.resultID {
+			sibling.Pipeline().OnParentStateUpdated(optimistic_sync.StateAbandoned)
+		}
+		return true
+	})
+}
+
+// OnBlockFinalized signals that the given block is finalized.
+// It finds all vertices for results of blocks that conflict with the finalized block and abort them.
+//
+// Parameters:
+//   - finalizedBlockID: the ID of the block that was finalized
+//   - parentBlockResultIDs: list of IDs for results for the finalized block's parent
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) OnBlockFinalized(finalizedBlockID flow.Identifier, parentBlockResultIDs []flow.Identifier) {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	// 1. Get all ExecutionResults for the finalized block's parent (done by caller)
+	// 2. For each of these results, get all child vertices
+	// 3. For each child vertex, cancel if it does not reference the finalized block
+
+	for _, parentResultID := range parentBlockResultIDs {
+		rf.iterateChildren(parentResultID, func(child *ExecutionResultContainer) bool {
+			if child.blockHeader.ID() != finalizedBlockID {
+				child.Pipeline().OnParentStateUpdated(optimistic_sync.StateAbandoned)
+			}
+			return true
+		})
+	}
+}
+
+// OnStateUpdated is called by pipeline state machines when their state changes, and propagates the
+// state update to all children of the result.
+//
+// Parameters:
+//   - resultID: the ID of the result whose state was updated
+//   - newState: the new state of the pipeline
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) OnStateUpdated(resultID flow.Identifier, newState optimistic_sync.State) {
+	// send state update to all children.
+	rf.mu.RLock()
+	rf.iterateChildren(resultID, func(child *ExecutionResultContainer) bool {
+		child.Pipeline().OnParentStateUpdated(newState)
+		return true
+	})
+	rf.mu.RUnlock()
+
+	// process completed pipelines
+	if newState == optimistic_sync.StateComplete {
+		if err := rf.processCompleted(resultID); err != nil {
+			// TODO: handle with a irrecoverable error
+			rf.log.Fatal().Err(err).Msg("irrecoverable exception: failed to process completed pipeline")
+		}
+	}
+}
+
+// processCompleted processes a completed pipeline and prunes the forest.
+//
+// Parameters:
+//   - resultID: the ID of the result whose pipeline completed
+//
+// Returns:
+//   - error: any error that occurred during the operation
+//
+// No errors are expected during normal operation. An error indicates the forest's internal state is
+// corrupted.
+//
+// Concurrency safety:
+//   - Safe for concurrent access
+func (rf *ResultsForest) processCompleted(resultID flow.Identifier) error {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	// first, ensure that the result ID is in the forest, otherwise the forest is in an inconsistent state
+	container, found := rf.getContainer(resultID)
+	if !found {
+		return fmt.Errorf("result %s not found in forest", resultID)
+	}
+
+	// next, ensure that this result matches the latest persisted sealed result, otherwise
+	// the forest is in an inconsistent state since persisting must be done sequentially
+	latestResultID, _ := rf.latestPersistedSealedResult.Latest()
+	if container.resultID != latestResultID {
+		return fmt.Errorf("completed result %s does not match latest persisted sealed result %s",
+			container.resultID, latestResultID)
+	}
+
+	// finally, prune the forest up to the latest persisted result's block view
+	latestPersistedView := container.blockHeader.View
+	err := rf.pruneUpToView(latestPersistedView)
+	if err != nil {
+		return fmt.Errorf("failed to prune results forest (view: %d): %w", latestPersistedView, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is part of a multiple PRs implementing the ResultsForest which will be used by the new Access ingestion engine.

This PR implements the `ResultsForest` and `ExecutionResultContainer` which is stored in the forest.

Subsequent PRs will implement loading and managing the forest and executing the pipelines.