### PR TITLE
[WIP] [DataAvailability]initial refactoring for accounts rpc endpoint handler

### DIFF
--- a/engine/access/rpc/backend/accounts/accounts.go
+++ b/engine/access/rpc/backend/accounts/accounts.go
@@ -1,0 +1,239 @@
+package accounts
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/engine/access/rpc/backend"
+	"github.com/onflow/flow-go/engine/access/rpc/backend/accounts/handler"
+	"github.com/onflow/flow-go/engine/access/rpc/connection"
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/execution"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/state/protocol"
+	"github.com/onflow/flow-go/storage"
+)
+
+type Accounts struct {
+	log                        zerolog.Logger
+	state                      protocol.State
+	headers                    storage.Headers
+	connFactory                connection.ConnectionFactory
+	nodeCommunicator           backend.Communicator
+	endpointHandler            handler.Handler
+	execNodeIdentitiesProvider *commonrpc.ExecutionNodeIdentitiesProvider
+}
+
+func NewAccounts(
+	log zerolog.Logger,
+	state protocol.State,
+	headers storage.Headers,
+	connFactory connection.ConnectionFactory,
+	nodeCommunicator backend.Communicator,
+	scriptExecMode backend.IndexQueryMode,
+	scriptExecutor execution.ScriptExecutor,
+	execNodeIdentitiesProvider *commonrpc.ExecutionNodeIdentitiesProvider,
+) *Accounts {
+	var h handler.Handler
+
+	// TODO: we can instantiate these strategies outside of backend (in access_node_builder e.g.)
+	switch scriptExecMode {
+	case backend.IndexQueryModeLocalOnly:
+		h = handler.NewLocalHandler(log, state, scriptExecutor)
+
+	case backend.IndexQueryModeExecutionNodesOnly:
+		h = handler.NewExecutionNodeHandler(log, state, connFactory, nodeCommunicator, execNodeIdentitiesProvider)
+
+	case backend.IndexQueryModeFailover:
+		local := handler.NewLocalHandler(log, state, scriptExecutor)
+		execNode := handler.NewExecutionNodeHandler(log, state, connFactory, nodeCommunicator, execNodeIdentitiesProvider)
+		h = handler.NewFailoverHandler(log, state, local, execNode)
+
+	case backend.IndexQueryModeCompare:
+		panic("TODO")
+	}
+
+	return &Accounts{
+		log:                        log,
+		state:                      state,
+		headers:                    headers,
+		connFactory:                connFactory,
+		nodeCommunicator:           nodeCommunicator,
+		endpointHandler:            h,
+		execNodeIdentitiesProvider: execNodeIdentitiesProvider,
+	}
+}
+
+// GetAccount returns the account details at the latest sealed block.
+// Alias for GetAccountAtLatestBlock
+func (a *Accounts) GetAccount(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	return a.GetAccountAtLatestBlock(ctx, address)
+}
+
+// GetAccountAtLatestBlock returns the account details at the latest sealed block.
+func (a *Accounts) GetAccountAtLatestBlock(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	sealed, err := a.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	account, err := a.endpointHandler.GetAccountAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		a.log.Debug().Err(err).Msgf("failed to get account at blockID: %v", sealedBlockID)
+		return nil, err
+	}
+
+	return account, nil
+}
+
+// GetAccountAtBlockHeight returns the account details at the given block height.
+func (a *Accounts) GetAccountAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	height uint64,
+) (*flow.Account, error) {
+	blockID, err := a.headers.BlockIDByHeight(height)
+	if err != nil {
+		return nil, commonrpc.ConvertStorageError(backend.ResolveHeightError(a.state.Params(), height, err))
+	}
+
+	account, err := a.endpointHandler.GetAccountAtBlockHeight(ctx, address, blockID, height)
+	if err != nil {
+		a.log.Debug().Err(err).Msgf("failed to get account at height: %d", height)
+		return nil, err
+	}
+
+	return account, nil
+}
+
+// GetAccountBalanceAtLatestBlock returns the account balance at the latest sealed block.
+func (a *Accounts) GetAccountBalanceAtLatestBlock(ctx context.Context, address flow.Address) (uint64, error) {
+	sealed, err := a.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return 0, err
+	}
+
+	sealedBlockID := sealed.ID()
+	balance, err := a.endpointHandler.GetAccountBalanceAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		a.log.Debug().Err(err).Msgf("failed to get account balance at blockID: %v", sealedBlockID)
+		return 0, err
+	}
+
+	return balance, nil
+}
+
+// GetAccountBalanceAtBlockHeight returns the account balance at the given block height.
+func (a *Accounts) GetAccountBalanceAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	height uint64,
+) (uint64, error) {
+	blockID, err := a.headers.BlockIDByHeight(height)
+	if err != nil {
+		return 0, commonrpc.ConvertStorageError(backend.ResolveHeightError(a.state.Params(), height, err))
+	}
+
+	balance, err := a.endpointHandler.GetAccountBalanceAtBlockHeight(ctx, address, blockID, height)
+	if err != nil {
+		a.log.Debug().Err(err).Msgf("failed to get account balance at height: %v", height)
+		return 0, err
+	}
+
+	return balance, nil
+}
+
+// GetAccountKeyAtLatestBlock returns the account public key at the latest sealed block.
+func (a *Accounts) GetAccountKeyAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+	keyIndex uint32,
+) (*flow.AccountPublicKey, error) {
+	sealed, err := a.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	accountKey, err := a.endpointHandler.GetAccountKeyAtBlockHeight(ctx, address, keyIndex, sealedBlockID, sealed.Height)
+	if err != nil {
+		a.log.Debug().Err(err).Msgf("failed to get account key at blockID: %v", sealedBlockID)
+		return nil, err
+	}
+
+	return accountKey, nil
+}
+
+// GetAccountKeysAtLatestBlock returns the account public keys at the latest sealed block.
+func (a *Accounts) GetAccountKeysAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+) ([]flow.AccountPublicKey, error) {
+	sealed, err := a.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	accountKeys, err := a.endpointHandler.GetAccountKeysAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		a.log.Debug().Err(err).Msgf("failed to get account keys at blockID: %v", sealedBlockID)
+		return nil, err
+	}
+
+	return accountKeys, nil
+
+}
+
+// GetAccountKeyAtBlockHeight returns the account public key by key index at the given block height.
+func (a *Accounts) GetAccountKeyAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	keyIndex uint32,
+	height uint64,
+) (*flow.AccountPublicKey, error) {
+	blockID, err := a.headers.BlockIDByHeight(height)
+	if err != nil {
+		return nil, commonrpc.ConvertStorageError(backend.ResolveHeightError(a.state.Params(), height, err))
+	}
+
+	accountKey, err := a.endpointHandler.GetAccountKeyAtBlockHeight(ctx, address, keyIndex, blockID, height)
+	if err != nil {
+		a.log.Debug().Err(err).Msgf("failed to get account key at height: %v", height)
+		return nil, err
+	}
+
+	return accountKey, nil
+}
+
+// GetAccountKeysAtBlockHeight returns the account public keys at the given block height.
+func (a *Accounts) GetAccountKeysAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	height uint64,
+) ([]flow.AccountPublicKey, error) {
+	blockID, err := a.headers.BlockIDByHeight(height)
+	if err != nil {
+		return nil, commonrpc.ConvertStorageError(backend.ResolveHeightError(a.state.Params(), height, err))
+	}
+
+	accountKeys, err := a.endpointHandler.GetAccountKeysAtBlockHeight(ctx, address, blockID, height)
+	if err != nil {
+		a.log.Debug().Err(err).Msgf("failed to get account keys at height: %v", height)
+		return nil, err
+	}
+
+	return accountKeys, nil
+
+}

--- a/engine/access/rpc/backend/accounts/handler/compare.go
+++ b/engine/access/rpc/backend/accounts/handler/compare.go
@@ -1,0 +1,69 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/state/protocol"
+)
+
+type Compare struct {
+	log   zerolog.Logger
+	state protocol.State
+}
+
+var _ Handler = (*Compare)(nil)
+
+func NewCompareHandler(log zerolog.Logger, state protocol.State) *Compare {
+	return &Compare{
+		log:   log,
+		state: state,
+	}
+}
+
+func (c *Compare) GetAccount(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Compare) GetAccountAtLatestBlock(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Compare) GetAccountAtBlockHeight(ctx context.Context, address flow.Address, blockID flow.Identifier, height uint64) (*flow.Account, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Compare) GetAccountBalanceAtLatestBlock(ctx context.Context, address flow.Address) (uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Compare) GetAccountBalanceAtBlockHeight(ctx context.Context, address flow.Address, blockID flow.Identifier, height uint64) (uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Compare) GetAccountKeyAtLatestBlock(ctx context.Context, address flow.Address, keyIndex uint32) (*flow.AccountPublicKey, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Compare) GetAccountKeyAtBlockHeight(ctx context.Context, address flow.Address, keyIndex uint32, blockID flow.Identifier, height uint64) (*flow.AccountPublicKey, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Compare) GetAccountKeysAtLatestBlock(ctx context.Context, address flow.Address) ([]flow.AccountPublicKey, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Compare) GetAccountKeysAtBlockHeight(ctx context.Context, address flow.Address, blockID flow.Identifier, height uint64) ([]flow.AccountPublicKey, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/engine/access/rpc/backend/accounts/handler/execution_node.go
+++ b/engine/access/rpc/backend/accounts/handler/execution_node.go
@@ -1,0 +1,262 @@
+package handler
+
+import (
+	"context"
+	"time"
+
+	execproto "github.com/onflow/flow/protobuf/go/flow/execution"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/onflow/flow-go/engine/access/rpc/backend"
+	"github.com/onflow/flow-go/engine/access/rpc/connection"
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
+	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/state/protocol"
+
+	"github.com/onflow/flow-go/engine/common/rpc"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+type ExecutionNode struct {
+	log                        zerolog.Logger
+	state                      protocol.State
+	connFactory                connection.ConnectionFactory
+	nodeCommunicator           backend.Communicator
+	execNodeIdentitiesProvider *commonrpc.ExecutionNodeIdentitiesProvider
+}
+
+var _ Handler = (*ExecutionNode)(nil)
+
+func NewExecutionNodeHandler(
+	log zerolog.Logger,
+	state protocol.State,
+	connFactory connection.ConnectionFactory,
+	nodeCommunicator backend.Communicator,
+	execNodeIdentityProvider *commonrpc.ExecutionNodeIdentitiesProvider,
+) *ExecutionNode {
+	return &ExecutionNode{
+		log:                        log,
+		state:                      state,
+		connFactory:                connFactory,
+		nodeCommunicator:           nodeCommunicator,
+		execNodeIdentitiesProvider: execNodeIdentityProvider,
+	}
+}
+
+func (e *ExecutionNode) GetAccount(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	return e.GetAccountAtLatestBlock(ctx, address)
+}
+
+func (e *ExecutionNode) GetAccountAtLatestBlock(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	sealed, err := e.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	account, err := e.GetAccountAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		e.log.Debug().Err(err).Msgf("failed to get account at blockID: %v", sealedBlockID)
+		return nil, err
+	}
+
+	return account, nil
+}
+
+func (e *ExecutionNode) GetAccountAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	blockID flow.Identifier,
+	_ uint64,
+) (*flow.Account, error) {
+	req := &execproto.GetAccountAtBlockIDRequest{
+		Address: address.Bytes(),
+		BlockId: blockID[:],
+	}
+
+	execNodes, err := e.execNodeIdentitiesProvider.ExecutionNodesForBlockID(
+		ctx,
+		blockID,
+	)
+	if err != nil {
+		return nil, rpc.ConvertError(err, "failed to find execution node to query", codes.Internal)
+	}
+
+	var resp *execproto.GetAccountAtBlockIDResponse
+	errToReturn := e.nodeCommunicator.CallAvailableNode(
+		execNodes,
+		func(node *flow.IdentitySkeleton) error {
+			var err error
+			start := time.Now()
+
+			resp, err = e.tryGetAccount(ctx, node, req)
+			duration := time.Since(start)
+
+			lg := e.log.With().
+				Str("execution_node", node.String()).
+				Hex("block_id", req.GetBlockId()).
+				Hex("address", req.GetAddress()).
+				Int64("rtt_ms", duration.Milliseconds()).
+				Logger()
+
+			if err != nil {
+				lg.Err(err).Msg("failed to execute GetAccount")
+				return err
+			}
+
+			// return if any execution node replied successfully
+			lg.Debug().Msg("Successfully got account info")
+			return nil
+		},
+		nil,
+	)
+
+	if errToReturn != nil {
+		return nil, rpc.ConvertError(errToReturn, "failed to get account from the execution node", codes.Internal)
+	}
+
+	account, err := convert.MessageToAccount(resp.GetAccount())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to convert account message: %v", err)
+	}
+
+	return account, nil
+}
+
+func (e *ExecutionNode) GetAccountBalanceAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+) (uint64, error) {
+	sealed, err := e.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return 0, err
+	}
+
+	sealedBlockID := sealed.ID()
+	account, err := e.GetAccountAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		e.log.Debug().Err(err).Msgf("failed to get account at blockID: %v", sealedBlockID)
+		return 0, err
+	}
+
+	return account.Balance, nil
+}
+
+func (e *ExecutionNode) GetAccountBalanceAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	blockID flow.Identifier,
+	height uint64,
+) (uint64, error) {
+	account, err := e.GetAccountAtBlockHeight(ctx, address, blockID, height)
+	if err != nil {
+		return 0, err
+	}
+
+	return account.Balance, nil
+}
+
+func (e *ExecutionNode) GetAccountKeyAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+	keyIndex uint32,
+) (*flow.AccountPublicKey, error) {
+	sealed, err := e.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	account, err := e.GetAccountAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range account.Keys {
+		if key.Index == keyIndex {
+			return &key, nil
+		}
+	}
+
+	return nil, status.Errorf(codes.NotFound, "failed to get account key by index: %d", keyIndex)
+}
+
+func (e *ExecutionNode) GetAccountKeyAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	keyIndex uint32,
+	blockID flow.Identifier,
+	height uint64,
+) (*flow.AccountPublicKey, error) {
+	account, err := e.GetAccountAtBlockHeight(ctx, address, blockID, height)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range account.Keys {
+		if key.Index == keyIndex {
+			return &key, nil
+		}
+	}
+
+	return nil, status.Errorf(codes.NotFound, "failed to get account key by index: %d", keyIndex)
+}
+
+func (e *ExecutionNode) GetAccountKeysAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+) ([]flow.AccountPublicKey, error) {
+	sealed, err := e.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	account, err := e.GetAccountAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		e.log.Debug().Err(err).Msgf("failed to get account keys at blockID: %v", sealedBlockID)
+		return nil, err
+	}
+
+	return account.Keys, nil
+}
+
+func (e *ExecutionNode) GetAccountKeysAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	blockID flow.Identifier,
+	height uint64,
+) ([]flow.AccountPublicKey, error) {
+	account, err := e.GetAccountAtBlockHeight(ctx, address, blockID, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return account.Keys, nil
+}
+
+// tryGetAccount attempts to get the account from the given execution node.
+func (e *ExecutionNode) tryGetAccount(
+	ctx context.Context,
+	execNode *flow.IdentitySkeleton,
+	req *execproto.GetAccountAtBlockIDRequest,
+) (*execproto.GetAccountAtBlockIDResponse, error) {
+	execRPCClient, closer, err := e.connFactory.GetExecutionAPIClient(execNode.Address)
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+
+	return execRPCClient.GetAccountAtBlockID(ctx, req)
+}

--- a/engine/access/rpc/backend/accounts/handler/failover.go
+++ b/engine/access/rpc/backend/accounts/handler/failover.go
@@ -1,0 +1,321 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/state/protocol"
+)
+
+type Failover struct {
+	log               zerolog.Logger
+	state             protocol.State
+	localRequester    Handler
+	execNodeRequester Handler
+}
+
+var _ Handler = (*Failover)(nil)
+
+func NewFailoverHandler(
+	log zerolog.Logger,
+	state protocol.State,
+	localRequester Handler,
+	execNodeRequester Handler,
+) *Failover {
+	return &Failover{
+		log:               log,
+		state:             state,
+		localRequester:    localRequester,
+		execNodeRequester: execNodeRequester,
+	}
+}
+
+func (f *Failover) GetAccount(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	return f.GetAccountAtLatestBlock(ctx, address)
+}
+
+func (f *Failover) GetAccountAtLatestBlock(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	sealed, err := f.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	account, err := f.GetAccountAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		f.log.Debug().Err(err).Msgf("failed to get account at latest block")
+		return nil, err
+	}
+
+	return account, nil
+}
+
+func (f *Failover) GetAccountAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	blockID flow.Identifier,
+	_ uint64, //TODO: fix ALL places with unused arguments
+) (*flow.Account, error) {
+	localAccount, localErr := f.localRequester.GetAccount(ctx, address)
+	if localErr == nil {
+		return localAccount, nil
+	}
+
+	ENAccount, ENErr := f.execNodeRequester.GetAccount(ctx, address)
+
+	//TODO: should we call this in this handler?
+	// It is supposed to be called only in handler.Compare handler, isn't it?
+	f.compareAccountResults(ENAccount, ENErr, localAccount, localErr, blockID, address)
+
+	return ENAccount, ENErr
+}
+
+func (f *Failover) GetAccountBalanceAtLatestBlock(ctx context.Context, address flow.Address) (uint64, error) {
+	sealed, err := f.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return 0, err
+	}
+
+	sealedBlockID := sealed.ID()
+	balance, err := f.GetAccountBalanceAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		f.log.Debug().Err(err).Msgf("failed to get account balance at latest block")
+		return 0, err
+	}
+
+	return balance, nil
+}
+
+func (f *Failover) GetAccountBalanceAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	blockID flow.Identifier,
+	height uint64,
+) (uint64, error) {
+	localBalance, localErr := f.localRequester.GetAccountBalanceAtBlockHeight(ctx, address, blockID, height)
+	if localErr == nil {
+		return localBalance, nil
+	}
+
+	ENBalance, ENErr := f.execNodeRequester.GetAccountBalanceAtBlockHeight(ctx, address, blockID, height)
+	if ENErr != nil {
+		return 0, ENErr
+	}
+
+	return ENBalance, nil
+}
+
+func (f *Failover) GetAccountKeyAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+	keyIndex uint32,
+) (*flow.AccountPublicKey, error) {
+	sealed, err := f.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	key, err := f.GetAccountKeyAtBlockHeight(ctx, address, keyIndex, sealedBlockID, sealed.Height)
+	if err != nil {
+		f.log.Debug().Err(err).Msgf("failed to get account key at latest block")
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func (f *Failover) GetAccountKeyAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	keyIndex uint32,
+	blockID flow.Identifier,
+	height uint64,
+) (*flow.AccountPublicKey, error) {
+	localKey, localErr := f.localRequester.GetAccountKeyAtBlockHeight(ctx, address, keyIndex, blockID, height)
+	if localErr == nil {
+		return localKey, nil
+	}
+
+	ENKey, ENErr := f.execNodeRequester.GetAccountKeyAtBlockHeight(ctx, address, keyIndex, blockID, height)
+	if ENErr != nil {
+		return nil, ENErr
+	}
+
+	return ENKey, nil
+}
+
+func (f *Failover) GetAccountKeysAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+) ([]flow.AccountPublicKey, error) {
+	sealed, err := f.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	keys, err := f.GetAccountKeysAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		f.log.Debug().Err(err).Msgf("failed to get account keys at latest block")
+		return nil, err
+	}
+
+	return keys, nil
+}
+
+func (f *Failover) GetAccountKeysAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	blockID flow.Identifier,
+	height uint64,
+) ([]flow.AccountPublicKey, error) {
+	localKeys, localErr := f.localRequester.GetAccountKeysAtBlockHeight(ctx, address, blockID, height)
+	if localErr == nil {
+		return localKeys, nil
+	}
+
+	ENKeys, ENErr := f.execNodeRequester.GetAccountKeysAtBlockHeight(ctx, address, blockID, height)
+	if ENErr != nil {
+		return nil, ENErr
+	}
+
+	return ENKeys, nil
+}
+
+// compareAccountResults compares the result and error returned from local and remote getAccount calls
+// and logs the results if they are different
+func (f *Failover) compareAccountResults(
+	execNodeResult *flow.Account,
+	execErr error,
+	localResult *flow.Account,
+	localErr error,
+	blockID flow.Identifier,
+	address flow.Address,
+) {
+	if f.log.GetLevel() > zerolog.DebugLevel {
+		return
+	}
+
+	lgCtx := f.log.With().
+		Hex("block_id", blockID[:]).
+		Str("address", address.String())
+
+	// errors are different
+	if !errors.Is(execErr, localErr) {
+		lgCtx = lgCtx.
+			AnErr("execution_node_error", execErr).
+			AnErr("local_error", localErr)
+
+		lg := lgCtx.Logger()
+		lg.Debug().Msg("errors from getting account on local and EN do not match")
+		return
+	}
+
+	// both errors are nil, compare the accounts
+	if execErr == nil {
+		lgCtx, ok := compareAccountsLogger(execNodeResult, localResult, lgCtx)
+		if !ok {
+			lg := lgCtx.Logger()
+			lg.Debug().Msg("accounts from local and EN do not match")
+		}
+	}
+}
+
+// compareAccountsLogger compares accounts produced by the execution node and local storage and
+// return a logger configured to log the differences
+func compareAccountsLogger(exec, local *flow.Account, lgCtx zerolog.Context) (zerolog.Context, bool) {
+	different := false
+
+	if exec.Address != local.Address {
+		lgCtx = lgCtx.
+			Str("exec_node_address", exec.Address.String()).
+			Str("local_address", local.Address.String())
+		different = true
+	}
+
+	if exec.Balance != local.Balance {
+		lgCtx = lgCtx.
+			Uint64("exec_node_balance", exec.Balance).
+			Uint64("local_balance", local.Balance)
+		different = true
+	}
+
+	contractListMatches := true
+	if len(exec.Contracts) != len(local.Contracts) {
+		lgCtx = lgCtx.
+			Int("exec_node_contract_count", len(exec.Contracts)).
+			Int("local_contract_count", len(local.Contracts))
+		contractListMatches = false
+		different = true
+	}
+
+	missingContracts := zerolog.Arr()
+	mismatchContracts := zerolog.Arr()
+
+	for name, execContract := range exec.Contracts {
+		localContract, ok := local.Contracts[name]
+
+		if !ok {
+			missingContracts.Str(name)
+			contractListMatches = false
+			different = true
+		}
+
+		if !bytes.Equal(execContract, localContract) {
+			mismatchContracts.Str(name)
+			different = true
+		}
+	}
+
+	lgCtx = lgCtx.
+		Array("missing_contracts", missingContracts).
+		Array("mismatch_contracts", mismatchContracts)
+
+	// only check if there were any missing
+	if !contractListMatches {
+		extraContracts := zerolog.Arr()
+		for name := range local.Contracts {
+			if _, ok := exec.Contracts[name]; !ok {
+				extraContracts.Str(name)
+				different = true
+			}
+		}
+		lgCtx = lgCtx.Array("extra_contracts", extraContracts)
+	}
+
+	if len(exec.Keys) != len(local.Keys) {
+		lgCtx = lgCtx.
+			Int("exec_node_key_count", len(exec.Keys)).
+			Int("local_key_count", len(local.Keys))
+		different = true
+	}
+
+	mismatchKeys := zerolog.Arr()
+
+	for i, execKey := range exec.Keys {
+		localKey := local.Keys[i]
+
+		if !execKey.PublicKey.Equals(localKey.PublicKey) {
+			mismatchKeys.Uint32(execKey.Index)
+			different = true
+		}
+	}
+
+	lgCtx = lgCtx.Array("mismatch_keys", mismatchKeys)
+
+	return lgCtx, !different
+}

--- a/engine/access/rpc/backend/accounts/handler/handler.go
+++ b/engine/access/rpc/backend/accounts/handler/handler.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+//TODO: consider better naming: Resolver (GQL style), Handler (RESTful style), etc.
+
+type Handler interface {
+	GetAccount(ctx context.Context, address flow.Address) (*flow.Account, error)
+	GetAccountAtLatestBlock(ctx context.Context, address flow.Address) (*flow.Account, error)
+	GetAccountAtBlockHeight(ctx context.Context, address flow.Address, blockID flow.Identifier, height uint64) (*flow.Account, error)
+
+	GetAccountBalanceAtLatestBlock(ctx context.Context, address flow.Address) (uint64, error)
+	GetAccountBalanceAtBlockHeight(ctx context.Context, address flow.Address, blockID flow.Identifier, height uint64) (uint64, error)
+
+	GetAccountKeyAtLatestBlock(ctx context.Context, address flow.Address, keyIndex uint32) (*flow.AccountPublicKey, error)
+	GetAccountKeyAtBlockHeight(ctx context.Context, address flow.Address, keyIndex uint32, blockID flow.Identifier, height uint64) (*flow.AccountPublicKey, error)
+
+	GetAccountKeysAtLatestBlock(ctx context.Context, address flow.Address) ([]flow.AccountPublicKey, error)
+	GetAccountKeysAtBlockHeight(ctx context.Context, address flow.Address, blockID flow.Identifier, height uint64) ([]flow.AccountPublicKey, error)
+}
+
+//TODO: maybe we'll need some CommonRequester type which can be 'inherited' from to reduce code duplication

--- a/engine/access/rpc/backend/accounts/handler/local.go
+++ b/engine/access/rpc/backend/accounts/handler/local.go
@@ -1,0 +1,199 @@
+package handler
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/onflow/flow-go/engine/access/rpc/backend"
+	"github.com/onflow/flow-go/engine/common/rpc"
+	fvmerrors "github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/module/execution"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/state/protocol"
+	"github.com/onflow/flow-go/storage"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+type Local struct {
+	log            zerolog.Logger
+	state          protocol.State
+	scriptExecutor execution.ScriptExecutor
+}
+
+var _ Handler = (*Local)(nil)
+
+func NewLocalHandler(
+	log zerolog.Logger,
+	state protocol.State,
+	scriptExecutor execution.ScriptExecutor,
+) *Local {
+	return &Local{
+		log:            log,
+		state:          state,
+		scriptExecutor: scriptExecutor,
+	}
+}
+
+func (l *Local) GetAccount(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	return l.GetAccountAtLatestBlock(ctx, address)
+}
+
+func (l *Local) GetAccountAtLatestBlock(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	sealed, err := l.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	account, err := l.GetAccountAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		l.log.Debug().Err(err).Msgf("failed to get account at blockID: %v", sealedBlockID)
+		return nil, err
+	}
+
+	return account, nil
+}
+
+func (l *Local) GetAccountAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	_ flow.Identifier,
+	height uint64,
+) (*flow.Account, error) {
+	account, err := l.scriptExecutor.GetAccountAtBlockHeight(ctx, address, height)
+	if err != nil {
+		return nil, convertAccountError(backend.ResolveHeightError(l.state.Params(), height, err), address, height)
+	}
+	return account, nil
+}
+
+func (l *Local) GetAccountBalanceAtLatestBlock(ctx context.Context, address flow.Address) (uint64, error) {
+	sealed, err := l.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return 0, err
+	}
+
+	sealedBlockID := sealed.ID()
+	balance, err := l.GetAccountBalanceAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		l.log.Debug().Err(err).Msgf("failed to get account at blockID: %v", sealedBlockID)
+		return 0, err
+	}
+
+	return balance, nil
+}
+
+func (l *Local) GetAccountBalanceAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	blockID flow.Identifier,
+	height uint64,
+) (uint64, error) {
+	accountBalance, err := l.scriptExecutor.GetAccountBalance(ctx, address, height)
+	if err != nil {
+		l.log.Debug().Err(err).Msgf("failed to get account balance at blockID: %v", blockID)
+		return 0, err
+	}
+
+	return accountBalance, nil
+}
+
+func (l *Local) GetAccountKeyAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+	keyIndex uint32,
+) (*flow.AccountPublicKey, error) {
+	sealed, err := l.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	key, err := l.GetAccountKeyAtBlockHeight(ctx, address, keyIndex, sealedBlockID, sealed.Height)
+	if err != nil {
+		l.log.Debug().Err(err).Msgf("failed to get account key at blockID: %v", sealedBlockID)
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func (l *Local) GetAccountKeyAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	keyIndex uint32,
+	_ flow.Identifier,
+	height uint64,
+) (*flow.AccountPublicKey, error) {
+	accountKey, err := l.scriptExecutor.GetAccountKey(ctx, address, keyIndex, height)
+	if err != nil {
+		l.log.Debug().Err(err).Msgf("failed to get account key at height: %d", height)
+		return nil, err
+	}
+
+	return accountKey, nil
+}
+
+func (l *Local) GetAccountKeysAtLatestBlock(
+	ctx context.Context,
+	address flow.Address,
+) ([]flow.AccountPublicKey, error) {
+	sealed, err := l.state.Sealed().Head()
+	if err != nil {
+		err := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
+	}
+
+	sealedBlockID := sealed.ID()
+	keys, err := l.GetAccountKeysAtBlockHeight(ctx, address, sealedBlockID, sealed.Height)
+	if err != nil {
+		l.log.Debug().Err(err).Msgf("failed to get account keys at blockID: %v", sealedBlockID)
+		return nil, err
+	}
+
+	return keys, nil
+}
+
+func (l *Local) GetAccountKeysAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	_ flow.Identifier,
+	height uint64,
+) ([]flow.AccountPublicKey, error) {
+	accountKeys, err := l.scriptExecutor.GetAccountKeys(ctx, address, height)
+	if err != nil {
+		l.log.Debug().Err(err).Msgf("failed to get account keys at height: %d", height)
+		return nil, err
+	}
+
+	return accountKeys, nil
+}
+
+// convertAccountError converts the script execution error to a gRPC error
+func convertAccountError(err error, address flow.Address, height uint64) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, storage.ErrNotFound) {
+		return status.Errorf(codes.NotFound, "account with address %s not found: %v", address, err)
+	}
+
+	if fvmerrors.IsAccountNotFoundError(err) {
+		return status.Errorf(codes.NotFound, "account not found")
+	}
+
+	return rpc.ConvertIndexError(err, height, "failed to get account")
+}

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -376,7 +376,7 @@ func (b *Backend) GetNetworkParameters(_ context.Context) accessmodel.NetworkPar
 	}
 }
 
-// resolveHeightError processes errors returned during height-based queries.
+// ResolveHeightError processes errors returned during height-based queries.
 // If the error is due to a block not being found, this function determines whether the queried
 // height falls outside the node's accessible range and provides context-sensitive error messages
 // based on spork and node root block heights.
@@ -388,7 +388,7 @@ func (b *Backend) GetNetworkParameters(_ context.Context) accessmodel.NetworkPar
 //
 // Expected errors during normal operation:
 // - storage.ErrNotFound - Indicates that the queried block does not exist in the local database.
-func resolveHeightError(
+func ResolveHeightError(
 	stateParams protocol.Params,
 	height uint64,
 	genericErr error,

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -69,7 +69,7 @@ func (b *backendAccounts) GetAccountAtBlockHeight(
 ) (*flow.Account, error) {
 	blockID, err := b.headers.BlockIDByHeight(height)
 	if err != nil {
-		return nil, rpc.ConvertStorageError(resolveHeightError(b.state.Params(), height, err))
+		return nil, rpc.ConvertStorageError(ResolveHeightError(b.state.Params(), height, err))
 	}
 
 	account, err := b.getAccountAtBlock(ctx, address, blockID, height)
@@ -109,7 +109,7 @@ func (b *backendAccounts) GetAccountBalanceAtBlockHeight(
 ) (uint64, error) {
 	blockID, err := b.headers.BlockIDByHeight(height)
 	if err != nil {
-		return 0, rpc.ConvertStorageError(resolveHeightError(b.state.Params(), height, err))
+		return 0, rpc.ConvertStorageError(ResolveHeightError(b.state.Params(), height, err))
 	}
 
 	balance, err := b.getAccountBalanceAtBlock(ctx, address, blockID, height)
@@ -177,7 +177,7 @@ func (b *backendAccounts) GetAccountKeyAtBlockHeight(
 ) (*flow.AccountPublicKey, error) {
 	blockID, err := b.headers.BlockIDByHeight(height)
 	if err != nil {
-		return nil, rpc.ConvertStorageError(resolveHeightError(b.state.Params(), height, err))
+		return nil, rpc.ConvertStorageError(ResolveHeightError(b.state.Params(), height, err))
 	}
 
 	accountKey, err := b.getAccountKeyAtBlock(ctx, address, keyIndex, blockID, height)
@@ -197,7 +197,7 @@ func (b *backendAccounts) GetAccountKeysAtBlockHeight(
 ) ([]flow.AccountPublicKey, error) {
 	blockID, err := b.headers.BlockIDByHeight(height)
 	if err != nil {
-		return nil, rpc.ConvertStorageError(resolveHeightError(b.state.Params(), height, err))
+		return nil, rpc.ConvertStorageError(ResolveHeightError(b.state.Params(), height, err))
 	}
 
 	accountKeys, err := b.getAccountKeysAtBlock(ctx, address, blockID, height)
@@ -401,7 +401,7 @@ func (b *backendAccounts) getAccountFromLocalStorage(
 	// make sure data is available for the requested block
 	account, err := b.scriptExecutor.GetAccountAtBlockHeight(ctx, address, height)
 	if err != nil {
-		return nil, convertAccountError(resolveHeightError(b.state.Params(), height, err), address, height)
+		return nil, convertAccountError(ResolveHeightError(b.state.Params(), height, err), address, height)
 	}
 	return account, nil
 }
@@ -503,7 +503,7 @@ func (b *backendAccounts) compareAccountResults(
 		Str("address", address.String())
 
 	// errors are different
-	if execErr != localErr {
+	if !errors.Is(execErr, localErr) {
 		lgCtx = lgCtx.
 			AnErr("execution_node_error", execErr).
 			AnErr("local_error", localErr)

--- a/engine/access/rpc/backend/backend_block_details.go
+++ b/engine/access/rpc/backend/backend_block_details.go
@@ -80,7 +80,7 @@ func (b *backendBlockDetails) GetBlockByID(ctx context.Context, id flow.Identifi
 func (b *backendBlockDetails) GetBlockByHeight(ctx context.Context, height uint64) (*flow.Block, flow.BlockStatus, error) {
 	block, err := b.blocks.ByHeight(height)
 	if err != nil {
-		return nil, flow.BlockStatusUnknown, rpc.ConvertStorageError(resolveHeightError(b.state.Params(), height, err))
+		return nil, flow.BlockStatusUnknown, rpc.ConvertStorageError(ResolveHeightError(b.state.Params(), height, err))
 	}
 
 	stat, err := b.getBlockStatus(ctx, block)

--- a/engine/access/rpc/backend/backend_block_headers.go
+++ b/engine/access/rpc/backend/backend_block_headers.go
@@ -69,7 +69,7 @@ func (b *backendBlockHeaders) GetBlockHeaderByID(ctx context.Context, id flow.Id
 func (b *backendBlockHeaders) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.Header, flow.BlockStatus, error) {
 	header, err := b.headers.ByHeight(height)
 	if err != nil {
-		return nil, flow.BlockStatusUnknown, rpc.ConvertStorageError(resolveHeightError(b.state.Params(), height, err))
+		return nil, flow.BlockStatusUnknown, rpc.ConvertStorageError(ResolveHeightError(b.state.Params(), height, err))
 	}
 
 	stat, err := b.getBlockStatus(ctx, header)

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -104,7 +104,7 @@ func (b *backendEvents) GetEventsForHeightRange(
 		// and avoids calculating header.ID() for each block.
 		blockID, err := b.headers.BlockIDByHeight(i)
 		if err != nil {
-			return nil, rpc.ConvertStorageError(resolveHeightError(b.state.Params(), i, err))
+			return nil, rpc.ConvertStorageError(ResolveHeightError(b.state.Params(), i, err))
 		}
 		header, err := b.headers.ByBlockID(blockID)
 		if err != nil {

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -105,7 +105,7 @@ func (b *backendScripts) ExecuteScriptAtBlockHeight(
 ) ([]byte, error) {
 	header, err := b.headers.ByHeight(blockHeight)
 	if err != nil {
-		return nil, rpc.ConvertStorageError(resolveHeightError(b.state.Params(), blockHeight, err))
+		return nil, rpc.ConvertStorageError(ResolveHeightError(b.state.Params(), blockHeight, err))
 	}
 
 	return b.executeScript(ctx, newScriptExecutionRequest(header.ID(), blockHeight, script, arguments))

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -2036,9 +2036,9 @@ func (suite *Suite) defaultBackendParams() Params {
 	}
 }
 
-// TestResolveHeightError tests the resolveHeightError function for various scenarios where the block height
+// TestResolveHeightError tests the ResolveHeightError function for various scenarios where the block height
 // is below the spork root height, below the node root height, above the node root height, or when a different
-// error is provided. It validates that resolveHeightError returns an appropriate error message for each case.
+// error is provided. It validates that ResolveHeightError returns an appropriate error message for each case.
 //
 // Test cases:
 // 1) If height is below the spork root height, it suggests using a historic node.
@@ -2101,7 +2101,7 @@ func (suite *Suite) TestResolveHeightError() {
 				stateParams.On("SealedRoot").Return(sealedRootHeader, nil).Once()
 			}
 
-			err := resolveHeightError(stateParams, test.height, test.genericErr)
+			err := ResolveHeightError(stateParams, test.height, test.genericErr)
 
 			if test.expectOriginalErr {
 				suite.Assert().True(errors.Is(err, test.genericErr))


### PR DESCRIPTION
Closes #7547 

Created new package for `accounts`. From now on, we will use the strategy design pattern to get rid of switching over query mode every time and split up the logic related to different query modes into different files