### PR TITLE
[Malleability] fix CollectionGuarantee ID indexing

### DIFF
--- a/storage/badger/guarantees.go
+++ b/storage/badger/guarantees.go
@@ -62,15 +62,15 @@ func NewGuarantees(
 				var storedGuaranteeID flow.Identifier
 				err = transaction.WithTx(operation.LookupGuarantee(collID, &storedGuaranteeID))(tx)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to retrieve existing guarantee for collection: %w", err)
 				}
 				if storedGuaranteeID != guaranteeID {
-					return fmt.Errorf("new guarantee ID %v did not match already stored guarantee ID %v, for collection %v: %w",
+					return fmt.Errorf("new guarantee %x did not match already stored guarantee %x, for collection %x: %w",
 						guaranteeID, storedGuaranteeID, collID, storage.ErrDataMismatch)
 				}
 			}
 			if err != nil {
-				return fmt.Errorf("could not index guarantee for collection (%x): %w", collID[:], err)
+				return err
 			}
 			return nil
 		}

--- a/storage/badger/guarantees.go
+++ b/storage/badger/guarantees.go
@@ -51,10 +51,10 @@ func NewGuarantees(
 
 	// While a collection guarantee can only be present once in the finalized chain,
 	// across different consensus forks we may encounter the same guarantee multiple times.
-	// There is a 1:1 correspondence between CollectionGuarantees and Collections, since
-	// each collection is produced only by one cluster, and the guarantee produced for that collection
-	// when it is finalized by the collector nodes is unique.
-	// Therefore it's safe to ignore duplicates when updating the CollectionID->GuaranteeID index.
+	// On the happy path there is a 1:1 correspondence between CollectionGuarantees and Collections.
+	// However, the finalization status of guarantees is not yet verified by consensus nodes,
+	// nor is the possibility of byzantine collection nodes dealt with, so we check here that
+	// there are no conflicting guarantees for the same collection.
 	indexByCollectionID := func(collID flow.Identifier, guaranteeID flow.Identifier) func(*transaction.Tx) error {
 		return func(tx *transaction.Tx) error {
 			err := transaction.WithTx(operation.IndexGuarantee(collID, guaranteeID))(tx)

--- a/storage/guarantees.go
+++ b/storage/guarantees.go
@@ -5,11 +5,13 @@ import (
 )
 
 // Guarantees represents persistent storage for collection guarantees.
+// Must only be used to store finalized collection guarantees.
 type Guarantees interface {
 
 	// Store inserts the collection guarantee and indexes it by the collection ID.
+	// It is the caller's responsibility to ensure that only finalized collection guarantees are passed to be stored.
 	// Expected errors of the returned anonymous function:
-	//   - storage.ErrAlreadyExists if a collection guarantee with the given id is already stored.
+	//   - storage.ErrDataMismatch if a different guarantee for the same collection is already stored.
 	Store(guarantee *flow.CollectionGuarantee) error
 
 	// ByID returns the flow.CollectionGuarantee by its ID.


### PR DESCRIPTION
Differing consensus forks can contain the same collection guarantee, which caused indexing from CollectionID -> GuaranteeID to fail with an irrecoverable error. However, this situation is expected, so needs to be handled. We now simply skip duplicates, since we know there is a 1:1 relationship between collections and guarantees.