### PR TITLE
Refined / extended Cursor rules

### DIFF
--- a/.cursor/rules/coding_conventions.mdc
+++ b/.cursor/rules/coding_conventions.mdc
@@ -1,0 +1,313 @@
+---
+description: Coding Conventions
+globs: *.go
+alwaysApply: false
+---
+# Coding Conventions
+
+## High-Assurance Software Engineering Principles
+
+Flow is a high-assurance software project where the cost of bugs that slip through can be catastrophically high. We consider all inputs to be potentially byzantine. This fundamentally shapes our approach to error handling and code correctness:
+
+### Inversion of Default Safety Assumptions
+- Traditional software engineering often assumes code paths are safe unless proven dangerous
+- In Flow, we invert this: **no code path is considered safe unless explicitly proven and documented to be safe**
+- The mere absence of known failure cases is NOT sufficient evidence of safety
+- We require conclusive arguments for why each code path will always behave correctly
+
+### Context-Dependent Error Classification
+
+A critical rule in Flow's error handling is that **the same error type can be benign in one context but an exception in another**. Error classification depends on the caller's context, not the error's type.
+
+Key principles:
+- An error type alone CANNOT determine whether it's benign or an exception
+- The caller's context and expectations determine the error's severity
+- The same error type may be handled differently in different contexts
+- Documentation *must* specify which errors are benign in which contexts
+
+Example of context-dependent error handling, where `storage.ErrNotFound` is _benign_:
+```go
+// We're checking if we need to request a block from another node
+//
+// No Expected errors during normal operations.
+func (s *Synchronizer) checkBlockExists(blockID flow.Identifier) error {
+    _, err := s.storage.ByBlockID(blockID)
+    if errors.Is(err, storage.ErrNotFound) {
+        // Expected during normal operation - request block from peer.
+        return s.requestBlockFromPeer(blockID) // Expecting no errors from this call under normal operations
+    }
+    if err != nil {
+        // Other storage errors are unexpected
+        return fmt.Errorf("unexpected storage error: %w", err)
+    }
+    return nil
+}
+```
+
+However, in this context, the same `storage.ErrNotFound` is not expected during normal operations (we term unexpected errors as "exceptions"):
+```go
+// We're trying to read a block we know was finalized
+//
+// No Expected errors during normal operations.
+func (s *State) GetFinalizedBlock(height uint64) (*flow.Block, error) {
+    blockID, err := s.storage.FinalizedBlockID(height)
+    if err != nil {
+        return nil, fmt.Errorf("could not get finalized block ID: %w", err)
+    }
+    
+    // At this point, we KNOW the block should exist
+    block, err := s.storage.ByBlockID(blockID)
+    if err != nil {
+        // Any error here (including ErrNotFound) indicates a bug or corruption
+        return nil, irrecoverable.NewExceptionf(
+            "storage corrupted - failed to get finalized block %v: %w", 
+            blockID, err)
+    }
+    return block, nil
+}
+```
+
+### Rules for Error Classification
+
+1. **Documentation Requirements**
+   - Functions MUST document which error types are benign in their context
+   - Documentation MUST explain WHY an error is considered benign
+   - Absence of documentation means an error is treated as an exception
+
+2. **Error Propagation**
+   - When propagating errors, evaluate if they remain benign in the new context
+   - If a benign error from a lower layer indicates a critical failure in your context, wrap it as an exception
+   - Use `irrecoverable.NewExceptionf` when elevating a benign error to an exception
+
+3. **Testing Requirements**
+   - Tests MUST verify error handling in different contexts
+   - Test that benign errors in one context are properly elevated to exceptions in another
+   - Mock dependencies to test both benign and exceptional paths
+
+### Error Handling Philosophy
+- All errors are considered potentially fatal by default
+- Only explicitly documented benign errors are safe to recover from
+- For any undocumented error case, we must assume the execution state is corrupted
+- Recovery from undocumented errors requires node restart from last known safe state
+- This conservative approach prioritizes safety over continuous operation
+
+Example of proper high-assurance error handling:
+```go
+func (e *engine) process(event interface{}) error {
+    // Step 1: type checking of input
+    switch v := event.(type) {
+    case *ValidEvent:
+        // explicitly documented safe path
+        return e.handleValidEvent(v)
+    default:
+        // undocumented event type - unsafe to proceed
+        return fmt.Errorf("unexpected event type %T: %w", event, ErrInvalidEventType)
+    }
+}
+
+func (e *engine) Submit(event interface{}) {
+    err := e.process(event)
+    if errors.Is(err, ErrInvalidEventType) {
+        // This is a documented benign error - safe to handle
+        metrics.InvalidEventsCounter.Inc()
+        return
+    }
+    if err != nil {
+        // Any other error is potentially fatal
+        // We cannot prove it's safe to continue
+        e.log.Fatal().Err(err).Msg("potentially corrupted state - must restart")
+        return
+    }
+}
+```
+
+## 1. Code Documentation
+- Every interface must have clear documentation
+- Copy and extend interface documentation in implementations
+- Include clear explanations for any deviations from conventions
+- Document all public functions individually
+- Document error handling strategies and expected error types
+
+Example of proper error documentation:
+```go
+// foo does abc.
+// Expected errors during normal operations:
+//  * ErrXFailed: if x failed
+func foo() err {
+   ...
+   return fmt.Errorf("details about failure: %w", ErrXFailed)
+}
+```
+
+## 2. Code Structure
+- Follow the component-based architecture
+- Each component must implement the `Component` interface
+- Clearly differentiate between trusted (internal) and untrusted (external) inputs
+- Components should have dedicated worker pools
+- Proper resource management with worker limits
+- Proper state management and recovery
+
+## 3. Error Categories and Handling Philosophy
+
+### a. Benign Errors
+- Component remains fully functional despite the error
+- Expected during normal operations
+- Must be handled within the component
+- Must be documented in the component's context
+- Must be represented as typed sentinel errors
+- Cannot be represented by generic/untyped errors unless explicitly documented as an optional simplification for components that solely return benign errors
+
+Example of proper benign error handling:
+```go
+// Expected errors during normal operations:
+//  * ErrXFailed: if x failed
+func benignErrorExample() error {
+    err := foo()
+    if err != nil {
+        return fmt.Errorf("failed to do foo: %w", err)
+    }
+    return nil
+}
+```
+
+### b. Exceptions
+- Potential symptoms of internal state corruption
+- Unexpected failures that may compromise component state
+- Should lead to component restart or node termination
+- Strongly encouraged to wrap with context when bubbling up
+
+Example of proper exception handling:
+```go
+err := foo()
+if errors.Is(err, XFailedErr) {
+   // expected error
+   return
+}
+if err != nil {
+   log.Fatal().Err(err).Msg("unexpected internal error")
+   return
+}
+```
+
+### c. Sentinel Error Requirements
+- Must be properly typed
+- Must be documented in GoDoc
+- Must avoid generic error formats
+- Must always wrap with context when bubbling up the call stack
+- Must document all expected error types
+- Must handle at the appropriate level where context is available
+- Must use proper error wrapping for stack traces
+
+Example of proper sentinel error definition and usage:
+```go
+ErrXFailed := errors.New("x failed")
+
+// bar does ...
+// Expected error returns during normal operations:
+//  * XFailedErr: if x failed
+func bar() err {
+   ...
+   err := foo()
+   if err != nil {
+      return fmt.Errorf("failed to do foo: %w", err)
+   }
+   ...
+}
+```
+
+## 4. Additional Best Practices
+- Prioritize safety over liveness
+- Don't continue on "best-effort" basis when encountering unexpected errors
+- Testing Error Handling:
+  - Test both benign error cases and exceptions
+  - Must verify that documented sentinel errors are returned in their specified situations
+  - Must verify that unexpected errors (exceptions) from lower layers or their mocks are not misinterpreted as benign errors
+  - Verify proper error propagation
+  - Test component recovery from errors
+  - Validate error handling in both trusted and untrusted contexts
+
+Example of proper error handling in components:
+```go
+func (e *engine) process(event interface{}) error {
+    switch v := event.(type) {
+       ...
+       default:
+          return fmt.Errorf("invalid input type %T: %w", event, InvalidMessageType)
+    }
+}
+
+func (e *engine) Process(chan network.Channel, originID flow.Identifier, event interface{}) error {
+    err := e.process(event)
+    if err != nil {
+        if errors.Is(err, InvalidMessageType) {
+            // this is EXPECTED during normal operations
+        }
+    }
+}
+
+func (e *engine) ProcessLocal(event interface{}) {
+    err := e.process(event)
+    if err != nil {
+        if errors.Is(err, InvalidMessageType) {
+            // this is a CRITICAL BUG
+        }
+    }
+}
+```
+
+## 5. Anti-patterns to Avoid
+- Don't use generic error logging without proper handling
+- Don't swallow errors silently
+- Don't continue execution after unexpected errors
+- Don't use untyped errors unless explicitly documented as benign
+
+Example of an anti-pattern to avoid:
+```go
+// DON'T DO THIS:
+err := foo()
+if err != nil {
+   log.Error().Err(err).Msg("foo failed")
+   return
+}
+```
+
+Instead, implement proper error handling:
+```go
+func (e *engine) Submit(chan network.Channel, originID flow.Identifier, event interface{}) {
+    e.unit.Launch(func() {
+        err := e.process(event)
+        if errors.Is(err, InvalidMessageType) {
+            // invalid input: ignore or slash
+            return
+        }
+        if err != nil {
+            // unexpected input: for now we prioritize safety over liveness and just crash
+            // TODO: restart engine from known good state
+            e.log.Fatal().Err(err).Msg("unexpected internal error")
+        }
+    })
+}
+```
+
+## 6. Security Considerations
+- Treat all external inputs as potentially byzantine
+- Handle byzantine inputs gracefully
+- Prevent state corruption from malicious inputs
+- Use proper error types for security-related issues 
+
+Example of handling untrusted inputs:
+```go
+func (e *engine) Submit(event interface{}) {
+    e.unit.Launch(func() {
+        err := e.process(event)
+        if errors.Is(err, InvalidMessageType) {
+            // invalid input from external source: ignore or slash
+            return
+        }
+        if err != nil {
+            // unexpected input: prioritize safety over liveness
+            e.log.Fatal().Err(err).Msg("unexpected internal error")
+        }
+    })
+}
+```

--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -1,0 +1,46 @@
+---
+description: Cursor Operational Doctrine
+globs: 
+alwaysApply: true
+---
+# Cursor Operational Doctrine
+
+You are an AI with extensive expertise in byzantine-fault-tolerant, distributed software engineering. You are Consider scalability, reliability, maintainability, and security in your recommendations.
+
+You are working in a pair-programming setting with a senior engineer. Their time is valuable, so work time-efficiently. They prefer an iterative working style, where you take one step at a time, confirm the direction is correct and then proceed. 
+Critically reflect on your work. Ask if you are not sure. Avoid confirmation bias - speak up (short and concisely reasoning, followed by tangible suggestions) if something should be changed or approached differently in your oppionion. 
+
+## Primary directive
+
+Your peers instructions, questions, requests **always** take precident over any general rules (such as the ones below).
+
+## Interactions with your peer
+- Never use apologies. 
+- Acknowledge if you missunderstood something, and concisely summarize what you have learned. 
+- Only when explicitly requested, provide feedback about your understanding of comments, documentation, code
+- Don't show or discuss the current implementation unless specifically requested.
+- State which files have been modifed and very briefly in which regard. But don't provide excerpts of changes made.
+- Don't ask for confirmation of information already provided in the context.
+- Don't ask your peer to verify implementations that are visible in the provided context.
+- Always provide links to the real files, not just the names x.md.
+
+## Verify Information
+- Always verify information before presenting it. Do not make assumptions or speculate without clear evidence.
+- For all changes you made, review your changes in the broader context of the component you are modifying. 
+  - internally, construct a correctness argument as evidence that the updated component will _always_ behave correctly
+  - memorize your correctness argument, but do not immediately include it in your response unless specifically requested by your peer
+
+## Software Design Approach
+- Leverage existing abstractions; refactor them judiciously.
+- Augment with tests, logging, and API exposition once the core business logic is robust.
+- Ensure new packages are modular, orthogonal, and future-proof.
+
+## No Inventions
+Don't invent changes other than what's explicitly requested.
+
+## No Unnecessary Updates
+- Don't remove unrelated code or functionalities. Pay attention to preserving existing structures.
+- Don't suggest updates or changes to files when there are no actual modifications needed.
+- Don't suggest whitespace changes.
+
+

--- a/.cursor/rules/godocs.mdc
+++ b/.cursor/rules/godocs.mdc
@@ -17,23 +17,18 @@ alwaysApply: false
 ## Method Rules
 ```go
 // MethodName performs a specific action or returns specific information.
-// 
-// Parameters:
-//   - param1: description of param1
-//   - param2: description of param2
 //
-// Returns:
-//   - return1: description of return1
-//   - return2: description of return2
+// Returns: (only if additional interpretation of return values is needed beyond the method / function signature)
+//   - return1: description of non-obvious aspects
+//   - return2: description of non-obvious aspects
 //
-// Expected Errors:
+// Expected errors during normal operations:
 //   - ErrType1: when and why this error occurs
 //   - ErrType2: when and why this error occurs
-//   - All other errors are unexpected and potential indicators of bugs or corrupted internal state
+//   - All other errors are potential indicators of bugs or corrupted internal state (continuation impossible)
 //
-// Concurrency safety:
-//   - Safe for concurrent access
-//   - Not safe for concurrent access
+// Safe for concurrent access (default, may be omitted)
+// CAUTION: not concurrency safe! (if applicable, documentation is obligatory)
 ```
 
 1. **Method Description**
@@ -41,41 +36,59 @@ alwaysApply: false
    - Use present tense
    - Start with the method name
    - End with a period
-   - Example: `// AddReceipt adds the given execution receipt to the container.`
+   - Prefer a concise description that naturally incorporates the meaning of parameters
+   - Example:
+     ```go
+     // ByBlockID returns the header with the given ID. It is available for finalized and ambiguous blocks.
+     // Error returns:
+     //  - ErrNotFound if no block header with the given ID exists
+     ByBlockID(blockID flow.Identifier) (*flow.Header, error)
+     ```
 
 2. **Parameters**
-   - List all parameters with their types
-   - Describe the purpose and any constraints
-   - Use bullet points for clarity
-   - Example:
-     ```go
-     // Parameters:
-     //   - receipt: the execution receipt to add
-     //   - block: the block header associated with the receipt
-     ```
+   - Only document parameters separately when they have non-obvious aspects:
+     - Complex constraints or requirements
+     - Special relationships with other parameters
+     - Formatting or validation rules
+     - Example:
+       ```go
+       // ValidateTransaction validates the transaction against the current state.
+       //
+       // Parameters:
+       //   - script: must be valid BPL-encoded script with max size of 64KB
+       //   - accounts: must contain at least one account with signing capability
+       ```
 
 3. **Returns**
-   - List all return values
-   - Describe the meaning of each return value
-   - Use bullet points for clarity
-   - Example:
+   - Only document return values if there is **additional information** necessary to interpret the function's or method's return values, which is not apparent from the method signature's return values
+   - When documenting non-error returns, be concise and focus only on non-obvious aspects:
      ```go
+     // Example 1 - No return docs needed (self-explanatory):
+     // GetHeight returns the block's height.
+     
+     // Example 2 - Additional context needed:
+     // GetPipeline returns the execution pipeline, or nil if not configured.
+     
+     // Example 3 - Complex return value needs explanation:
+     // GetBlockStatus returns the block's current status.
      // Returns:
-     //   - bool: true if the receipt was added, false if it already existed
-     //   - error: any error that occurred during the operation
+     //   - status: PENDING if still processing, FINALIZED if complete, INVALID if failed validation
      ```
+   - Error returns documentation is mandatory (see section `Error Returns` below)
+
 
 4. **Error Returns**
    - List all expected errors (sentinel errors)
    - **DO NOT make up sentinel errors**. Only document errors that are returned by the method. If you don't know, add a TODO for the user to complete.
    - Describe when and why each error occurs
+   - by convention, they should be the last part of a method's or function's documentation.    
    - Always include a catch-all for unexpected errors
    - Example:
      ```go
-     // Expected Errors:
+     // Expected errors during normal operations:
      //   - ErrInvalidReceipt: when the receipt is malformed
      //   - ErrDuplicateReceipt: when the receipt already exists
-     //   - All other errors are unexpected and potential indicators of bugs or corrupted internal state
+     //   - All other errors are potential indicators of bugs or corrupted internal state (continuation impossible)
      ```
    - If there are no expected errors, use:
      ```go
@@ -83,16 +96,19 @@ alwaysApply: false
      ```
 
 5. **Concurrency Safety**
-   - Explicitly state whether the method is safe for concurrent access
+   - By default, we assume methods and functions to be concurrency safe. 
+   - Every struct and interface must explicitly state whether it is safe for concurrent access
    - If not thread-safe, explain why
-   - If all methods are thread-safe, only document this in the struct godocs and mention that all methods are thread-safe. Do not include the line in each 
-   - Example:
+   - For methods or functions that are not concurrency safe (deviating from the default), it is **mandatory** to diligently document this by indlucing the following call-out:
      ```go
-     // Concurrency safety:
-     //   - Safe for concurrent access
+     // CAUTION: not concurrency safe! 
+     ```
+   - If **all methods** of a struct or interface are thread-safe, only document this in the struct's or interface's godoc and mention that all methods are thread-safe. Do not include the line in each method:
+     ```go
+     // Safe for concurrent access
      ```
 
-8. **Special Cases**
+6. **Special Cases**
    - For getters/setters, use simplified format:
      ```go
      // GetterName returns the value of the field.
@@ -109,7 +125,7 @@ alwaysApply: false
      //   - error: any error that occurred during creation
      ```
 
-10. **Private Methods**
+7. **Private Methods**
     - Private methods should still be documented
     - Can use more technical language
     - Focus on implementation details
@@ -119,52 +135,28 @@ alwaysApply: false
 
 ### Standard Method
 ```go
-// AddReceipt adds the given execution receipt to the container.
+// AddReceipt adds the given execution receipt to the container and associates it with the block.
+// Returns true if the receipt was added, false if it already existed. Safe for concurrent access.
 //
-// Parameters:
-//   - receipt: the execution receipt to add
-//   - block: the block header associated with the receipt
-//
-// Returns:
-//   - bool: true if the receipt was added, false if it already existed
-//   - error: any error that occurred during the operation
-//
-// Error returns:
+// Expected errors during normal operations:
 //   - ErrInvalidReceipt: when the receipt is malformed
 //   - ErrDuplicateReceipt: when the receipt already exists
-//   - All other errors are unexpected and potential indicators of corrupted internal state
-//
-// Concurrency safety:
-//   - Safe for concurrent access
+//   - All other errors are potential indicators of bugs or corrupted internal state (continuation impossible)
 ```
 
 ### Getter Method
 ```go
 // Pipeline returns the pipeline associated with this execution result container.
-//
-// Returns:
-//   - *Pipeline: the associated pipeline, or nil if no pipeline is set
-//
-// Concurrency safety:
-//   - Safe for concurrent access
+// Returns nil if no pipeline is set. Safe for concurrent access
 ```
 
 ### Constructor
 ```go
-// NewExecutionResultContainer creates a new instance of ExecutionResultContainer.
-//
-// Parameters:
-//   - result: the execution result to store
-//   - block: the block header associated with the result
-//   - pipeline: the pipeline to process the result
-//
-// Returns:
-//   - *ExecutionResultContainer: the newly created container
-//   - error: any error that occurred during creation
+// NewExecutionResultContainer creates a new instance of ExecutionResultContainer with the given result and pipeline.
 //
 // Expected Errors:
 //   - ErrInvalidBlock: when the block ID doesn't match the result's block ID
-//   - All other errors are unexpected and potential indicators of corrupted internal state
+//   - All other errors are potential indicators of bugs or corrupted internal state (continuation impossible)
 ```
 
 ## Interface Documentation
@@ -172,10 +164,11 @@ alwaysApply: false
    - Start with the interface name
    - Describe the purpose and behavior of the interface
    - Explain any invariants or guarantees the interface provides
+   - Explicitly state whether it is safe for concurrent access
    - Example:
      ```go
      // Executor defines the interface for executing transactions.
-     // Implementations must guarantee thread-safety and handle all error cases.
+     // Implementations must guarantee thread-safety and handle byzantine inputs gracefully.
      type Executor interface {
          // ... methods ...
      }
@@ -185,17 +178,12 @@ alwaysApply: false
    - Document each method in the interface
    - Focus on the contract/behavior rather than implementation details
    - Include error documentation for methods that return errors
+   - Ensure that the interface documentation is consistent with the structs' documentations implementing this interface
+      - Every sentinel error that can be returned by any of the implementations must also be documented by the interface. 
    - Example:
      ```go
-     // Execute processes the given transaction and returns the result.
-     // The method must be idempotent and handle all error cases gracefully.
-     //
-     // Parameters:
-     //   - tx: the transaction to execute
-     //
-     // Returns:
-     //   - *Result: the execution result
-     //   - error: any error that occurred during execution
+     // Execute processes the given transaction and returns its execution result.
+     // The method must be idempotent and handle byzantine inputs gracefully.
      //
      // Expected Errors:
      //   - ErrInvalidTransaction: when the transaction is malformed


### PR DESCRIPTION
* updated cursor rules `godocs.mdc`:
   * tailored rules to produce more concise documentation
* added core rules `core.mdc`:
  - priming AI for area of work (BFT, high-assurance system)
  - streamlining user interaction 
  - high-level Software Design Approach approach
* translated `CodingConventions.md` into Cursor rule (resulting `coding_conventions.mdc` has some overlap with `godocs.mdc`)

I am not quite sure how helpful my revisions of `godocs.mdc` are:
* it produces less boiler-plate words now making the produced goDoc less bloated (good)
* the new rules are less prescriptive and require more understanding on the LLM's side to decide which pattern to follow. 