### PR TITLE
Add untrusted message constructors

### DIFF
--- a/engine/collection/compliance/core_test.go
+++ b/engine/collection/compliance/core_test.go
@@ -201,7 +201,7 @@ func (cs *CoreSuite) TestOnBlockProposalValidParent() {
 	originID := unittest.IdentifierFixture()
 	block := unittest.ClusterBlockWithParent(cs.head)
 
-	proposal := messages.NewClusterBlockProposal(&block)
+	proposal := messages.NewClusterBlockProposalFromInternal(&block)
 
 	// store the data for retrieval
 	cs.headerDB[block.Header.ParentID] = cs.head
@@ -226,7 +226,7 @@ func (cs *CoreSuite) TestOnBlockProposalValidAncestor() {
 	ancestor := unittest.ClusterBlockWithParent(cs.head)
 	parent := unittest.ClusterBlockWithParent(&ancestor)
 	block := unittest.ClusterBlockWithParent(&parent)
-	proposal := messages.NewClusterBlockProposal(&block)
+	proposal := messages.NewClusterBlockProposalFromInternal(&block)
 
 	// store the data for retrieval
 	cs.headerDB[parent.ID()] = &parent
@@ -279,7 +279,7 @@ func (cs *CoreSuite) TestOnBlockProposal_FailsHotStuffValidation() {
 	ancestor := unittest.ClusterBlockWithParent(cs.head)
 	parent := unittest.ClusterBlockWithParent(&ancestor)
 	block := unittest.ClusterBlockWithParent(&parent)
-	proposal := messages.NewClusterBlockProposal(&block)
+	proposal := messages.NewClusterBlockProposalFromInternal(&block)
 	hotstuffProposal := model.SignedProposalFromFlow(block.Header)
 
 	// store the data for retrieval
@@ -362,7 +362,7 @@ func (cs *CoreSuite) TestOnBlockProposal_FailsProtocolStateValidation() {
 	ancestor := unittest.ClusterBlockWithParent(cs.head)
 	parent := unittest.ClusterBlockWithParent(&ancestor)
 	block := unittest.ClusterBlockWithParent(&parent)
-	proposal := messages.NewClusterBlockProposal(&block)
+	proposal := messages.NewClusterBlockProposalFromInternal(&block)
 	hotstuffProposal := model.SignedProposalFromFlow(block.Header)
 
 	// store the data for retrieval
@@ -528,7 +528,7 @@ func (cs *CoreSuite) TestProposalBufferingOrder() {
 			},
 		)
 
-		proposal := messages.NewClusterBlockProposal(block)
+		proposal := messages.NewClusterBlockProposalFromInternal(block)
 
 		// process and make sure no error occurs (as they are unverifiable)
 		err := cs.core.OnBlockProposal(flow.Slashable[*messages.ClusterBlockProposal]{
@@ -561,7 +561,7 @@ func (cs *CoreSuite) TestProposalBufferingOrder() {
 	cs.voteAggregator.On("AddBlock", mock.Anything).Times(4)
 	cs.validator.On("ValidateProposal", mock.Anything).Times(4).Return(nil)
 
-	missingProposal := messages.NewClusterBlockProposal(missing)
+	missingProposal := messages.NewClusterBlockProposalFromInternal(missing)
 
 	proposalsLookup[missing.ID()] = missing
 

--- a/engine/collection/compliance/engine_test.go
+++ b/engine/collection/compliance/engine_test.go
@@ -164,7 +164,7 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 	go func() {
 		for i := 0; i < blockCount; i++ {
 			block := unittest.ClusterBlockWithParent(cs.head)
-			proposal := messages.NewClusterBlockProposal(&block)
+			proposal := messages.NewClusterBlockProposalFromInternal(&block)
 			hotstuffProposal := model.SignedProposalFromFlow(block.Header)
 			cs.hotstuff.On("SubmitProposal", hotstuffProposal).Return().Once()
 			cs.voteAggregator.On("AddBlock", hotstuffProposal).Once()
@@ -181,7 +181,7 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 	go func() {
 		// create a proposal that directly descends from the latest finalized header
 		block := unittest.ClusterBlockWithParent(cs.head)
-		proposal := messages.NewClusterBlockProposal(&block)
+		proposal := messages.NewClusterBlockProposalFromInternal(&block)
 
 		hotstuffProposal := model.SignedProposalFromFlow(block.Header)
 		cs.hotstuff.On("SubmitProposal", hotstuffProposal).Once()

--- a/engine/collection/message_hub/message_hub.go
+++ b/engine/collection/message_hub/message_hub.go
@@ -332,7 +332,7 @@ func (h *MessageHub) sendOwnProposal(header *flow.Header) error {
 	}
 
 	// create the proposal message for the collection
-	proposal := messages.NewClusterBlockProposal(&cluster.Block{
+	proposal := messages.NewClusterBlockProposalFromInternal(&cluster.Block{
 		Header:  header,
 		Payload: payload,
 	})

--- a/engine/collection/message_hub/message_hub_test.go
+++ b/engine/collection/message_hub/message_hub_test.go
@@ -188,7 +188,7 @@ func (s *MessageHubSuite) TestProcessIncomingMessages() {
 	s.Run("to-compliance-engine", func() {
 		block := unittest.ClusterBlockFixture()
 
-		blockProposalMsg := messages.NewClusterBlockProposal(&block)
+		blockProposalMsg := messages.NewClusterBlockProposalFromInternal(&block)
 		expectedComplianceMsg := flow.Slashable[*messages.ClusterBlockProposal]{
 			OriginID: originID,
 			Message:  blockProposalMsg,
@@ -270,7 +270,7 @@ func (s *MessageHubSuite) TestOnOwnProposal() {
 	})
 
 	s.Run("should broadcast proposal and pass to HotStuff for valid proposals", func() {
-		expectedBroadcastMsg := messages.NewClusterBlockProposal(&block)
+		expectedBroadcastMsg := messages.NewClusterBlockProposalFromInternal(&block)
 
 		submitted := make(chan struct{}) // closed when proposal is submitted to hotstuff
 		hotstuffProposal := model.SignedProposalFromFlow(block.Header)
@@ -337,7 +337,7 @@ func (s *MessageHubSuite) TestProcessMultipleMessagesHappyPath() {
 		hotstuffProposal := model.SignedProposalFromFlow(proposal.Header)
 		s.voteAggregator.On("AddBlock", hotstuffProposal)
 		s.hotstuff.On("SubmitProposal", hotstuffProposal)
-		expectedBroadcastMsg := messages.NewClusterBlockProposal(&proposal)
+		expectedBroadcastMsg := messages.NewClusterBlockProposalFromInternal(&proposal)
 		s.con.On("Publish", expectedBroadcastMsg, s.cluster[1].NodeID, s.cluster[2].NodeID).
 			Run(func(_ mock.Arguments) { wg.Done() }).
 			Return(nil)

--- a/engine/collection/synchronization/engine_test.go
+++ b/engine/collection/synchronization/engine_test.go
@@ -427,18 +427,18 @@ func (ss *SyncSuite) TestOnBlockResponse() {
 	originID := unittest.IdentifierFixture()
 	res := &messages.ClusterBlockResponse{
 		Nonce:  rand.Uint64(),
-		Blocks: []messages.UntrustedClusterBlock{},
+		Blocks: []*clustermodel.Block{},
 	}
 
 	// add one block that should be processed
 	processable := unittest.ClusterBlockFixture()
 	ss.core.On("HandleBlock", processable.Header).Return(true)
-	res.Blocks = append(res.Blocks, messages.UntrustedClusterBlockFromInternal(&processable))
+	res.Blocks = append(res.Blocks, &processable)
 
 	// add one block that should not be processed
 	unprocessable := unittest.ClusterBlockFixture()
 	ss.core.On("HandleBlock", unprocessable.Header).Return(false)
-	res.Blocks = append(res.Blocks, messages.UntrustedClusterBlockFromInternal(&unprocessable))
+	res.Blocks = append(res.Blocks, &unprocessable)
 
 	ss.comp.On("OnSyncedClusterBlock", mock.Anything).Run(func(args mock.Arguments) {
 		res := args.Get(0).(flow.Slashable[*messages.ClusterBlockProposal])

--- a/engine/collection/synchronization/request_handler.go
+++ b/engine/collection/synchronization/request_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onflow/flow-go/engine"
 	commonsync "github.com/onflow/flow-go/engine/common/synchronization"
+	clustermodel "github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
@@ -234,7 +235,7 @@ func (r *RequestHandlerEngine) onRangeRequest(originID flow.Identifier, req *mes
 	}
 
 	// get all of the blocks, one by one
-	blocks := make([]messages.UntrustedClusterBlock, 0, req.ToHeight-req.FromHeight+1)
+	blocks := make([]*clustermodel.Block, 0, req.ToHeight-req.FromHeight+1)
 	for height := req.FromHeight; height <= req.ToHeight; height++ {
 		block, err := r.blocks.ByHeight(height)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -244,7 +245,7 @@ func (r *RequestHandlerEngine) onRangeRequest(originID flow.Identifier, req *mes
 		if err != nil {
 			return fmt.Errorf("could not get block for height (%d): %w", height, err)
 		}
-		blocks = append(blocks, messages.UntrustedClusterBlockFromInternal(block))
+		blocks = append(blocks, block)
 	}
 
 	// if there are no blocks to send, skip network message
@@ -303,7 +304,7 @@ func (r *RequestHandlerEngine) onBatchRequest(originID flow.Identifier, req *mes
 	}
 
 	// try to get all the blocks by ID
-	blocks := make([]messages.UntrustedClusterBlock, 0, len(blockIDs))
+	blocks := make([]*clustermodel.Block, 0, len(blockIDs))
 	for blockID := range blockIDs {
 		block, err := r.blocks.ByID(blockID)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -313,7 +314,7 @@ func (r *RequestHandlerEngine) onBatchRequest(originID flow.Identifier, req *mes
 		if err != nil {
 			return fmt.Errorf("could not get block by ID (%s): %w", blockID, err)
 		}
-		blocks = append(blocks, messages.UntrustedClusterBlockFromInternal(block))
+		blocks = append(blocks, block)
 	}
 
 	// if there are no blocks to send, skip network message

--- a/engine/common/synchronization/engine_test.go
+++ b/engine/common/synchronization/engine_test.go
@@ -339,18 +339,18 @@ func (ss *SyncSuite) TestOnBlockResponse() {
 	originID := unittest.IdentifierFixture()
 	res := &messages.BlockResponse{
 		Nonce:  nonce,
-		Blocks: []messages.UntrustedBlock{},
+		Blocks: []*flow.Block{},
 	}
 
 	// add one block that should be processed
 	processable := unittest.BlockFixture()
 	ss.core.On("HandleBlock", processable.Header).Return(true)
-	res.Blocks = append(res.Blocks, messages.UntrustedBlockFromInternal(&processable))
+	res.Blocks = append(res.Blocks, &processable)
 
 	// add one block that should not be processed
 	unprocessable := unittest.BlockFixture()
 	ss.core.On("HandleBlock", unprocessable.Header).Return(false)
-	res.Blocks = append(res.Blocks, messages.UntrustedBlockFromInternal(&unprocessable))
+	res.Blocks = append(res.Blocks, &unprocessable)
 
 	ss.comp.On("OnSyncedBlocks", mock.Anything).Run(func(args mock.Arguments) {
 		res := args.Get(0).(flow.Slashable[[]*messages.BlockProposal])

--- a/engine/common/synchronization/request_handler.go
+++ b/engine/common/synchronization/request_handler.go
@@ -221,7 +221,7 @@ func (r *RequestHandler) onRangeRequest(originID flow.Identifier, req *messages.
 	}
 
 	// get all the blocks, one by one
-	blocks := make([]messages.UntrustedBlock, 0, req.ToHeight-req.FromHeight+1)
+	blocks := make([]*flow.Block, 0, req.ToHeight-req.FromHeight+1)
 	for height := req.FromHeight; height <= req.ToHeight; height++ {
 		block, err := r.blocks.ByHeight(height)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -231,7 +231,7 @@ func (r *RequestHandler) onRangeRequest(originID flow.Identifier, req *messages.
 		if err != nil {
 			return fmt.Errorf("could not get block for height (%d): %w", height, err)
 		}
-		blocks = append(blocks, messages.UntrustedBlockFromInternal(block))
+		blocks = append(blocks, block)
 	}
 
 	// if there are no blocks to send, skip network message
@@ -293,7 +293,7 @@ func (r *RequestHandler) onBatchRequest(originID flow.Identifier, req *messages.
 	}
 
 	// try to get all the blocks by ID
-	blocks := make([]messages.UntrustedBlock, 0, len(blockIDs))
+	blocks := make([]*flow.Block, 0, len(blockIDs))
 	for blockID := range blockIDs {
 		block, err := r.blocks.ByID(blockID)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -303,7 +303,7 @@ func (r *RequestHandler) onBatchRequest(originID flow.Identifier, req *messages.
 		if err != nil {
 			return fmt.Errorf("could not get block by ID (%s): %w", blockID, err)
 		}
-		blocks = append(blocks, messages.UntrustedBlockFromInternal(block))
+		blocks = append(blocks, block)
 	}
 
 	// if there are no blocks to send, skip network message

--- a/engine/consensus/message_hub/message_hub.go
+++ b/engine/consensus/message_hub/message_hub.go
@@ -342,7 +342,7 @@ func (h *MessageHub) sendOwnProposal(header *flow.Header) error {
 	// NOTE: some fields are not needed for the message
 	// - proposer ID is conveyed over the network message
 	// - the payload hash is deduced from the payload
-	proposal := messages.NewBlockProposal(&flow.Block{
+	proposal := messages.NewBlockProposalFromInternal(&flow.Block{
 		Header:  header,
 		Payload: payload,
 	})

--- a/engine/consensus/message_hub/message_hub_test.go
+++ b/engine/consensus/message_hub/message_hub_test.go
@@ -174,7 +174,7 @@ func (s *MessageHubSuite) TestProcessIncomingMessages() {
 	s.Run("to-compliance-engine", func() {
 		block := unittest.BlockFixture()
 
-		blockProposalMsg := messages.NewBlockProposal(&block)
+		blockProposalMsg := messages.NewBlockProposalFromInternal(&block)
 		expectedComplianceMsg := flow.Slashable[*messages.BlockProposal]{
 			OriginID: originID,
 			Message:  blockProposalMsg,
@@ -247,7 +247,7 @@ func (s *MessageHubSuite) TestOnOwnProposal() {
 	})
 
 	s.Run("should broadcast proposal and pass to HotStuff for valid proposals", func() {
-		expectedBroadcastMsg := messages.NewBlockProposal(block)
+		expectedBroadcastMsg := messages.NewBlockProposalFromInternal(block)
 
 		submitted := make(chan struct{}) // closed when proposal is submitted to hotstuff
 		hotstuffProposal := model.SignedProposalFromFlow(block.Header)
@@ -318,7 +318,7 @@ func (s *MessageHubSuite) TestProcessMultipleMessagesHappyPath() {
 		hotstuffProposal := model.SignedProposalFromFlow(proposal.Header)
 		s.voteAggregator.On("AddBlock", hotstuffProposal).Once()
 		s.hotstuff.On("SubmitProposal", hotstuffProposal)
-		expectedBroadcastMsg := messages.NewBlockProposal(&proposal)
+		expectedBroadcastMsg := messages.NewBlockProposalFromInternal(&proposal)
 		s.con.On("Publish", expectedBroadcastMsg, s.participants[1].NodeID, s.participants[2].NodeID).
 			Run(func(_ mock.Arguments) { wg.Done() }).
 			Return(nil)

--- a/model/events/synchronization.go
+++ b/model/events/synchronization.go
@@ -1,16 +1,17 @@
 package events
 
 import (
+	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
 )
 
 type SyncedBlock struct {
 	OriginID flow.Identifier
-	Block    messages.UntrustedBlock
+	Block    *flow.Block
 }
 
 type SyncedClusterBlock struct {
 	OriginID flow.Identifier
-	Block    messages.UntrustedClusterBlock
+	Block    *cluster.Block
 }

--- a/model/libp2p/message/testmessage.go
+++ b/model/libp2p/message/testmessage.go
@@ -1,6 +1,31 @@
 package message
 
 // TestMessage is used for testing the network layer.
+//
+//structwrite:immutable
 type TestMessage struct {
 	Text string
+}
+
+// UntrustedTestMessage is an untrusted input-only representation of a TestMessage,
+// used for construction.
+//
+// An instance of UntrustedTestMessage should be validated and converted into
+// a trusted TestMessage using NewTestMessage constructor.
+type UntrustedTestMessage TestMessage
+
+// NewTestMessage creates a new TestMessage.
+//
+// Parameters:
+//   - untrusted: untrusted TestMessage to be validated
+//
+// Returns:
+//   - TestMessage: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewTestMessage(untrusted UntrustedTestMessage) (TestMessage, error) {
+	// TODO: add validation logic
+	return TestMessage{Text: untrusted.Text}, nil
 }

--- a/model/messages/collection.go
+++ b/model/messages/collection.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -74,20 +76,106 @@ func UntrustedClusterBlockFromInternal(clusterBlock *cluster.Block) UntrustedClu
 // ClusterBlockProposal is a proposal for a block in collection node cluster
 // consensus. The header contains information about consensus state and the
 // payload contains the proposed collection (may be empty).
+//
+//structwrite:immutable
 type ClusterBlockProposal struct {
-	Block UntrustedClusterBlock
+	Block *cluster.Block
 }
 
-func NewClusterBlockProposal(internal *cluster.Block) *ClusterBlockProposal {
-	return &ClusterBlockProposal{
-		Block: UntrustedClusterBlockFromInternal(internal),
+// UntrustedClusterBlockProposal is an untrusted input-only representation of a ClusterBlockProposal,
+// used for construction.
+//
+// An instance of UntrustedClusterBlockProposal should be validated and converted into
+// a trusted ClusterBlockProposal using NewClusterBlockProposal constructor.
+type UntrustedClusterBlockProposal ClusterBlockProposal
+
+// NewClusterBlockProposal creates a new instance of ClusterBlockProposal.
+//
+// Parameters:
+//   - untrusted: untrusted ClusterBlockProposal to be validated
+//
+// Returns:
+//   - *ClusterBlockProposal: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewClusterBlockProposal(untrusted UntrustedClusterBlockProposal) (*ClusterBlockProposal, error) {
+	// TODO: add validation logic
+	if untrusted.Block == nil {
+		return nil, fmt.Errorf("block must not be nil")
 	}
+	return &ClusterBlockProposal{Block: untrusted.Block}, nil
+}
+
+func NewClusterBlockProposalFromInternal(internal *cluster.Block) *ClusterBlockProposal {
+	return &ClusterBlockProposal{Block: internal}
 }
 
 // ClusterBlockVote is a vote for a proposed block in collection node cluster
 // consensus; effectively a vote for a particular collection.
+//
+//structwrite:immutable
 type ClusterBlockVote BlockVote
+
+// UntrustedClusterBlockVote is an untrusted input-only representation of a ClusterBlockVote,
+// used for construction.
+//
+// An instance of UntrustedClusterBlockVote should be validated and converted into
+// a trusted ClusterBlockVote using NewClusterBlockVote constructor.
+type UntrustedClusterBlockVote ClusterBlockVote
+
+// NewClusterBlockVote creates a new instance of ClusterBlockVote.
+//
+// Parameters:
+//   - untrusted: untrusted ClusterBlockVote to be validated
+//
+// Returns:
+//   - *ClusterBlockVote: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewClusterBlockVote(untrusted UntrustedClusterBlockVote) (*ClusterBlockVote, error) {
+	// TODO: add validation logic
+	vote, err := NewBlockVote(UntrustedBlockVote(untrusted))
+	if err != nil {
+		return nil, err
+	}
+	cv := ClusterBlockVote(*vote)
+	return &cv, nil
+}
 
 // ClusterTimeoutObject is part of the collection cluster protocol and represents a collection node
 // timing out in given round. Contains a sequential number for deduplication purposes.
+//
+//structwrite:immutable
 type ClusterTimeoutObject TimeoutObject
+
+// UntrustedClusterTimeoutObject is an untrusted input-only representation of a ClusterTimeoutObject,
+// used for construction.
+//
+// An instance of UntrustedClusterTimeoutObject should be validated and converted into
+// a trusted ClusterTimeoutObject using NewClusterTimeoutObject constructor.
+type UntrustedClusterTimeoutObject ClusterTimeoutObject
+
+// NewClusterTimeoutObject creates a new instance of ClusterTimeoutObject.
+//
+// Parameters:
+//   - untrusted: untrusted ClusterTimeoutObject to be validated
+//
+// Returns:
+//   - *ClusterTimeoutObject: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewClusterTimeoutObject(untrusted UntrustedClusterTimeoutObject) (*ClusterTimeoutObject, error) {
+	// TODO: add validation logic
+	to, err := NewTimeoutObject(UntrustedTimeoutObject(untrusted))
+	if err != nil {
+		return nil, err
+	}
+	cto := ClusterTimeoutObject(*to)
+	return &cto, nil
+}

--- a/model/messages/consensus.go
+++ b/model/messages/consensus.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -128,30 +130,121 @@ func UntrustedBlockFromInternal(flowBlock *flow.Block) UntrustedBlock {
 
 // BlockProposal is part of the consensus protocol and represents the leader
 // of a consensus round pushing a new proposal to the network.
+//
+//structwrite:immutable
 type BlockProposal struct {
-	Block UntrustedBlock
+	Block *flow.Block
 }
 
-func NewBlockProposal(internal *flow.Block) *BlockProposal {
-	return &BlockProposal{
-		Block: UntrustedBlockFromInternal(internal),
+// UntrustedBlockProposal is an untrusted input-only representation of a BlockProposal,
+// used for construction.
+//
+// This type exists to ensure that constructor functions are invoked explicitly
+// with named fields, which improves clarity and reduces the risk of incorrect field
+// ordering during construction.
+//
+// An instance of UntrustedBlockProposal should be validated and converted into
+// a trusted BlockProposal using NewBlockProposal constructor.
+type UntrustedBlockProposal BlockProposal
+
+// NewBlockProposal creates a new instance of BlockProposal.
+// Construction BlockProposal allowed only within the constructor.
+//
+// Parameters:
+//   - untrusted: untrusted BlockProposal to be validated
+//
+// Returns:
+//   - *BlockProposal: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewBlockProposal(untrusted UntrustedBlockProposal) (*BlockProposal, error) {
+	// TODO: add validation logic
+	if untrusted.Block == nil {
+		return nil, fmt.Errorf("block must not be nil")
 	}
+	return &BlockProposal{Block: untrusted.Block}, nil
+}
+
+func NewBlockProposalFromInternal(internal *flow.Block) *BlockProposal {
+	return &BlockProposal{Block: internal}
 }
 
 // BlockVote is part of the consensus protocol and represents a consensus node
 // voting on the proposal of the leader of a given round.
+//
+//structwrite:immutable
 type BlockVote struct {
 	BlockID flow.Identifier
 	View    uint64
 	SigData []byte
 }
 
+// UntrustedBlockVote is an untrusted input-only representation of a BlockVote,
+// used for construction.
+//
+// An instance of UntrustedBlockVote should be validated and converted into
+// a trusted BlockVote using NewBlockVote constructor.
+type UntrustedBlockVote BlockVote
+
+// NewBlockVote creates a new instance of BlockVote.
+//
+// Parameters:
+//   - untrusted: untrusted BlockVote to be validated
+//
+// Returns:
+//   - *BlockVote: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewBlockVote(untrusted UntrustedBlockVote) (*BlockVote, error) {
+	// TODO: add validation logic
+	return &BlockVote{
+		BlockID: untrusted.BlockID,
+		View:    untrusted.View,
+		SigData: untrusted.SigData,
+	}, nil
+}
+
 // TimeoutObject is part of the consensus protocol and represents a consensus node
 // timing out in given round. Contains a sequential number for deduplication purposes.
+//
+//structwrite:immutable
 type TimeoutObject struct {
 	TimeoutTick uint64
 	View        uint64
 	NewestQC    *flow.QuorumCertificate
 	LastViewTC  *flow.TimeoutCertificate
 	SigData     []byte
+}
+
+// UntrustedTimeoutObject is an untrusted input-only representation of a TimeoutObject,
+// used for construction.
+//
+// An instance of UntrustedTimeoutObject should be validated and converted into
+// a trusted TimeoutObject using NewTimeoutObject constructor.
+type UntrustedTimeoutObject TimeoutObject
+
+// NewTimeoutObject creates a new instance of TimeoutObject.
+//
+// Parameters:
+//   - untrusted: untrusted TimeoutObject to be validated
+//
+// Returns:
+//   - *TimeoutObject: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewTimeoutObject(untrusted UntrustedTimeoutObject) (*TimeoutObject, error) {
+	// TODO: add validation logic
+	return &TimeoutObject{
+		TimeoutTick: untrusted.TimeoutTick,
+		View:        untrusted.View,
+		NewestQC:    untrusted.NewestQC,
+		LastViewTC:  untrusted.LastViewTC,
+		SigData:     untrusted.SigData,
+	}, nil
 }

--- a/model/messages/convert_test.go
+++ b/model/messages/convert_test.go
@@ -6,31 +6,27 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/flow-go/model/cluster"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestBlockProposal(t *testing.T) {
 	block := unittest.FullBlockFixture()
-	proposal := messages.NewBlockProposal(&block)
-	converted := proposal.Block.ToInternal()
-	assert.Equal(t, &block, converted)
+	proposal := messages.NewBlockProposalFromInternal(&block)
+	assert.Equal(t, &block, proposal.Block)
 }
 
 func TestClusterBlockProposal(t *testing.T) {
 	block := unittest.ClusterBlockFixture()
-	proposal := messages.NewClusterBlockProposal(&block)
-	converted := proposal.Block.ToInternal()
-	assert.Equal(t, &block, converted)
+	proposal := messages.NewClusterBlockProposalFromInternal(&block)
+	assert.Equal(t, &block, proposal.Block)
 }
 
 func TestBlockResponse(t *testing.T) {
 	expected := unittest.BlockFixtures(2)
 	res := messages.BlockResponse{
-		Blocks: []messages.UntrustedBlock{
-			messages.UntrustedBlockFromInternal(expected[0]),
-			messages.UntrustedBlockFromInternal(expected[1]),
-		},
+		Blocks: []*flow.Block{expected[0], expected[1]},
 	}
 	converted := res.BlocksInternal()
 	assert.Equal(t, expected, converted)
@@ -41,10 +37,7 @@ func TestClusterBlockResponse(t *testing.T) {
 	b2 := unittest.ClusterBlockFixture()
 	expected := []*cluster.Block{&b1, &b2}
 	res := messages.ClusterBlockResponse{
-		Blocks: []messages.UntrustedClusterBlock{
-			messages.UntrustedClusterBlockFromInternal(expected[0]),
-			messages.UntrustedClusterBlockFromInternal(expected[1]),
-		},
+		Blocks: []*cluster.Block{expected[0], expected[1]},
 	}
 	converted := res.BlocksInternal()
 	assert.Equal(t, expected, converted)

--- a/model/messages/dkg.go
+++ b/model/messages/dkg.go
@@ -7,9 +7,34 @@ import (
 )
 
 // DKGMessage is the type of message exchanged between DKG nodes.
+//
+//structwrite:immutable
 type DKGMessage struct {
 	Data          []byte
 	DKGInstanceID string
+}
+
+// UntrustedDKGMessage is an untrusted input-only representation of a DKGMessage,
+// used for construction.
+//
+// An instance of UntrustedDKGMessage should be validated and converted into
+// a trusted DKGMessage using NewDKGMessage constructor.
+type UntrustedDKGMessage DKGMessage
+
+// NewDKGMessage creates a new DKGMessage.
+//
+// Parameters:
+//   - untrusted: untrusted DKGMessage to be validated
+//
+// Returns:
+//   - DKGMessage: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewDKGMessage(untrusted UntrustedDKGMessage) (DKGMessage, error) {
+	// TODO: add validation logic
+	return DKGMessage{Data: untrusted.Data, DKGInstanceID: untrusted.DKGInstanceID}, nil
 }
 
 // NewDKGMessage creates a new DKGMessage.

--- a/model/messages/exchange.go
+++ b/model/messages/exchange.go
@@ -9,16 +9,66 @@ import (
 // specified here. In the typical case, the identifier is simply the ID of the
 // entity being requested, but more complex identifier-entity relationships can
 // be used as well.
+//
+//structwrite:immutable
 type EntityRequest struct {
 	Nonce     uint64
 	EntityIDs []flow.Identifier
 }
 
+// UntrustedEntityRequest is an untrusted input-only representation of an EntityRequest,
+// used for construction.
+//
+// An instance of UntrustedEntityRequest should be validated and converted into
+// a trusted EntityRequest using NewEntityRequest constructor.
+type UntrustedEntityRequest EntityRequest
+
+// NewEntityRequest creates a new instance of EntityRequest.
+//
+// Parameters:
+//   - untrusted: untrusted EntityRequest to be validated
+//
+// Returns:
+//   - *EntityRequest: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewEntityRequest(untrusted UntrustedEntityRequest) (*EntityRequest, error) {
+	// TODO: add validation logic
+	return &EntityRequest{Nonce: untrusted.Nonce, EntityIDs: untrusted.EntityIDs}, nil
+}
+
 // EntityResponse is a response to an entity request, containing a set of
 // serialized entities and the identifiers used to request them. The returned
 // entity set may be empty or incomplete.
+//
+//structwrite:immutable
 type EntityResponse struct {
 	Nonce     uint64
 	EntityIDs []flow.Identifier
 	Blobs     [][]byte
+}
+
+// UntrustedEntityResponse is an untrusted input-only representation of an EntityResponse,
+// used for construction.
+//
+// An instance of UntrustedEntityResponse should be validated and converted into
+// a trusted EntityResponse using NewEntityResponse constructor.
+type UntrustedEntityResponse EntityResponse
+
+// NewEntityResponse creates a new instance of EntityResponse.
+//
+// Parameters:
+//   - untrusted: untrusted EntityResponse to be validated
+//
+// Returns:
+//   - *EntityResponse: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewEntityResponse(untrusted UntrustedEntityResponse) (*EntityResponse, error) {
+	// TODO: add validation logic
+	return &EntityResponse{Nonce: untrusted.Nonce, EntityIDs: untrusted.EntityIDs, Blobs: untrusted.Blobs}, nil
 }

--- a/model/messages/execution.go
+++ b/model/messages/execution.go
@@ -6,14 +6,64 @@ import (
 
 // ChunkDataRequest represents a request for the a chunk data pack
 // which is specified by a chunk ID.
+//
+//structwrite:immutable
 type ChunkDataRequest struct {
 	ChunkID flow.Identifier
 	Nonce   uint64 // so that we aren't deduplicated by the network layer
 }
 
+// UntrustedChunkDataRequest is an untrusted input-only representation of a ChunkDataRequest,
+// used for construction.
+//
+// An instance of UntrustedChunkDataRequest should be validated and converted into
+// a trusted ChunkDataRequest using NewChunkDataRequest constructor.
+type UntrustedChunkDataRequest ChunkDataRequest
+
+// NewChunkDataRequest creates a new instance of ChunkDataRequest.
+//
+// Parameters:
+//   - untrusted: untrusted ChunkDataRequest to be validated
+//
+// Returns:
+//   - *ChunkDataRequest: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewChunkDataRequest(untrusted UntrustedChunkDataRequest) (*ChunkDataRequest, error) {
+	// TODO: add validation logic
+	return &ChunkDataRequest{ChunkID: untrusted.ChunkID, Nonce: untrusted.Nonce}, nil
+}
+
 // ChunkDataResponse is the response to a chunk data pack request.
 // It contains the chunk data pack of the interest.
+//
+//structwrite:immutable
 type ChunkDataResponse struct {
 	ChunkDataPack flow.ChunkDataPack
 	Nonce         uint64 // so that we aren't deduplicated by the network layer
+}
+
+// UntrustedChunkDataResponse is an untrusted input-only representation of a ChunkDataResponse,
+// used for construction.
+//
+// An instance of UntrustedChunkDataResponse should be validated and converted into
+// a trusted ChunkDataResponse using NewChunkDataResponse constructor.
+type UntrustedChunkDataResponse ChunkDataResponse
+
+// NewChunkDataResponse creates a new instance of ChunkDataResponse.
+//
+// Parameters:
+//   - untrusted: untrusted ChunkDataResponse to be validated
+//
+// Returns:
+//   - *ChunkDataResponse: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewChunkDataResponse(untrusted UntrustedChunkDataResponse) (*ChunkDataResponse, error) {
+	// TODO: add validation logic
+	return &ChunkDataResponse{ChunkDataPack: untrusted.ChunkDataPack, Nonce: untrusted.Nonce}, nil
 }

--- a/model/messages/synchronization.go
+++ b/model/messages/synchronization.go
@@ -10,17 +10,67 @@ import (
 // the same information from the recipient.
 // All SyncRequest messages are validated before being processed. If validation fails, then a misbehavior report is created.
 // See synchronization.validateSyncRequestForALSP for more details.
+//
+//structwrite:immutable
 type SyncRequest struct {
 	Nonce  uint64
 	Height uint64
 }
 
+// UntrustedSyncRequest is an untrusted input-only representation of a SyncRequest,
+// used for construction.
+//
+// An instance of UntrustedSyncRequest should be validated and converted into
+// a trusted SyncRequest using NewSyncRequest constructor.
+type UntrustedSyncRequest SyncRequest
+
+// NewSyncRequest creates a new instance of SyncRequest.
+//
+// Parameters:
+//   - untrusted: untrusted SyncRequest to be validated
+//
+// Returns:
+//   - *SyncRequest: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewSyncRequest(untrusted UntrustedSyncRequest) (*SyncRequest, error) {
+	// TODO: add validation logic
+	return &SyncRequest{Nonce: untrusted.Nonce, Height: untrusted.Height}, nil
+}
+
 // SyncResponse is part of the synchronization protocol and represents the reply
 // to a synchronization request that contains the latest finalized block height
 // of the responding node.
+//
+//structwrite:immutable
 type SyncResponse struct {
 	Nonce  uint64
 	Height uint64
+}
+
+// UntrustedSyncResponse is an untrusted input-only representation of a SyncResponse,
+// used for construction.
+//
+// An instance of UntrustedSyncResponse should be validated and converted into
+// a trusted SyncResponse using NewSyncResponse constructor.
+type UntrustedSyncResponse SyncResponse
+
+// NewSyncResponse creates a new instance of SyncResponse.
+//
+// Parameters:
+//   - untrusted: untrusted SyncResponse to be validated
+//
+// Returns:
+//   - *SyncResponse: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewSyncResponse(untrusted UntrustedSyncResponse) (*SyncResponse, error) {
+	// TODO: add validation logic
+	return &SyncResponse{Nonce: untrusted.Nonce, Height: untrusted.Height}, nil
 }
 
 // RangeRequest is part of the synchronization protocol and represents an active
@@ -29,10 +79,39 @@ type SyncResponse struct {
 // heights.
 // All RangeRequest messages are validated before being processed. If validation fails, then a misbehavior report is created.
 // See synchronization.validateRangeRequestForALSP for more details.
+//
+//structwrite:immutable
 type RangeRequest struct {
 	Nonce      uint64
 	FromHeight uint64
 	ToHeight   uint64
+}
+
+// UntrustedRangeRequest is an untrusted input-only representation of a RangeRequest,
+// used for construction.
+//
+// An instance of UntrustedRangeRequest should be validated and converted into
+// a trusted RangeRequest using NewRangeRequest constructor.
+type UntrustedRangeRequest RangeRequest
+
+// NewRangeRequest creates a new instance of RangeRequest.
+//
+// Parameters:
+//   - untrusted: untrusted RangeRequest to be validated
+//
+// Returns:
+//   - *RangeRequest: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewRangeRequest(untrusted UntrustedRangeRequest) (*RangeRequest, error) {
+	// TODO: add validation logic
+	return &RangeRequest{
+		Nonce:      untrusted.Nonce,
+		FromHeight: untrusted.FromHeight,
+		ToHeight:   untrusted.ToHeight,
+	}, nil
 }
 
 // BatchRequest is part of the synchronization protocol and represents an active
@@ -40,40 +119,105 @@ type RangeRequest struct {
 // requests finalized or unfinalized blocks by a list of block IDs.
 // All BatchRequest messages are validated before being processed. If validation fails, then a misbehavior report is created.
 // See synchronization.validateBatchRequestForALSP for more details.
+//
+//structwrite:immutable
 type BatchRequest struct {
 	Nonce    uint64
 	BlockIDs []flow.Identifier
 }
 
+// UntrustedBatchRequest is an untrusted input-only representation of a BatchRequest,
+// used for construction.
+//
+// An instance of UntrustedBatchRequest should be validated and converted into
+// a trusted BatchRequest using NewBatchRequest constructor.
+type UntrustedBatchRequest BatchRequest
+
+// NewBatchRequest creates a new instance of BatchRequest.
+//
+// Parameters:
+//   - untrusted: untrusted BatchRequest to be validated
+//
+// Returns:
+//   - *BatchRequest: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewBatchRequest(untrusted UntrustedBatchRequest) (*BatchRequest, error) {
+	// TODO: add validation logic
+	return &BatchRequest{Nonce: untrusted.Nonce, BlockIDs: untrusted.BlockIDs}, nil
+}
+
 // BlockResponse is part of the synchronization protocol and represents the
 // reply to any active synchronization attempts. It contains a list of blocks
 // that should correspond to the request.
+//
+//structwrite:immutable
 type BlockResponse struct {
 	Nonce  uint64
-	Blocks []UntrustedBlock
+	Blocks []*flow.Block
+}
+
+// UntrustedBlockResponse is an untrusted input-only representation of a BlockResponse,
+// used for construction.
+//
+// An instance of UntrustedBlockResponse should be validated and converted into
+// a trusted BlockResponse using NewBlockResponse constructor.
+type UntrustedBlockResponse BlockResponse
+
+// NewBlockResponse creates a new instance of BlockResponse.
+//
+// Parameters:
+//   - untrusted: untrusted BlockResponse to be validated
+//
+// Returns:
+//   - *BlockResponse: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewBlockResponse(untrusted UntrustedBlockResponse) (*BlockResponse, error) {
+	// TODO: add validation logic
+	return &BlockResponse{Nonce: untrusted.Nonce, Blocks: untrusted.Blocks}, nil
 }
 
 func (br *BlockResponse) BlocksInternal() []*flow.Block {
-	internal := make([]*flow.Block, len(br.Blocks))
-	for i, block := range br.Blocks {
-		block := block
-		internal[i] = block.ToInternal()
-	}
-	return internal
+	return br.Blocks
 }
 
 // ClusterBlockResponse is the same thing as BlockResponse, but for cluster
 // consensus.
+//
+//structwrite:immutable
 type ClusterBlockResponse struct {
 	Nonce  uint64
-	Blocks []UntrustedClusterBlock
+	Blocks []*cluster.Block
+}
+
+// UntrustedClusterBlockResponse is an untrusted input-only representation of a ClusterBlockResponse,
+// used for construction.
+//
+// An instance of UntrustedClusterBlockResponse should be validated and converted into
+// a trusted ClusterBlockResponse using NewClusterBlockResponse constructor.
+type UntrustedClusterBlockResponse ClusterBlockResponse
+
+// NewClusterBlockResponse creates a new instance of ClusterBlockResponse.
+//
+// Parameters:
+//   - untrusted: untrusted ClusterBlockResponse to be validated
+//
+// Returns:
+//   - *ClusterBlockResponse: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewClusterBlockResponse(untrusted UntrustedClusterBlockResponse) (*ClusterBlockResponse, error) {
+	// TODO: add validation logic
+	return &ClusterBlockResponse{Nonce: untrusted.Nonce, Blocks: untrusted.Blocks}, nil
 }
 
 func (br *ClusterBlockResponse) BlocksInternal() []*cluster.Block {
-	internal := make([]*cluster.Block, len(br.Blocks))
-	for i, block := range br.Blocks {
-		block := block
-		internal[i] = block.ToInternal()
-	}
-	return internal
+	return br.Blocks
 }

--- a/model/messages/verification.go
+++ b/model/messages/verification.go
@@ -4,14 +4,68 @@ import "github.com/onflow/flow-go/model/flow"
 
 // ApprovalRequest represents a request for a ResultApproval corresponding to
 // a specific chunk.
+//
+//structwrite:immutable
 type ApprovalRequest struct {
 	Nonce      uint64
 	ResultID   flow.Identifier
 	ChunkIndex uint64
 }
 
+// UntrustedApprovalRequest is an untrusted input-only representation of an ApprovalRequest,
+// used for construction.
+//
+// An instance of UntrustedApprovalRequest should be validated and converted into
+// a trusted ApprovalRequest using NewApprovalRequest constructor.
+type UntrustedApprovalRequest ApprovalRequest
+
+// NewApprovalRequest creates a new instance of ApprovalRequest.
+//
+// Parameters:
+//   - untrusted: untrusted ApprovalRequest to be validated
+//
+// Returns:
+//   - *ApprovalRequest: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewApprovalRequest(untrusted UntrustedApprovalRequest) (*ApprovalRequest, error) {
+	// TODO: add validation logic
+	return &ApprovalRequest{
+		Nonce:      untrusted.Nonce,
+		ResultID:   untrusted.ResultID,
+		ChunkIndex: untrusted.ChunkIndex,
+	}, nil
+}
+
 // ApprovalResponse contains a response to an approval request.
+//
+//structwrite:immutable
 type ApprovalResponse struct {
 	Nonce    uint64
 	Approval flow.ResultApproval
+}
+
+// UntrustedApprovalResponse is an untrusted input-only representation of an ApprovalResponse,
+// used for construction.
+//
+// An instance of UntrustedApprovalResponse should be validated and converted into
+// a trusted ApprovalResponse using NewApprovalResponse constructor.
+type UntrustedApprovalResponse ApprovalResponse
+
+// NewApprovalResponse creates a new instance of ApprovalResponse.
+//
+// Parameters:
+//   - untrusted: untrusted ApprovalResponse to be validated
+//
+// Returns:
+//   - *ApprovalResponse: the newly created instance
+//   - error: any error that occurred during creation
+//
+// Expected Errors:
+//   - TODO: add validation errors
+func NewApprovalResponse(untrusted UntrustedApprovalResponse) (*ApprovalResponse, error) {
+	// TODO: add validation logic
+	return &ApprovalResponse{Nonce: untrusted.Nonce, Approval: untrusted.Approval}, nil
 }

--- a/network/codec/roundTripHeader_test.go
+++ b/network/codec/roundTripHeader_test.go
@@ -22,13 +22,13 @@ import (
 // next developer who wants to add a new serialization format :-)
 func roundTripHeaderViaCodec(t *testing.T, codec network.Codec) {
 	block := unittest.BlockFixture()
-	message := messages.NewBlockProposal(&block)
+	message := messages.NewBlockProposalFromInternal(&block)
 	encoded, err := codec.Encode(message)
 	assert.NoError(t, err)
 	decodedInterface, err := codec.Decode(encoded)
 	assert.NoError(t, err)
 	decoded := decodedInterface.(*messages.BlockProposal)
-	decodedBlock := decoded.Block.ToInternal()
+	decodedBlock := decoded.Block
 	// compare LastViewTC separately, because it is a pointer field
 	if decodedBlock.Header.LastViewTC == nil {
 		assert.Equal(t, block.Header.LastViewTC, decodedBlock.Header.LastViewTC)

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -262,11 +262,11 @@ func ProposalFixture() *messages.BlockProposal {
 }
 
 func ProposalFromBlock(block *flow.Block) *messages.BlockProposal {
-	return messages.NewBlockProposal(block)
+	return messages.NewBlockProposalFromInternal(block)
 }
 
 func ClusterProposalFromBlock(block *cluster.Block) *messages.ClusterBlockProposal {
-	return messages.NewClusterBlockProposal(block)
+	return messages.NewClusterBlockProposalFromInternal(block)
 }
 
 func BlockchainFixture(length int) []*flow.Block {


### PR DESCRIPTION
## Summary
- add untrusted versions and constructors for several network message types
- mark messages with `//structwrite:immutable` to ensure immutability
- replace UntrustedBlock fields with canonical block types

## Testing
- `gofmt -w model/libp2p/message/testmessage.go model/messages/collection.go model/messages/consensus.go model/messages/dkg.go model/messages/exchange.go model/messages/execution.go model/messages/synchronization.go model/messages/verification.go model/events/synchronization.go engine/common/synchronization/request_handler.go engine/collection/synchronization/request_handler.go engine/common/synchronization/engine_test.go engine/collection/synchronization/engine_test.go engine/consensus/message_hub/message_hub.go engine/consensus/message_hub/message_hub_test.go utils/unittest/fixtures.go model/messages/convert_test.go network/codec/roundTripHeader_test.go engine/collection/compliance/core_test.go engine/collection/compliance/engine_test.go`


------
https://chatgpt.com/codex/tasks/task_b_685d8e0ad7f88332906333b5e5344f06