### PR TITLE
[Malleability] Removing PayloadHash from HotStuff model.Block

### DIFF
--- a/consensus/hotstuff/forks/block_builder_test.go
+++ b/consensus/hotstuff/forks/block_builder_test.go
@@ -94,16 +94,14 @@ func (bb *BlockBuilder) Proposals() ([]*model.Proposal, error) {
 		if !ok {
 			return nil, fmt.Errorf("test fail: no qc found for qc index: %v", bv.QCIndex())
 		}
-		payloadHash := makePayloadHash(bv.View, qc, bv.BlockVersion)
 		var lastViewTC *flow.TimeoutCertificate
 		if qc.View+1 != bv.View {
 			lastViewTC = helper.MakeTC(helper.WithTCView(bv.View - 1))
 		}
 		proposal := &model.Proposal{
 			Block: &model.Block{
-				View:        bv.View,
-				QC:          qc,
-				PayloadHash: payloadHash,
+				View: bv.View,
+				QC:   qc,
 			},
 			LastViewTC: lastViewTC,
 		}
@@ -133,27 +131,13 @@ func (bb *BlockBuilder) Blocks() ([]*model.Block, error) {
 	return toBlocks(proposals), nil
 }
 
-func makePayloadHash(view uint64, qc *flow.QuorumCertificate, blockVersion int) flow.Identifier {
-	return flow.MakeID(struct {
-		View         uint64
-		QC           *flow.QuorumCertificate
-		BlockVersion uint64
-	}{
-		View:         view,
-		QC:           qc,
-		BlockVersion: uint64(blockVersion),
-	})
-}
-
 func makeBlockID(block *model.Block) flow.Identifier {
 	return flow.MakeID(struct {
-		View        uint64
-		QC          *flow.QuorumCertificate
-		PayloadHash flow.Identifier
+		View uint64
+		QC   *flow.QuorumCertificate
 	}{
-		View:        block.View,
-		QC:          block.QC,
-		PayloadHash: block.PayloadHash,
+		View: block.View,
+		QC:   block.QC,
 	})
 }
 

--- a/consensus/hotstuff/helper/block.go
+++ b/consensus/hotstuff/helper/block.go
@@ -12,12 +12,11 @@ import (
 func MakeBlock(options ...func(*model.Block)) *model.Block {
 	view := rand.Uint64()
 	block := model.Block{
-		View:        view,
-		BlockID:     unittest.IdentifierFixture(),
-		PayloadHash: unittest.IdentifierFixture(),
-		ProposerID:  unittest.IdentifierFixture(),
-		Timestamp:   time.Now().UTC(),
-		QC:          MakeQC(WithQCView(view - 1)),
+		View:       view,
+		BlockID:    unittest.IdentifierFixture(),
+		ProposerID: unittest.IdentifierFixture(),
+		Timestamp:  time.Now().UTC(),
+		QC:         MakeQC(WithQCView(view - 1)),
 	}
 	for _, option := range options {
 		option(&block)
@@ -122,7 +121,6 @@ func SignedProposalToFlow(proposal *model.SignedProposal) *flow.ProposalHeader {
 			ProposerID:         block.ProposerID,
 			LastViewTC:         proposal.LastViewTC,
 		},
-		PayloadHash: block.PayloadHash,
 	}
 
 	return &flow.ProposalHeader{

--- a/consensus/hotstuff/model/block.go
+++ b/consensus/hotstuff/model/block.go
@@ -10,23 +10,21 @@ import (
 // Block is the HotStuff algorithm's concept of a block, which - in the bigger picture - corresponds
 // to the block header.
 type Block struct {
-	View        uint64
-	BlockID     flow.Identifier
-	ProposerID  flow.Identifier
-	QC          *flow.QuorumCertificate
-	PayloadHash flow.Identifier
-	Timestamp   time.Time
+	View       uint64
+	BlockID    flow.Identifier
+	ProposerID flow.Identifier
+	QC         *flow.QuorumCertificate
+	Timestamp  time.Time
 }
 
 // BlockFromFlow converts a flow header to a hotstuff block.
 func BlockFromFlow(header *flow.Header) *Block {
 	block := Block{
-		BlockID:     header.ID(),
-		View:        header.View,
-		QC:          header.QuorumCertificate(),
-		ProposerID:  header.ProposerID,
-		PayloadHash: header.PayloadHash,
-		Timestamp:   header.Timestamp,
+		BlockID:    header.ID(),
+		View:       header.View,
+		QC:         header.QuorumCertificate(),
+		ProposerID: header.ProposerID,
+		Timestamp:  header.Timestamp,
 	}
 
 	return &block
@@ -36,12 +34,11 @@ func BlockFromFlow(header *flow.Header) *Block {
 // block based on the given header.
 func GenesisBlockFromFlow(header *flow.Header) *Block {
 	genesis := &Block{
-		BlockID:     header.ID(),
-		View:        header.View,
-		ProposerID:  header.ProposerID,
-		QC:          nil,
-		PayloadHash: header.PayloadHash,
-		Timestamp:   header.Timestamp,
+		BlockID:    header.ID(),
+		View:       header.View,
+		ProposerID: header.ProposerID,
+		QC:         nil,
+		Timestamp:  header.Timestamp,
 	}
 	return genesis
 }

--- a/consensus/hotstuff/notifications/log_consumer.go
+++ b/consensus/hotstuff/notifications/log_consumer.go
@@ -231,7 +231,6 @@ func (lc *LogConsumer) logBasicBlockData(loggerEvent *zerolog.Event, block *mode
 		Uint64("block_view", block.View).
 		Hex("block_id", logging.ID(block.BlockID)).
 		Hex("proposer_id", logging.ID(block.ProposerID)).
-		Hex("payload_hash", logging.ID(block.PayloadHash)).
 		Uint64("qc_view", block.QC.View).
 		Hex("qc_block_id", logging.ID(block.QC.BlockID))
 

--- a/consensus/hotstuff/notifications/slashing_violation_consumer.go
+++ b/consensus/hotstuff/notifications/slashing_violation_consumer.go
@@ -32,7 +32,6 @@ func (c *SlashingViolationsConsumer) OnInvalidBlockDetected(err flow.Slashable[m
 		Hex("proposer_id", block.ProposerID[:]).
 		Uint64("block_view", block.View).
 		Hex("block_id", block.BlockID[:]).
-		Hex("block_payloadhash", block.PayloadHash[:]).
 		Time("block_timestamp", block.Timestamp).
 		Msgf("OnInvalidBlockDetected: %s", err.Message.Error())
 }

--- a/consensus/participant.go
+++ b/consensus/participant.go
@@ -186,12 +186,11 @@ func makeCertifiedRootBlock(header *flow.Header, qc *flow.QuorumCertificate) (mo
 	// instead of having to distinguish between a genesis block without a qc
 	// and a later-finalized root block where we can retrieve the qc.
 	rootBlock := &model.Block{
-		View:        header.View,
-		BlockID:     header.ID(),
-		ProposerID:  header.ProposerID,
-		QC:          nil, // QC is omitted
-		PayloadHash: header.PayloadHash,
-		Timestamp:   header.Timestamp,
+		View:       header.View,
+		BlockID:    header.ID(),
+		ProposerID: header.ProposerID,
+		QC:         nil, // QC is omitted
+		Timestamp:  header.Timestamp,
 	}
 	return model.NewCertifiedBlock(rootBlock, qc)
 }


### PR DESCRIPTION
Issue: #7311 (Low priority)

## Context

> - [ ]  I think the field `PayloadHash` in the HotStuff representation of a block can be removed. Its only usage is printing the value in a few logs and I don't think we ever really used this value from the logs. Hence, I think it is safe to be removed. 

## Changes
- Removed `PayloadHash` field from HotStuff `model.Block`.
- Updated tests and usages.