### PR TITLE
[Malleability Immutable] Add ExecutionResult validation to UnsignedExecutionReceipt constructor

### DIFF
--- a/admin/commands/storage/read_results_test.go
+++ b/admin/commands/storage/read_results_test.go
@@ -50,7 +50,7 @@ func (suite *ReadResultsSuite) SetupTest() {
 	var results []*flow.ExecutionResult
 
 	genesis := unittest.GenesisFixture()
-	genesisResult := unittest.ExecutionResultFixture(unittest.WithBlock(genesis))
+	genesisResult := unittest.ExecutionResultFixture(unittest.WithBlock(genesis), unittest.WithPreviousResultID(flow.ZeroID))
 	blocks = append(blocks, genesis)
 	results = append(results, genesisResult)
 

--- a/model/flow/execution_receipt.go
+++ b/model/flow/execution_receipt.go
@@ -92,17 +92,16 @@ func NewUnsignedExecutionReceipt(untrusted UntrustedUnsignedExecutionReceipt) (*
 	if untrusted.ExecutorID == ZeroID {
 		return nil, fmt.Errorf("executor ID must not be zero")
 	}
-	//TODO: uncomment this code then constructor for ExecutionResult will be added (when PR #7525 will be merged)
-	//executionResult, err := NewExecutionResult(UntrustedExecutionResult(untrusted.ExecutionResult))
-	//if err != nil {
-	//	return nil, fmt.Errorf("invalid execution result: %w", err)
-	//}
+	executionResult, err := NewExecutionResult(UntrustedExecutionResult(untrusted.ExecutionResult))
+	if err != nil {
+		return nil, fmt.Errorf("invalid execution result: %w", err)
+	}
 	if len(untrusted.Spocks) == 0 {
 		return nil, fmt.Errorf("spocks must not be empty")
 	}
 	return &UnsignedExecutionReceipt{
 		ExecutorID:      untrusted.ExecutorID,
-		ExecutionResult: untrusted.ExecutionResult,
+		ExecutionResult: *executionResult,
 		Spocks:          untrusted.Spocks,
 	}, nil
 }

--- a/model/flow/execution_receipt_test.go
+++ b/model/flow/execution_receipt_test.go
@@ -186,16 +186,15 @@ func TestNewUnsignedExecutionReceipt(t *testing.T) {
 		assert.Contains(t, err.Error(), "executor ID must not be zero")
 	})
 
-	// TODO: add a test case for the case where the execution result is invalid, after PR #7525 will be merged
-	//t.Run("invalid input with invalid execution result", func(t *testing.T) {
-	//	receipt := unittest.UnsignedExecutionReceiptFixture()
-	//	receipt.ExecutionResult.BlockID = flow.ZeroID
-	//
-	//	res, err := flow.NewUnsignedExecutionReceipt(flow.UntrustedUnsignedExecutionReceipt(*receipt))
-	//	require.Error(t, err)
-	//	require.Nil(t, res)
-	//	assert.Contains(t, err.Error(), "invalid execution result: BlockID must not be empty")
-	//})
+	t.Run("invalid input with invalid execution result", func(t *testing.T) {
+		receipt := unittest.UnsignedExecutionReceiptFixture()
+		receipt.ExecutionResult.BlockID = flow.ZeroID
+
+		res, err := flow.NewUnsignedExecutionReceipt(flow.UntrustedUnsignedExecutionReceipt(*receipt))
+		require.Error(t, err)
+		require.Nil(t, res)
+		assert.Contains(t, err.Error(), "invalid execution result: BlockID must not be empty")
+	})
 
 	t.Run("invalid input with nil Spocks", func(t *testing.T) {
 		receipt := unittest.UnsignedExecutionReceiptFixture()

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -876,9 +876,14 @@ func WithPreviousResult(prevResult flow.ExecutionResult) func(*flow.ExecutionRes
 	}
 }
 
+func WithPreviousResultID(previousResultID flow.Identifier) func(*flow.ExecutionResult) {
+	return func(result *flow.ExecutionResult) {
+		result.PreviousResultID = previousResultID
+	}
+}
+
 func WithBlock(block *flow.Block) func(*flow.ExecutionResult) {
 	chunks := 1 // tailing chunk is always system chunk
-	var previousResultID flow.Identifier
 	chunks += len(block.Payload.Guarantees)
 	blockID := block.ID()
 
@@ -886,7 +891,7 @@ func WithBlock(block *flow.Block) func(*flow.ExecutionResult) {
 		startState := result.Chunks[0].StartState // retain previous start state in case it was user-defined
 		result.BlockID = blockID
 		result.Chunks = ChunkListFixture(uint(chunks), blockID, startState)
-		result.PreviousResultID = previousResultID
+		result.PreviousResultID = IdentifierFixture()
 	}
 }
 
@@ -1585,8 +1590,9 @@ func VerifiableChunkDataFixture(chunkIndex uint64, opts ...func(*flow.HeaderBody
 	}
 
 	result := flow.ExecutionResult{
-		BlockID: block.ID(),
-		Chunks:  chunks,
+		PreviousResultID: IdentifierFixture(),
+		BlockID:          block.ID(),
+		Chunks:           chunks,
 	}
 
 	// computes chunk end state


### PR DESCRIPTION
Closes: #7543

## Changes
- Updated the `NewUnsignedExecutionReceipt` constructor to validate the embedded `ExecutionResult` field using the new `NewExecutionResult` constructor. 
- Replaced the existing TODO with an actual constructor call and error handling. 
- Added unit test to verify that invalid `ExecutionResult` values are correctly rejected.
- Updated creation of `ExecutionResult` in fixture