### PR TITLE
Remove unused migration flags in execution-state-extract

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -27,38 +27,23 @@ import (
 )
 
 var (
-	flagExecutionStateDir                  string
-	flagOutputDir                          string
-	flagBlockHash                          string
-	flagStateCommitment                    string
-	flagDatadir                            string
-	flagChain                              string
-	flagNWorker                            int
-	flagNoMigration                        bool
-	flagMigration                          string
-	flagNoReport                           bool
-	flagValidateMigration                  bool
-	flagAllowPartialStateFromPayloads      bool
-	flagSortPayloads                       bool
-	flagPrune                              bool
-	flagLogVerboseValidationError          bool
-	flagDiffMigration                      bool
-	flagLogVerboseDiff                     bool
-	flagVerboseErrorOutput                 bool
-	flagStagedContractsFile                string
-	flagContinueMigrationOnValidationError bool
-	flagCheckStorageHealthBeforeMigration  bool
-	flagCheckStorageHealthAfterMigration   bool
-	flagInputPayloadFileName               string
-	flagOutputPayloadFileName              string
-	flagOutputPayloadByAddresses           string
-	flagMaxAccountSize                     uint64
-	flagFixSlabsWithBrokenReferences       bool
-	flagFilterUnreferencedSlabs            bool
-	flagCPUProfile                         string
-	flagReportMetrics                      bool
-	flagCacheStaticTypeMigrationResults    bool
-	flagCacheEntitlementsMigrationResults  bool
+	flagExecutionStateDir             string
+	flagOutputDir                     string
+	flagBlockHash                     string
+	flagStateCommitment               string
+	flagDatadir                       string
+	flagChain                         string
+	flagNWorker                       int
+	flagNoMigration                   bool
+	flagMigration                     string
+	flagNoReport                      bool
+	flagAllowPartialStateFromPayloads bool
+	flagSortPayloads                  bool
+	flagPrune                         bool
+	flagInputPayloadFileName          string
+	flagOutputPayloadFileName         string
+	flagOutputPayloadByAddresses      string
+	flagCPUProfile                    string
 )
 
 var Cmd = &cobra.Command{
@@ -98,35 +83,8 @@ func init() {
 
 	Cmd.Flags().IntVar(&flagNWorker, "n-migrate-worker", 10, "number of workers to migrate payload concurrently")
 
-	Cmd.Flags().BoolVar(&flagValidateMigration, "validate", false,
-		"validate migrated Cadence values (atree migration)")
-
-	Cmd.Flags().BoolVar(&flagLogVerboseValidationError, "log-verbose-validation-error", false,
-		"log entire Cadence values on validation error (atree migration)")
-
-	Cmd.Flags().BoolVar(&flagDiffMigration, "diff", false,
-		"compare Cadence values and log diff (migration)")
-
-	Cmd.Flags().BoolVar(&flagLogVerboseDiff, "log-verbose-diff", false,
-		"log entire Cadence values on diff (requires --diff flag)")
-
-	Cmd.Flags().BoolVar(&flagVerboseErrorOutput, "verbose-error-output", true,
-		"log verbose output on migration errors")
-
-	Cmd.Flags().StringVar(&flagStagedContractsFile, "staged-contracts", "",
-		"Staged contracts CSV file")
-
 	Cmd.Flags().BoolVar(&flagAllowPartialStateFromPayloads, "allow-partial-state-from-payload-file", false,
 		"allow input payload file containing partial state (e.g. not all accounts)")
-
-	Cmd.Flags().BoolVar(&flagCheckStorageHealthBeforeMigration, "check-storage-health-before", false,
-		"check (atree) storage health before migration")
-
-	Cmd.Flags().BoolVar(&flagCheckStorageHealthAfterMigration, "check-storage-health-after", false,
-		"check (atree) storage health after migration")
-
-	Cmd.Flags().BoolVar(&flagContinueMigrationOnValidationError, "continue-migration-on-validation-errors", false,
-		"continue migration even if validation fails")
 
 	Cmd.Flags().BoolVar(&flagSortPayloads, "sort-payloads", true,
 		"sort payloads (generate deterministic output; disable only for development purposes)")
@@ -164,26 +122,8 @@ func init() {
 		"extract payloads of addresses (comma separated hex-encoded addresses) to file specified by output-payload-filename",
 	)
 
-	Cmd.Flags().Uint64Var(&flagMaxAccountSize, "max-account-size", 0,
-		"max account size")
-
-	Cmd.Flags().BoolVar(&flagFixSlabsWithBrokenReferences, "fix-testnet-slabs-with-broken-references", false,
-		"fix slabs with broken references in testnet")
-
-	Cmd.Flags().BoolVar(&flagFilterUnreferencedSlabs, "filter-unreferenced-slabs", false,
-		"filter unreferenced slabs")
-
 	Cmd.Flags().StringVar(&flagCPUProfile, "cpu-profile", "",
 		"enable CPU profiling")
-
-	Cmd.Flags().BoolVar(&flagReportMetrics, "report-metrics", false,
-		"report migration metrics")
-
-	Cmd.Flags().BoolVar(&flagCacheStaticTypeMigrationResults, "cache-static-type-migration", false,
-		"cache static type migration results")
-
-	Cmd.Flags().BoolVar(&flagCacheEntitlementsMigrationResults, "cache-entitlements-migration", false,
-		"cache entitlements migration results")
 }
 
 func run(*cobra.Command, []string) {
@@ -222,10 +162,6 @@ func run(*cobra.Command, []string) {
 	// When flagOutputPayloadByAddresses is specified, flagOutputPayloadFileName is required.
 	if len(flagOutputPayloadFileName) == 0 && len(flagOutputPayloadByAddresses) > 0 {
 		log.Fatal().Msg("--extract-payloads-by-address requires --output-payload-filename to be specified")
-	}
-
-	if flagValidateMigration && flagDiffMigration {
-		log.Fatal().Msg("Both --validate and --diff are enabled, please specify only one (or none) of these")
 	}
 
 	var stateCommitment flow.StateCommitment
@@ -314,34 +250,6 @@ func run(*cobra.Command, []string) {
 
 	if flagNoReport {
 		log.Warn().Msgf("--no-report flag is deprecated")
-	}
-
-	if flagValidateMigration {
-		log.Warn().Msgf("--validate flag is enabled and will increase duration of migration")
-	}
-
-	if flagLogVerboseValidationError {
-		log.Warn().Msgf("--log-verbose-validation-error flag is enabled which may increase size of log")
-	}
-
-	if flagDiffMigration {
-		log.Warn().Msgf("--diff flag is enabled and will increase duration of migration")
-	}
-
-	if flagLogVerboseDiff {
-		log.Warn().Msgf("--log-verbose-diff flag is enabled which may increase size of log")
-	}
-
-	if flagVerboseErrorOutput {
-		log.Warn().Msgf("--verbose-error-output flag is enabled which may increase size of log")
-	}
-
-	if flagCheckStorageHealthBeforeMigration {
-		log.Warn().Msgf("--check-storage-health-before flag is enabled and will increase duration of migration")
-	}
-
-	if flagCheckStorageHealthAfterMigration {
-		log.Warn().Msgf("--check-storage-health-after flag is enabled and will increase duration of migration")
 	}
 
 	var inputMsg string


### PR DESCRIPTION
I found unused flags while working on migration for #7573.

These flags were used in a prior migration but they are no longer used in `execution-state-extract`:

- `validate`
- `log-verbose-validation-error`
- `diff`
- `log-verbose-diff`
- `verbose-error-output`
- `staged-contracts`
- `check-storage-health-before`
- `check-storage-health-after`
- `continue-migration-on-validation-errors`
- `max-account-size`
- `fix-testnet-slabs-with-broken-references`
- `filter-unreferenced-slabs`
- `report-metrics`
- `cache-static-type-migration`
- `cache-entitlements-migration`
