### PR TITLE
[Storage] Optimize IterateKeys by creating processing funcs outside of loop

### DIFF
--- a/storage/operation/reads.go
+++ b/storage/operation/reads.go
@@ -77,12 +77,12 @@ func IterateKeys(r storage.Reader, startPrefix []byte, endPrefix []byte, iterFun
 		errToReturn = merr.CloseAndMergeError(it, errToReturn)
 	}()
 
+	// Initialize processing functions for iteration
+	check, create, handle := iterFunc()
+
 	for it.First(); it.Valid(); it.Next() {
 		item := it.IterItem()
 		key := item.Key()
-
-		// initialize processing functions for iteration
-		check, create, handle := iterFunc()
 
 		keyCopy := make([]byte, len(key))
 


### PR DESCRIPTION
Currently, processing functions are initialized inside an iteration loop.

This PR optimizes this by initializing processing functions outside the loop, so the closures are created just once instead of being created repeatedly for:

```Go
  check, create, handle := iterFunc() 
```
