### PR TITLE
fix inconsistent struct name in comment

### DIFF
--- a/storage/operation/dbtest/helper.go
+++ b/storage/operation/dbtest/helper.go
@@ -36,7 +36,7 @@ func RunWithDB(t *testing.T, fn func(*testing.T, storage.DB)) {
 	})
 }
 
-// RunFuncsWithNewPebbleDBHandle runs provided functions with
+// RunFuncsWithNewDBHandle runs provided functions with
 // new database handles of the same underlying database.
 // Each provided function will receive a new (different) DB handle.
 // This can be used to test database persistence.

--- a/storage/store/chained/results.go
+++ b/storage/store/chained/results.go
@@ -15,7 +15,7 @@ type ChainedExecutionResults struct {
 
 var _ storage.ExecutionResultsReader = (*ChainedExecutionResults)(nil)
 
-// NewResults returns a new ChainedExecutionResults results store, which will handle reads. which only implements
+// NewExecutionResults returns a new ChainedExecutionResults results store, which will handle reads. which only implements
 // read operations
 // for reads, it first query the first database, then the second database, this is useful when migrating
 // data from badger to pebble


### PR DESCRIPTION
fix inconsistent struct name in comment