### PR TITLE
Add support for promoting images to partner registry

### DIFF
--- a/.github/workflows/image_builds.yml
+++ b/.github/workflows/image_builds.yml
@@ -164,6 +164,7 @@ jobs:
           role: ${{ matrix.role }} 
           tags: "${{ inputs.tag }},${{ inputs.tag }}-without-adx,${{ inputs.tag }}-without-netgo-without-adx,${{ inputs.tag }}-arm"
 
+  promote-to-public-registry:
     # This job promotes container images for various roles from a private registry to a public registry.
     # It uses a matrix strategy to handle the promotion of images for different roles in parallel.
     # The environments defined for each role are used to gate the promotion process.

--- a/.github/workflows/image_builds.yml
+++ b/.github/workflows/image_builds.yml
@@ -131,7 +131,39 @@ jobs:
           ref: master-private 
           workflow_file_name: 'secure_build.yml'
 
-  promote-images:
+  promote-to-partner-registry:
+    # This job promotes container images from the private registry to the partner registry.
+    # As of right now, the only role being promoted to the partner registry is 'access'.
+    # It uses a matrix strategy to handle the promotion of images for different roles in parallel.
+    # The environments defined for each role are used to gate the promotion process.
+    # This ensures that only approved images are deployed to the partner registry.
+    name: Promote Images to Partner Registry
+    runs-on: ubuntu-latest
+    needs: [public-build, secure-build]
+    # This job will only run if the previous jobs were successful and not cancelled.
+    # It checks the results of both the public and secure builds to ensure that at least one of them succeeded.
+    if: |
+      ${{ !cancelled() }} &&
+      ${{ needs.public-build.result != 'failure' || needs.secure-build.result != 'failure' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        role: [access]
+    environment: ${{ matrix.role }} image promotion to partner registry 
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Promote ${{ matrix.role }} 
+        uses: ./actions/promote-images
+        with:
+          gcp_credentials: ${{ secrets.PARTNER_REGISTRY_PROMOTION_SECRET }}
+          private_registry: ${{ vars.PRIVATE_REGISTRY }}
+          private_registry_host: ${{ env.PRIVATE_REGISTRY_HOST }}
+          promotion_registry: ${{ vars.PARTNER_REGISTRY }}
+          role: ${{ matrix.role }} 
+          tags: "${{ inputs.tag }},${{ inputs.tag }}-without-adx,${{ inputs.tag }}-without-netgo-without-adx,${{ inputs.tag }}-arm"
+
     # This job promotes container images for various roles from a private registry to a public registry.
     # It uses a matrix strategy to handle the promotion of images for different roles in parallel.
     # The environments defined for each role are used to gate the promotion process.

--- a/.github/workflows/image_builds.yml
+++ b/.github/workflows/image_builds.yml
@@ -192,7 +192,7 @@ jobs:
           gcp_credentials: ${{ secrets.PUBLIC_REGISTRY_PROMOTION_SECRET }}
           private_registry: ${{ vars.PRIVATE_REGISTRY }}
           private_registry_host: ${{ env.PRIVATE_REGISTRY_HOST }}
-          public_registry: ${{ vars.PUBLIC_REGISTRY }}
+          promotion_registry: ${{ vars.PUBLIC_REGISTRY }}
           role: ${{ matrix.role }} 
           tags: "${{ inputs.tag }},${{ inputs.tag }}-without-adx,${{ inputs.tag }}-without-netgo-without-adx,${{ inputs.tag }}-arm"
 

--- a/actions/promote-images/action.yml
+++ b/actions/promote-images/action.yml
@@ -1,5 +1,5 @@
-name: Promote Image to Public Registry
-description: Pull image from private registry and push to public registry
+name: Promote Image to another Registry
+description: Pull image from private registry and push to another registry
 
 inputs:
   gcp_credentials:
@@ -11,8 +11,8 @@ inputs:
   private_registry_host:
     description: 'Private Google Artifact Registry hostname'
     required: true
-  public_registry:
-    description: 'Public container registry URL'
+  promotion_registry:
+    description: 'Registry to promote images to'
     required: true
   role:
     description: 'Role to promote'
@@ -43,29 +43,29 @@ runs:
         # Convert comma-separated tags input into an array
         IFS=',' read -ra TAGS <<< "${{ inputs.tags }}"
 
-        # Loop through each tag and pull the image from the private registry, then tag it for the public registry
+        # Loop through each tag and pull the image from the private registry, then tag it for the registry to promote to 
         for TAG in "${TAGS[@]}"; do
           IMAGE_PRIVATE="${{ inputs.private_registry }}/${{ inputs.role }}:${TAG}"
-          IMAGE_PUBLIC="${{ inputs.public_registry }}/${{ inputs.role }}:${TAG}"
-          echo "Processing ${IMAGE_PRIVATE} -> ${IMAGE_PUBLIC}"
+          IMAGE_PROMOTION="${{ inputs.promotion_registry }}/${{ inputs.role }}:${TAG}"
+          echo "Processing ${IMAGE_PRIVATE} -> ${IMAGE_PROMOTION}"
           docker pull "${IMAGE_PRIVATE}"
-          docker tag "${IMAGE_PRIVATE}" "${IMAGE_PUBLIC}"
+          docker tag "${IMAGE_PRIVATE}" "${IMAGE_PROMOTION}"
         done
 
-    - name: Authenticate with Public Registry 
+    - name: Authenticate with registry to promote to
       run: |
         gcloud auth configure-docker 
       shell: bash
 
-    - name: Push Images to Public Registry
+    - name: Push Images to registry to promote to 
       shell: bash
       run: |
         # Convert comma-separated tags input into an array
         IFS=',' read -ra TAGS <<< "${{ inputs.tags }}"
-        # Loop through each tag and push the image to the public registry
+        # Loop through each tag and push the image to the promotion registry
         for TAG in "${TAGS[@]}"; do
-          IMAGE_PUBLIC="${{ inputs.public_registry }}/${{ inputs.role }}:${TAG}"
-          echo "Pushing Image ${IMAGE_PUBLIC} to Public registry"
-          docker push "${IMAGE_PUBLIC}"
+          IMAGE_PROMOTION="${{ inputs.promotion_registry }}/${{ inputs.role }}:${TAG}"
+          echo "Pushing Image ${IMAGE_PROMOTION} to Public registry"
+          docker push "${IMAGE_PROMOTION}"
         done
 


### PR DESCRIPTION
## Description

This pull request introduces a new job to the GitHub Actions workflow for promoting container images from the private registry to the partner registry. The promotion process is designed to ensure that only approved images are deployed to the partner registry.

## Changes

- **New Job: `promote-to-partner-registry`**
  - Promotes container images for the `access` role from the private registry to the partner registry.
  - Utilizes a matrix strategy to handle promotion tasks in parallel for different roles (currently only `access`).
  - Includes gating mechanisms to ensure promotion only occurs if at least one of the `public-build` or `secure-build` jobs succeeds.
  - Defines an environment for each role to manage the promotion process.

- **Steps in the Job:**
  - Checks out the repository using `actions/checkout@v3`.
  - Executes the promotion process using a custom action (`./actions/promote-images`) with the following inputs:
    - GCP credentials for accessing the public registry.
    - Private and public registry details.
    - Role-specific tags for the images being promoted.
    
- **Update promote-images action**
  - Updates the inputs & variable names to be generic rather than explicitly specify public registry
     
- **Update promote-images job**
  - Updates the input to the `promote-images` action to use new variable name
  - Update job name to align with intent

   
Example Run:
- https://github.com/onflow/flow-go/actions/runs/16206416773