### PR TITLE
[Malleability] Changed buffer backend to support generic payload

### DIFF
--- a/model/cluster/block.go
+++ b/model/cluster/block.go
@@ -118,3 +118,9 @@ type Proposal struct {
 	Block           Block
 	ProposerSigData []byte
 }
+
+// ProposalHeader converts the proposal into a compact [ProposalHeader] representation,
+// where the payload is compressed to a hash reference.
+func (b *Proposal) ProposalHeader() *flow.ProposalHeader {
+	return &flow.ProposalHeader{Header: b.Block.ToHeader(), ProposerSigData: b.ProposerSigData}
+}

--- a/module/buffer/backend.go
+++ b/module/buffer/backend.go
@@ -14,6 +14,8 @@ type item[T any] struct {
 	payload  flow.Slashable[T]
 }
 
+// extractProposalHeader is a type constraint for the generic type which allows to extract flow.ProposalHeader
+// from the underlying type.
 type extractProposalHeader interface {
 	ProposalHeader() *flow.ProposalHeader
 }

--- a/module/buffer/backend.go
+++ b/module/buffer/backend.go
@@ -6,58 +6,63 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// item represents an item in the cache: a block header, payload, and the ID
-// of the node that sent it to us. The payload is generic.
-type item struct {
-	header  flow.Slashable[*flow.ProposalHeader]
-	payload interface{}
+// item represents an item in the cache: the main payload and auxiliary data that is
+// needed to implement indexed lookups by parent ID and pruning by view.
+type item[T any] struct {
+	view     uint64
+	parentID flow.Identifier
+	payload  flow.Slashable[T]
 }
 
-// backend implements a simple cache of pending blocks, indexed by parent ID.
-type backend struct {
+type extractProposalHeader interface {
+	ProposalHeader() *flow.ProposalHeader
+}
+
+// backend implements a simple cache of pending blocks, indexed by parent ID and pruned by view.
+type backend[T extractProposalHeader] struct {
 	mu sync.RWMutex
 	// map of pending header IDs, keyed by parent ID for ByParentID lookups
 	blocksByParent map[flow.Identifier][]flow.Identifier
 	// set of pending blocks, keyed by ID to avoid duplication
-	blocksByID map[flow.Identifier]*item
+	blocksByID map[flow.Identifier]*item[T]
 }
 
 // newBackend returns a new pending header cache.
-func newBackend() *backend {
-	cache := &backend{
+func newBackend[T extractProposalHeader]() *backend[T] {
+	cache := &backend[T]{
 		blocksByParent: make(map[flow.Identifier][]flow.Identifier),
-		blocksByID:     make(map[flow.Identifier]*item),
+		blocksByID:     make(map[flow.Identifier]*item[T]),
 	}
 	return cache
 }
 
 // add adds the item to the cache, returning false if it already exists and
 // true otherwise.
-func (b *backend) add(block flow.Slashable[*flow.ProposalHeader], payload interface{}) bool {
+func (b *backend[T]) add(block flow.Slashable[T]) bool {
+	header := block.Message.ProposalHeader().Header
+	blockID := header.ID()
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
-
-	blockID := block.Message.Header.ID()
 
 	_, exists := b.blocksByID[blockID]
 	if exists {
 		return false
 	}
 
-	item := &item{
-		header:  block,
-		payload: payload,
+	item := &item[T]{
+		view:     header.View,
+		parentID: header.ParentID,
+		payload:  block,
 	}
 
 	b.blocksByID[blockID] = item
-	b.blocksByParent[block.Message.Header.ParentID] = append(b.blocksByParent[block.Message.Header.ParentID], blockID)
+	b.blocksByParent[item.parentID] = append(b.blocksByParent[item.parentID], blockID)
 
 	return true
 }
 
-func (b *backend) byID(id flow.Identifier) (*item, bool) {
-
+func (b *backend[T]) byID(id flow.Identifier) (*item[T], bool) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -71,8 +76,7 @@ func (b *backend) byID(id flow.Identifier) (*item, bool) {
 
 // byParentID returns a list of cached blocks with the given parent. If no such
 // blocks exist, returns false.
-func (b *backend) byParentID(parentID flow.Identifier) ([]*item, bool) {
-
+func (b *backend[T]) byParentID(parentID flow.Identifier) ([]*item[T], bool) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -81,7 +85,7 @@ func (b *backend) byParentID(parentID flow.Identifier) ([]*item, bool) {
 		return nil, false
 	}
 
-	items := make([]*item, 0, len(forParent))
+	items := make([]*item[T], 0, len(forParent))
 	for _, blockID := range forParent {
 		items = append(items, b.blocksByID[blockID])
 	}
@@ -90,8 +94,7 @@ func (b *backend) byParentID(parentID flow.Identifier) ([]*item, bool) {
 }
 
 // dropForParent removes all cached blocks with the given parent (non-recursively).
-func (b *backend) dropForParent(parentID flow.Identifier) {
-
+func (b *backend[T]) dropForParent(parentID flow.Identifier) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -108,21 +111,20 @@ func (b *backend) dropForParent(parentID flow.Identifier) {
 
 // pruneByView prunes any items in the cache that have view less than or
 // equal to the given view. The pruning view should be the finalized view.
-func (b *backend) pruneByView(view uint64) {
-
+func (b *backend[T]) pruneByView(view uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	for id, item := range b.blocksByID {
-		if item.header.Message.Header.View <= view {
+		if item.view <= view {
 			delete(b.blocksByID, id)
-			delete(b.blocksByParent, item.header.Message.Header.ParentID)
+			delete(b.blocksByParent, item.parentID)
 		}
 	}
 }
 
 // size returns the number of elements stored in teh backend
-func (b *backend) size() uint {
+func (b *backend[T]) size() uint {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return uint(len(b.blocksByID))

--- a/module/buffer/backend_test.go
+++ b/module/buffer/backend_test.go
@@ -12,7 +12,7 @@ import (
 
 type BackendSuite struct {
 	suite.Suite
-	backend *backend
+	backend *backend[*flow.Proposal]
 }
 
 func TestBackendSuite(t *testing.T) {
@@ -20,38 +20,39 @@ func TestBackendSuite(t *testing.T) {
 }
 
 func (suite *BackendSuite) SetupTest() {
-	suite.backend = newBackend()
+	suite.backend = newBackend[*flow.Proposal]()
 }
 
-func (suite *BackendSuite) item() *item {
+func (suite *BackendSuite) item() *item[*flow.Proposal] {
 	parent := unittest.BlockHeaderFixture()
 	return suite.itemWithParent(parent)
 }
 
-func (suite *BackendSuite) itemWithParent(parent *flow.Header) *item {
-	header := unittest.BlockHeaderWithParentFixture(parent)
-	return &item{
-		header: flow.Slashable[*flow.ProposalHeader]{
+func (suite *BackendSuite) itemWithParent(parent *flow.Header) *item[*flow.Proposal] {
+	block := unittest.BlockWithParentFixture(parent)
+	return &item[*flow.Proposal]{
+		view:     block.Header.View,
+		parentID: block.Header.ParentID,
+		payload: flow.Slashable[*flow.Proposal]{
 			OriginID: unittest.IdentifierFixture(),
-			Message:  unittest.ProposalHeaderFromHeader(header),
+			Message:  unittest.ProposalFromBlock(block),
 		},
-		payload: unittest.IdentifierFixture(),
 	}
 }
 
-func (suite *BackendSuite) Add(item *item) {
-	suite.backend.add(item.header, item.payload)
+func (suite *BackendSuite) Add(item *item[*flow.Proposal]) {
+	suite.backend.add(item.payload)
 }
 
 func (suite *BackendSuite) TestAdd() {
 	expected := suite.item()
-	suite.backend.add(expected.header, expected.payload)
+	suite.backend.add(expected.payload)
 
-	actual, ok := suite.backend.byID(expected.header.Message.Header.ID())
+	actual, ok := suite.backend.byID(expected.payload.Message.Block.ID())
 	suite.Assert().True(ok)
 	suite.Assert().Equal(expected, actual)
 
-	byParent, ok := suite.backend.byParentID(expected.header.Message.Header.ParentID)
+	byParent, ok := suite.backend.byParentID(expected.parentID)
 	suite.Assert().True(ok)
 	suite.Assert().Len(byParent, 1)
 	suite.Assert().Equal(expected, byParent[0])
@@ -60,9 +61,9 @@ func (suite *BackendSuite) TestAdd() {
 func (suite *BackendSuite) TestChildIndexing() {
 
 	parent := suite.item()
-	child1 := suite.itemWithParent(parent.header.Message.Header)
-	child2 := suite.itemWithParent(parent.header.Message.Header)
-	grandchild := suite.itemWithParent(child1.header.Message.Header)
+	child1 := suite.itemWithParent(parent.payload.Message.Block.ToHeader())
+	child2 := suite.itemWithParent(parent.payload.Message.Block.ToHeader())
+	grandchild := suite.itemWithParent(child1.payload.Message.Block.ToHeader())
 	unrelated := suite.item()
 
 	suite.Add(child1)
@@ -71,7 +72,7 @@ func (suite *BackendSuite) TestChildIndexing() {
 	suite.Add(unrelated)
 
 	suite.Run("retrieve by parent ID", func() {
-		byParent, ok := suite.backend.byParentID(parent.header.Message.Header.ID())
+		byParent, ok := suite.backend.byParentID(parent.payload.Message.Block.ID())
 		suite.Assert().True(ok)
 		// should only include direct children
 		suite.Assert().Len(byParent, 2)
@@ -80,22 +81,22 @@ func (suite *BackendSuite) TestChildIndexing() {
 	})
 
 	suite.Run("drop for parent ID", func() {
-		suite.backend.dropForParent(parent.header.Message.Header.ID())
+		suite.backend.dropForParent(parent.payload.Message.Block.ID())
 
 		// should only drop direct children
-		_, exists := suite.backend.byID(child1.header.Message.Header.ID())
+		_, exists := suite.backend.byID(child1.payload.Message.Block.ID())
 		suite.Assert().False(exists)
-		_, exists = suite.backend.byID(child2.header.Message.Header.ID())
+		_, exists = suite.backend.byID(child2.payload.Message.Block.ID())
 		suite.Assert().False(exists)
 
 		// grandchildren should be unaffected
-		_, exists = suite.backend.byParentID(child1.header.Message.Header.ID())
+		_, exists = suite.backend.byParentID(child1.payload.Message.Block.ID())
 		suite.Assert().True(exists)
-		_, exists = suite.backend.byID(grandchild.header.Message.Header.ID())
+		_, exists = suite.backend.byID(grandchild.payload.Message.Block.ID())
 		suite.Assert().True(exists)
 
 		// nothing else should be affected
-		_, exists = suite.backend.byID(unrelated.header.Message.Header.ID())
+		_, exists = suite.backend.byID(unrelated.payload.Message.Block.ID())
 		suite.Assert().True(exists)
 	})
 }
@@ -103,7 +104,7 @@ func (suite *BackendSuite) TestChildIndexing() {
 func (suite *BackendSuite) TestPruneByView() {
 
 	const N = 100 // number of items we're testing with
-	items := make([]*item, 0, N)
+	items := make([]*item[*flow.Proposal], 0, N)
 
 	// build a pending buffer
 	for i := 0; i < N; i++ {
@@ -119,20 +120,20 @@ func (suite *BackendSuite) TestPruneByView() {
 		// 90% of the time, build on an existing header
 		if i%2 == 1 {
 			parent := items[rand.Intn(len(items))]
-			item := suite.itemWithParent(parent.header.Message.Header)
+			item := suite.itemWithParent(parent.payload.Message.Block.ToHeader())
 			suite.Add(item)
 			items = append(items, item)
 		}
 	}
 
 	// pick a height to prune that's guaranteed to prune at least one item
-	pruneAt := items[rand.Intn(len(items))].header.Message.Header.View
+	pruneAt := items[rand.Intn(len(items))].view
 	suite.backend.pruneByView(pruneAt)
 
 	for _, item := range items {
-		view := item.header.Message.Header.View
-		id := item.header.Message.Header.ID()
-		parentID := item.header.Message.Header.ParentID
+		view := item.view
+		id := item.payload.Message.Block.ID()
+		parentID := item.parentID
 
 		// check that items below the prune view were removed
 		if view <= pruneAt {
@@ -143,7 +144,7 @@ func (suite *BackendSuite) TestPruneByView() {
 		}
 
 		// check that other items were not removed
-		if view > item.header.Message.Header.View {
+		if view > item.view {
 			_, exists := suite.backend.byID(id)
 			suite.Assert().True(exists)
 			_, exists = suite.backend.byParentID(parentID)

--- a/module/buffer/pending_blocks.go
+++ b/module/buffer/pending_blocks.go
@@ -8,24 +8,19 @@ import (
 // PendingBlocks is a mempool for holding blocks. Furthermore, given a block ID, we can
 // query all children that are currently stored in the mempool. The mempool's backend
 // is intended to work generically for consensus blocks as well as cluster blocks.
-// TODO: this mempool was implemented prior to generics being available in Go. Hence, the
-// backend abstracts the payload as an interface{}. This should be updated to use generics.
 type PendingBlocks struct {
-	backend *backend
+	backend *backend[*flow.Proposal]
 }
 
 var _ module.PendingBlockBuffer = (*PendingBlocks)(nil)
 
 func NewPendingBlocks() *PendingBlocks {
-	b := &PendingBlocks{backend: newBackend()}
+	b := &PendingBlocks{backend: newBackend[*flow.Proposal]()}
 	return b
 }
 
 func (b *PendingBlocks) Add(block flow.Slashable[*flow.Proposal]) bool {
-	return b.backend.add(flow.Slashable[*flow.ProposalHeader]{
-		OriginID: block.OriginID,
-		Message:  block.Message.ProposalHeader(),
-	}, block.Message.Block.Payload)
+	return b.backend.add(block)
 }
 
 func (b *PendingBlocks) ByID(blockID flow.Identifier) (flow.Slashable[*flow.Proposal], bool) {
@@ -33,25 +28,7 @@ func (b *PendingBlocks) ByID(blockID flow.Identifier) (flow.Slashable[*flow.Prop
 	if !ok {
 		return flow.Slashable[*flow.Proposal]{}, false
 	}
-
-	block, err := flow.NewBlock(
-		flow.UntrustedBlock{
-			Header:  item.header.Message.Header.HeaderBody,
-			Payload: item.payload.(flow.Payload),
-		},
-	)
-	if err != nil {
-		return flow.Slashable[*flow.Proposal]{}, false
-	}
-	proposal := flow.Slashable[*flow.Proposal]{
-		OriginID: item.header.OriginID,
-		Message: &flow.Proposal{
-			Block:           *block,
-			ProposerSigData: item.header.Message.ProposerSigData,
-		},
-	}
-
-	return proposal, true
+	return item.payload, true
 }
 
 func (b *PendingBlocks) ByParentID(parentID flow.Identifier) ([]flow.Slashable[*flow.Proposal], bool) {
@@ -62,26 +39,8 @@ func (b *PendingBlocks) ByParentID(parentID flow.Identifier) ([]flow.Slashable[*
 
 	proposals := make([]flow.Slashable[*flow.Proposal], 0, len(items))
 	for _, item := range items {
-		block, err := flow.NewBlock(
-			flow.UntrustedBlock{
-				Header:  item.header.Message.Header.HeaderBody,
-				Payload: item.payload.(flow.Payload),
-			},
-		)
-		if err != nil {
-			return nil, false
-		}
-
-		proposal := flow.Slashable[*flow.Proposal]{
-			OriginID: item.header.OriginID,
-			Message: &flow.Proposal{
-				Block:           *block,
-				ProposerSigData: item.header.Message.ProposerSigData,
-			},
-		}
-		proposals = append(proposals, proposal)
+		proposals = append(proposals, item.payload)
 	}
-
 	return proposals, true
 }
 


### PR DESCRIPTION
### Context

This PR changes the `buffer.backend` to work with generic type which allows us to get rid of dangerous constructions where we need to [convert back and forth and ignore errors](https://github.com/onflow/flow-go/pull/7560/files#diff-c51489b595f635ca130c092b75159cab5e6d20ec989e76f210074d688792987aR37-R46). 

By using this approach we will be able to use the backend for both `flow.Proposal` and `cluster.Proposal` without relying on common type(`flow.ProposalHeader`) and `interface{}`