### PR TITLE
[Storage] Optimize the IterFunction

### DIFF
--- a/storage/operation/computation_result.go
+++ b/storage/operation/computation_result.go
@@ -34,7 +34,7 @@ func GetBlockIDsByStatus(r storage.Reader, blockIDs *[]flow.Identifier,
 			return true, err
 		}
 
-		if blockIDs != nil && wasUploadCompleted == targetUploadStatus {
+		if wasUploadCompleted == targetUploadStatus {
 			*blockIDs = append(*blockIDs, flow.HashToID(keyCopy[1:]))
 		}
 		return false, nil

--- a/storage/operation/reads.go
+++ b/storage/operation/reads.go
@@ -13,9 +13,9 @@ import (
 	"github.com/onflow/flow-go/utils/merr"
 )
 
-// IterationFunc is a function that will be called on each key-value pair during the iteration.
-// The key is copied and passed to the function, so the caller can safely add it to a slice.
-// The `getValue` function can be called to retrieve the value of the current key.
+// IterationFunc is a callback function that will be called on each key-value pair during the iteration.
+// The key is copied and passed to the function, so key can be modified or retained after iteration.
+// The `getValue` function can be called to retrieve the value of the current key and decode value into destVal object.
 // The caller can return (true, nil) to stop the iteration early.
 type IterationFunc func(keyCopy []byte, getValue func(destVal any) error) (bail bool, err error)
 

--- a/storage/operation/reads.go
+++ b/storage/operation/reads.go
@@ -26,7 +26,7 @@ type CheckFunc func(key []byte) (bool, error)
 
 // CreateFunc returns a pointer to an initialized entity that we can potentially
 // decode the next value into during a badger DB iteration.
-type CreateFunc func() interface{}
+type CreateFunc func() any
 
 // HandleFunc is a function that starts the processing of the current key-value
 // pair during a badger iteration. It should be called after the key was checked
@@ -158,7 +158,7 @@ func KeyExists(r storage.Reader, key []byte) (exist bool, errToReturn error) {
 //   - storage.ErrNotFound if the key does not exist in the database
 //   - generic error in case of unexpected failure from the database layer, or failure
 //     to decode an existing database value
-func RetrieveByKey(r storage.Reader, key []byte, entity interface{}) (errToReturn error) {
+func RetrieveByKey(r storage.Reader, key []byte, entity any) (errToReturn error) {
 	val, closer, err := r.Get(key)
 	if err != nil {
 		return err
@@ -179,7 +179,7 @@ func RetrieveByKey(r storage.Reader, key []byte, entity interface{}) (errToRetur
 // keys with the format prefix` + `height` (where "+" denotes concatenation of binary strings). The height
 // is encoded as Big-Endian (entries with numerically smaller height have lexicographically smaller key).
 // The function finds the *highest* key with the given prefix and height equal to or below the given height.
-func FindHighestAtOrBelowByPrefix(r storage.Reader, prefix []byte, height uint64, entity interface{}) (errToReturn error) {
+func FindHighestAtOrBelowByPrefix(r storage.Reader, prefix []byte, height uint64, entity any) (errToReturn error) {
 	if len(prefix) == 0 {
 		return fmt.Errorf("prefix must not be empty")
 	}

--- a/storage/operation/reads.go
+++ b/storage/operation/reads.go
@@ -13,8 +13,6 @@ import (
 	"github.com/onflow/flow-go/utils/merr"
 )
 
-
-
 // HandleFunc is a function that starts the processing of the current key-value
 // pair during a badger iteration. It should be called after the key was checked
 // and the entity was decoded.

--- a/storage/operation/reads.go
+++ b/storage/operation/reads.go
@@ -13,12 +13,6 @@ import (
 	"github.com/onflow/flow-go/utils/merr"
 )
 
-// HandleFunc is a function that starts the processing of the current key-value
-// pair during a badger iteration. It should be called after the key was checked
-// and the entity was decoded.
-// No errors are expected during normal operation. Any errors will halt the iteration.
-type HandleFunc func(data []byte) error
-
 // IterationFunc is a function that will be called on each key-value pair during the iteration.
 // The key is copied and passed to the function, so the caller can safely add it to a slice.
 // The `getValue` function can be called to retrieve the value of the current key.

--- a/storage/operation/reads.go
+++ b/storage/operation/reads.go
@@ -96,7 +96,7 @@ func TraverseByPrefix(r storage.Reader, prefix []byte, iterFunc IterationFunc, o
 
 // KeyOnlyIterateFunc returns an IterationFunc that only iterates over keys
 func KeyOnlyIterateFunc(fn func(key []byte) error) IterationFunc {
-	return func(key []byte, getValue func(destVal any) error) (bail bool, err error) {
+	return func(key []byte, _ func(destVal any) error) (bail bool, err error) {
 		err = fn(key)
 		if err != nil {
 			return true, err

--- a/storage/operation/reads_test.go
+++ b/storage/operation/reads_test.go
@@ -264,21 +264,19 @@ func TestTraverse(t *testing.T) {
 		actual := make([]uint64, 0, len(keyVals))
 
 		// Define the iteration logic
-		iterationFunc := func() (operation.CheckFunc, operation.HandleFunc) {
+		iterationFunc := func(unmarshal func(data []byte, v any) error) (operation.CheckFunc, operation.HandleFunc) {
 			check := func(key []byte) (bool, error) {
 				// Skip the key {0x42, 0x56}
 				return !bytes.Equal(key, []byte{0x42, 0x56}), nil
 			}
-			handle := func(unmarshal func(data []byte, entity interface{}) error) func(data []byte) error {
-				return func(data []byte) error {
-					var val uint64
-					err := unmarshal(data, &val)
-					if err != nil {
-						return err
-					}
-					actual = append(actual, val)
-					return nil
+			handle := func(data []byte) error {
+				var val uint64
+				err := unmarshal(data, &val)
+				if err != nil {
+					return err
 				}
+				actual = append(actual, val)
+				return nil
 			}
 			return check, handle
 		}

--- a/storage/operation/reads_test.go
+++ b/storage/operation/reads_test.go
@@ -90,10 +90,10 @@ func TestIterateKeysByPrefixRange(t *testing.T) {
 
 		// Forward iteration and check boundaries
 		var found [][]byte
-		require.NoError(t, operation.Iterate(prefixStart, prefixEnd, func(key []byte) error {
+		require.NoError(t, operation.IterateKeysByPrefixRange(r, prefixStart, prefixEnd, func(key []byte) error {
 			found = append(found, key)
 			return nil
-		})(r), "should iterate forward without error")
+		}), "should iterate forward without error")
 		require.ElementsMatch(t, keysInRange, found, "forward iteration should return the correct keys in range")
 	})
 }
@@ -160,10 +160,10 @@ func TestIterateHierachicalPrefixes(t *testing.T) {
 			{0x11, 0xff, 0xff},
 		}
 		firstPrefixRangeActual := make([][]byte, 0)
-		err := operation.Iterate([]byte{0x10}, []byte{0x11}, func(key []byte) error {
+		err := operation.IterateKeysByPrefixRange(r, []byte{0x10}, []byte{0x11}, func(key []byte) error {
 			firstPrefixRangeActual = append(firstPrefixRangeActual, key)
 			return nil
-		})(r)
+		})
 		require.NoError(t, err, "iterate with range of first prefixes should not return an error")
 		require.Equal(t, firstPrefixRangeExpected, firstPrefixRangeActual, "iterated values for range of first prefixes should match expected values")
 
@@ -175,10 +175,10 @@ func TestIterateHierachicalPrefixes(t *testing.T) {
 			{0x10, 0x21, 0x00},
 			{0x10, 0x21, 0xff},
 		}
-		err = operation.Iterate([]byte{0x10, 0x20}, []byte{0x10, 0x21}, func(key []byte) error {
+		err = operation.IterateKeysByPrefixRange(r, []byte{0x10, 0x20}, []byte{0x10, 0x21}, func(key []byte) error {
 			secondPrefixRangeActual = append(secondPrefixRangeActual, key)
 			return nil
-		})(r)
+		})
 		require.NoError(t, err, "iterate with range of second prefixes should not return an error")
 		require.Equal(t, secondPrefixRangeExpected, secondPrefixRangeActual, "iterated values for range of second prefixes should match expected values")
 	})
@@ -229,10 +229,10 @@ func TestIterationBoundary(t *testing.T) {
 
 		// Forward iteration and check boundaries
 		var found [][]byte
-		require.NoError(t, operation.Iterate(prefixStart, prefixEnd, func(key []byte) error {
+		require.NoError(t, operation.IterateKeysByPrefixRange(r, prefixStart, prefixEnd, func(key []byte) error {
 			found = append(found, key)
 			return nil
-		})(r), "should iterate forward without error")
+		}), "should iterate forward without error")
 		require.ElementsMatch(t, expectedKeys, found, "forward iteration should return the correct keys in range")
 	})
 }
@@ -264,21 +264,18 @@ func TestTraverse(t *testing.T) {
 		actual := make([]uint64, 0, len(keyVals))
 
 		// Define the iteration logic
-		iterationFunc := func(unmarshal func(data []byte, v any) error) (operation.CheckFunc, operation.HandleFunc) {
-			check := func(key []byte) (bool, error) {
-				// Skip the key {0x42, 0x56}
-				return !bytes.Equal(key, []byte{0x42, 0x56}), nil
+		iterationFunc := func(keyCopy []byte, getValue func(destVal any) error) (bail bool, err error) {
+			// Skip the key {0x42, 0x56}
+			if bytes.Equal(keyCopy, []byte{0x42, 0x56}) {
+				return false, nil
 			}
-			handle := func(data []byte) error {
-				var val uint64
-				err := unmarshal(data, &val)
-				if err != nil {
-					return err
-				}
-				actual = append(actual, val)
-				return nil
+			var val uint64
+			err = getValue(&val)
+			if err != nil {
+				return true, err
 			}
-			return check, handle
+			actual = append(actual, val)
+			return false, nil
 		}
 
 		// Traverse the keys starting with prefix {0x42}
@@ -323,10 +320,10 @@ func TestTraverseKeyOnly(t *testing.T) {
 		actual := make([][]byte, 0)
 
 		// Traverse the keys starting with prefix {0x11}
-		err := operation.Traverse([]byte{0x10}, operation.KeyOnlyIterateFunc(func(key []byte) error {
+		err := operation.TraverseByPrefix(r, []byte{0x10}, operation.KeyOnlyIterateFunc(func(key []byte) error {
 			actual = append(actual, key)
 			return nil
-		}), storage.DefaultIteratorOptions())(r)
+		}), storage.DefaultIteratorOptions())
 		require.NoError(t, err, "traverse should not return an error")
 
 		// Assert that the actual values match the expected values
@@ -393,10 +390,11 @@ func TestFindHighestAtOrBelow(t *testing.T) {
 					prefixToUse = []byte{}
 				}
 
-				err := operation.FindHighestAtOrBelow(
+				err := operation.FindHighestAtOrBelowByPrefix(
+					r,
 					prefixToUse,
 					tt.height,
-					&entity)(r)
+					&entity)
 
 				if tt.expectError {
 					require.Error(t, err, fmt.Sprintf("expected error but got nil, entity: %v", entity))

--- a/storage/operation/receipts.go
+++ b/storage/operation/receipts.go
@@ -43,22 +43,20 @@ func LookupExecutionReceipts(r storage.Reader, blockID flow.Identifier, receiptI
 }
 
 // receiptIterationFunc returns an in iteration function which returns all receipt IDs found during traversal
-func receiptIterationFunc(receiptIDs *[]flow.Identifier) func() (CheckFunc, HandleFunc) {
-	return func() (CheckFunc, HandleFunc) {
+func receiptIterationFunc(receiptIDs *[]flow.Identifier) IterationFunc {
+	return func(unmarshal func(data []byte, v any) error) (CheckFunc, HandleFunc) {
 		check := func(key []byte) (bool, error) {
 			return true, nil
 		}
 
-		handle := func(unmarshal func(data []byte, entity interface{}) error) func(data []byte) error {
-			return func(data []byte) error {
-				var receiptID flow.Identifier
-				err := unmarshal(data, &receiptID)
-				if err != nil {
-					return err
-				}
-				*receiptIDs = append(*receiptIDs, receiptID)
-				return nil
+		handle := func(data []byte) error {
+			var receiptID flow.Identifier
+			err := unmarshal(data, &receiptID)
+			if err != nil {
+				return err
 			}
+			*receiptIDs = append(*receiptIDs, receiptID)
+			return nil
 		}
 		return check, handle
 	}

--- a/storage/operation/receipts.go
+++ b/storage/operation/receipts.go
@@ -44,20 +44,13 @@ func LookupExecutionReceipts(r storage.Reader, blockID flow.Identifier, receiptI
 
 // receiptIterationFunc returns an in iteration function which returns all receipt IDs found during traversal
 func receiptIterationFunc(receiptIDs *[]flow.Identifier) IterationFunc {
-	return func(unmarshal func(data []byte, v any) error) (CheckFunc, HandleFunc) {
-		check := func(key []byte) (bool, error) {
-			return true, nil
+	return func(keyCopy []byte, getValue func(destVal any) error) (bail bool, err error) {
+		var receiptID flow.Identifier
+		err = getValue(&receiptID)
+		if err != nil {
+			return true, err
 		}
-
-		handle := func(data []byte) error {
-			var receiptID flow.Identifier
-			err := unmarshal(data, &receiptID)
-			if err != nil {
-				return err
-			}
-			*receiptIDs = append(*receiptIDs, receiptID)
-			return nil
-		}
-		return check, handle
+		*receiptIDs = append(*receiptIDs, receiptID)
+		return false, nil
 	}
 }

--- a/storage/operation/transaction_results.go
+++ b/storage/operation/transaction_results.go
@@ -27,19 +27,22 @@ func RetrieveTransactionResultByIndex(r storage.Reader, blockID flow.Identifier,
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupTransactionResultsByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResults *[]flow.TransactionResult) error {
 
-	txErrIterFunc := func() (CheckFunc, CreateFunc, HandleFunc) {
+	txErrIterFunc := func() (CheckFunc, HandleFunc) {
 		check := func(_ []byte) (bool, error) {
 			return true, nil
 		}
-		var val flow.TransactionResult
-		create := func() interface{} {
-			return &val
+		handle := func(unmarshal func(data []byte, entity interface{}) error) func(data []byte) error {
+			return func(data []byte) error {
+				var val flow.TransactionResult
+				err := unmarshal(data, &val)
+				if err != nil {
+					return err
+				}
+				*txResults = append(*txResults, val)
+				return nil
+			}
 		}
-		handle := func() error {
-			*txResults = append(*txResults, val)
-			return nil
-		}
-		return check, create, handle
+		return check, handle
 	}
 
 	return TraverseByPrefix(r, MakePrefix(codeTransactionResultIndex, blockID), txErrIterFunc, storage.DefaultIteratorOptions())
@@ -94,19 +97,22 @@ func RetrieveLightTransactionResultByIndex(r storage.Reader, blockID flow.Identi
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupLightTransactionResultsByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResults *[]flow.LightTransactionResult) error {
 
-	txErrIterFunc := func() (CheckFunc, CreateFunc, HandleFunc) {
+	txErrIterFunc := func() (CheckFunc, HandleFunc) {
 		check := func(_ []byte) (bool, error) {
 			return true, nil
 		}
-		var val flow.LightTransactionResult
-		create := func() interface{} {
-			return &val
+		handle := func(unmarshal func(data []byte, entity interface{}) error) func(data []byte) error {
+			return func(data []byte) error {
+				var val flow.LightTransactionResult
+				err := unmarshal(data, &val)
+				if err != nil {
+					return err
+				}
+				*txResults = append(*txResults, val)
+				return nil
+			}
 		}
-		handle := func() error {
-			*txResults = append(*txResults, val)
-			return nil
-		}
-		return check, create, handle
+		return check, handle
 	}
 
 	return TraverseByPrefix(r, MakePrefix(codeLightTransactionResultIndex, blockID), txErrIterFunc, storage.DefaultIteratorOptions())
@@ -147,19 +153,22 @@ func TransactionResultErrorMessagesExists(r storage.Reader, blockID flow.Identif
 // LookupTransactionResultErrorMessagesByBlockIDUsingIndex retrieves all tx result error messages for a block, by using
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupTransactionResultErrorMessagesByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResultErrorMessages *[]flow.TransactionResultErrorMessage) error {
-	txErrIterFunc := func() (CheckFunc, CreateFunc, HandleFunc) {
+	txErrIterFunc := func() (CheckFunc, HandleFunc) {
 		check := func(_ []byte) (bool, error) {
 			return true, nil
 		}
-		var val flow.TransactionResultErrorMessage
-		create := func() interface{} {
-			return &val
+		handle := func(unmarshal func(data []byte, entity interface{}) error) func(data []byte) error {
+			return func(data []byte) error {
+				var val flow.TransactionResultErrorMessage
+				err := unmarshal(data, &val)
+				if err != nil {
+					return err
+				}
+				*txResultErrorMessages = append(*txResultErrorMessages, val)
+				return nil
+			}
 		}
-		handle := func() error {
-			*txResultErrorMessages = append(*txResultErrorMessages, val)
-			return nil
-		}
-		return check, create, handle
+		return check, handle
 	}
 
 	return TraverseByPrefix(r, MakePrefix(codeTransactionResultErrorMessageIndex, blockID), txErrIterFunc, storage.DefaultIteratorOptions())

--- a/storage/operation/transaction_results.go
+++ b/storage/operation/transaction_results.go
@@ -27,20 +27,18 @@ func RetrieveTransactionResultByIndex(r storage.Reader, blockID flow.Identifier,
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupTransactionResultsByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResults *[]flow.TransactionResult) error {
 
-	txErrIterFunc := func() (CheckFunc, HandleFunc) {
+	txErrIterFunc := func(unmarshal func(data []byte, v any) error) (CheckFunc, HandleFunc) {
 		check := func(_ []byte) (bool, error) {
 			return true, nil
 		}
-		handle := func(unmarshal func(data []byte, entity interface{}) error) func(data []byte) error {
-			return func(data []byte) error {
-				var val flow.TransactionResult
-				err := unmarshal(data, &val)
-				if err != nil {
-					return err
-				}
-				*txResults = append(*txResults, val)
-				return nil
+		handle := func(data []byte) error {
+			var val flow.TransactionResult
+			err := unmarshal(data, &val)
+			if err != nil {
+				return err
 			}
+			*txResults = append(*txResults, val)
+			return nil
 		}
 		return check, handle
 	}
@@ -97,20 +95,18 @@ func RetrieveLightTransactionResultByIndex(r storage.Reader, blockID flow.Identi
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupLightTransactionResultsByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResults *[]flow.LightTransactionResult) error {
 
-	txErrIterFunc := func() (CheckFunc, HandleFunc) {
+	txErrIterFunc := func(unmarshal func(data []byte, v any) error) (CheckFunc, HandleFunc) {
 		check := func(_ []byte) (bool, error) {
 			return true, nil
 		}
-		handle := func(unmarshal func(data []byte, entity interface{}) error) func(data []byte) error {
-			return func(data []byte) error {
-				var val flow.LightTransactionResult
-				err := unmarshal(data, &val)
-				if err != nil {
-					return err
-				}
-				*txResults = append(*txResults, val)
-				return nil
+		handle := func(data []byte) error {
+			var val flow.LightTransactionResult
+			err := unmarshal(data, &val)
+			if err != nil {
+				return err
 			}
+			*txResults = append(*txResults, val)
+			return nil
 		}
 		return check, handle
 	}
@@ -153,20 +149,18 @@ func TransactionResultErrorMessagesExists(r storage.Reader, blockID flow.Identif
 // LookupTransactionResultErrorMessagesByBlockIDUsingIndex retrieves all tx result error messages for a block, by using
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupTransactionResultErrorMessagesByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResultErrorMessages *[]flow.TransactionResultErrorMessage) error {
-	txErrIterFunc := func() (CheckFunc, HandleFunc) {
+	txErrIterFunc := func(unmarshal func(data []byte, v any) error) (CheckFunc, HandleFunc) {
 		check := func(_ []byte) (bool, error) {
 			return true, nil
 		}
-		handle := func(unmarshal func(data []byte, entity interface{}) error) func(data []byte) error {
-			return func(data []byte) error {
-				var val flow.TransactionResultErrorMessage
-				err := unmarshal(data, &val)
-				if err != nil {
-					return err
-				}
-				*txResultErrorMessages = append(*txResultErrorMessages, val)
-				return nil
+		handle := func(data []byte) error {
+			var val flow.TransactionResultErrorMessage
+			err := unmarshal(data, &val)
+			if err != nil {
+				return err
 			}
+			*txResultErrorMessages = append(*txResultErrorMessages, val)
+			return nil
 		}
 		return check, handle
 	}

--- a/storage/operation/transaction_results.go
+++ b/storage/operation/transaction_results.go
@@ -27,20 +27,14 @@ func RetrieveTransactionResultByIndex(r storage.Reader, blockID flow.Identifier,
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupTransactionResultsByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResults *[]flow.TransactionResult) error {
 
-	txErrIterFunc := func(unmarshal func(data []byte, v any) error) (CheckFunc, HandleFunc) {
-		check := func(_ []byte) (bool, error) {
-			return true, nil
+	txErrIterFunc := func(keyCopy []byte, getValue func(destVal any) error) (bail bool, err error) {
+		var val flow.TransactionResult
+		err = getValue(&val)
+		if err != nil {
+			return true, err
 		}
-		handle := func(data []byte) error {
-			var val flow.TransactionResult
-			err := unmarshal(data, &val)
-			if err != nil {
-				return err
-			}
-			*txResults = append(*txResults, val)
-			return nil
-		}
-		return check, handle
+		*txResults = append(*txResults, val)
+		return false, nil
 	}
 
 	return TraverseByPrefix(r, MakePrefix(codeTransactionResultIndex, blockID), txErrIterFunc, storage.DefaultIteratorOptions())
@@ -95,20 +89,14 @@ func RetrieveLightTransactionResultByIndex(r storage.Reader, blockID flow.Identi
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupLightTransactionResultsByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResults *[]flow.LightTransactionResult) error {
 
-	txErrIterFunc := func(unmarshal func(data []byte, v any) error) (CheckFunc, HandleFunc) {
-		check := func(_ []byte) (bool, error) {
-			return true, nil
+	txErrIterFunc := func(keyCopy []byte, getValue func(destVal any) error) (bail bool, err error) {
+		var val flow.LightTransactionResult
+		err = getValue(&val)
+		if err != nil {
+			return true, err
 		}
-		handle := func(data []byte) error {
-			var val flow.LightTransactionResult
-			err := unmarshal(data, &val)
-			if err != nil {
-				return err
-			}
-			*txResults = append(*txResults, val)
-			return nil
-		}
-		return check, handle
+		*txResults = append(*txResults, val)
+		return false, nil
 	}
 
 	return TraverseByPrefix(r, MakePrefix(codeLightTransactionResultIndex, blockID), txErrIterFunc, storage.DefaultIteratorOptions())
@@ -149,20 +137,14 @@ func TransactionResultErrorMessagesExists(r storage.Reader, blockID flow.Identif
 // LookupTransactionResultErrorMessagesByBlockIDUsingIndex retrieves all tx result error messages for a block, by using
 // tx_index index. This correctly handles cases of duplicate transactions within block.
 func LookupTransactionResultErrorMessagesByBlockIDUsingIndex(r storage.Reader, blockID flow.Identifier, txResultErrorMessages *[]flow.TransactionResultErrorMessage) error {
-	txErrIterFunc := func(unmarshal func(data []byte, v any) error) (CheckFunc, HandleFunc) {
-		check := func(_ []byte) (bool, error) {
-			return true, nil
+	txErrIterFunc := func(keyCopy []byte, getValue func(destVal any) error) (bail bool, err error) {
+		var val flow.TransactionResultErrorMessage
+		err = getValue(&val)
+		if err != nil {
+			return true, err
 		}
-		handle := func(data []byte) error {
-			var val flow.TransactionResultErrorMessage
-			err := unmarshal(data, &val)
-			if err != nil {
-				return err
-			}
-			*txResultErrorMessages = append(*txResultErrorMessages, val)
-			return nil
-		}
-		return check, handle
+		*txResultErrorMessages = append(*txResultErrorMessages, val)
+		return false, nil
 	}
 
 	return TraverseByPrefix(r, MakePrefix(codeTransactionResultErrorMessageIndex, blockID), txErrIterFunc, storage.DefaultIteratorOptions())


### PR DESCRIPTION
Refactored the iteration mechanism in storage/operation to improve developer experience and prevent common bugs.

  The previous IterationFunc required the caller to manage key copying, which could lead to subtle bugs if a key was appended to a slice without being copied first. The iteration control was also less intuitive, relying on sentinel errors to
  exit early.

  This commit introduces the following changes:
   - The IterationFunc signature is changed to func(keyCopy []byte, getValue func(destVal any) error) (bail bool, err error).
   - Key copying is now handled internally within the IterateKeys function, hiding this implementation detail from the caller and preventing misuse.
   - Callers can now exit an iteration early by returning (bail=true, err=nil), which is more explicit than the previous sentinel error pattern.
   - The now-unused CheckFunc, HandleFunc, and CreateFunc types have been removed, simplifying the API.
   - All call sites of the iteration functions have been updated to use the new, safer, and more ergonomic API.
