### PR TITLE
[CI] Add dockerhub login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,13 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker build
         env:
           CADENCE_DEPLOY_KEY: ${{ secrets.CADENCE_DEPLOY_KEY }}

--- a/.github/workflows/image_builds.yml
+++ b/.github/workflows/image_builds.yml
@@ -93,6 +93,12 @@ jobs:
       - name: Setup Google Cloud Authentication
         run: gcloud auth configure-docker ${{ env.PRIVATE_REGISTRY_HOST }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Execute ${{ matrix.build_command }} command to build and push images
         env:
           IMAGE_TAG: ${{ inputs.tag }}


### PR DESCRIPTION
Occasionally, we get rate limited by docker hub due to high volume of CI pulls. Update workflows to use our CI dockerhub account with a higher rate limit.