### PR TITLE
Reverting portions of `mutable_protocol_state_test.go` to avoid weakening the tests

### DIFF
--- a/state/protocol/protocol_state/state/mutable_protocol_state_test.go
+++ b/state/protocol/protocol_state/state/mutable_protocol_state_test.go
@@ -637,9 +637,7 @@ func (m *mockStateTransition) Mock() protocol_statemock.OrthogonalStoreStateMach
 	stateMachine.On("Build").Run(func(args mock.Arguments) {
 		require.True(m.T, evolveStateCalled, "Method `OrthogonalStoreStateMachine.Build` called before `EvolveState`!")
 	}).Return([]storage.BlockIndexingBatchWrite{
-		func(blockID flow.Identifier, rw storage.ReaderBatchWriter) error {
-			return nil
-		},
+		func(blockID flow.Identifier, rw storage.ReaderBatchWriter) error { return nil },
 	}, nil).Once()
 	return *stateMachine //nolint:govet
 }

--- a/state/protocol/protocol_state/state/mutable_protocol_state_test.go
+++ b/state/protocol/protocol_state/state/mutable_protocol_state_test.go
@@ -34,9 +34,8 @@ type StateMutatorSuite struct {
 	protocolKVStoreDB       protocol_statemock.ProtocolKVStore
 	epochProtocolStateDB    storagemock.EpochProtocolStateEntries
 	globalParams            psmock.GlobalParams
-	kvStateMachines         []*protocol_statemock.OrthogonalStoreStateMachine[protocol.KVStoreReader]
-	kvStateMachineFactories []*protocol_statemock.KeyValueStoreStateMachineFactory
-	kvErrors                []error
+	kvStateMachines         []protocol_statemock.OrthogonalStoreStateMachine[protocol.KVStoreReader]
+	kvStateMachineFactories []protocol_statemock.KeyValueStoreStateMachineFactory
 
 	// basic setup for happy path test
 	parentState           protocol_statemock.KVStoreAPI // Protocol state of `candidate`s parent block
@@ -73,27 +72,13 @@ func (s *StateMutatorSuite) SetupTest() {
 
 	// Factories for the state machines expect `s.parentState` as parent state and `s.replicatedState` as target state.
 	// CAUTION: the behaviour of each state machine has to be defined by the tests.
-	s.kvStateMachines = make([]*protocol_statemock.OrthogonalStoreStateMachine[protocol.KVStoreReader], 2)
-	s.kvStateMachineFactories = make([]*protocol_statemock.KeyValueStoreStateMachineFactory, len(s.kvStateMachines))
-	s.kvErrors = make([]error, 2)
+	s.kvStateMachines = make([]protocol_statemock.OrthogonalStoreStateMachine[protocol.KVStoreReader], 2)
+	s.kvStateMachineFactories = make([]protocol_statemock.KeyValueStoreStateMachineFactory, len(s.kvStateMachines))
 	kvStateMachineFactories := make([]protocol_state.KeyValueStoreStateMachineFactory, len(s.kvStateMachines)) // slice of interface-typed pointers to the elements of s.kvStateMachineFactories
 	for i := range s.kvStateMachines {
-		func(i int) {
-			s.kvStateMachineFactories[i] = protocol_statemock.NewKeyValueStoreStateMachineFactory(s.T())
-			// the create method is mocked with a function which will return the kvStateMachines[i]
-			// and kvStateMachines[i] is nil at this moment, but should be updated in the test case
-			// before `Create` method is called.
-			s.kvStateMachineFactories[i].On("Create", s.candidate.View, s.candidate.ParentID, &s.parentState, &s.evolvingState).
-				Return(func(
-					view uint64,
-					parentID flow.Identifier,
-					parentState protocol.KVStoreReader,
-					targetState protocol_state.KVStoreMutator,
-				) (protocol_state.OrthogonalStoreStateMachine[protocol.KVStoreReader], error) {
-					return s.kvStateMachines[i], s.kvErrors[i]
-				}).Maybe()
-			kvStateMachineFactories[i] = s.kvStateMachineFactories[i]
-		}(i)
+		s.kvStateMachineFactories[i] = *protocol_statemock.NewKeyValueStoreStateMachineFactory(s.T())
+		s.kvStateMachineFactories[i].On("Create", s.candidate.View, s.candidate.ParentID, &s.parentState, &s.evolvingState).Return(&s.kvStateMachines[i], nil)
+		kvStateMachineFactories[i] = &s.kvStateMachineFactories[i]
 	}
 
 	s.mutableState = newMutableProtocolState(
@@ -417,7 +402,7 @@ func (s *StateMutatorSuite) Test_InvalidParent() {
 	_, dbUpdates, err := s.mutableState.EvolveState(unknownParent, s.candidate.View, []*flow.Seal{})
 	require.Error(s.T(), err)
 	require.False(s.T(), protocol.IsInvalidServiceEventError(err))
-	require.True(s.T(), len(dbUpdates) == 0)
+	require.Empty(s.T(), dbUpdates)
 }
 
 // Test_ReplicateFails verifies that errors during the parent state replication are escalated to the caller.
@@ -431,12 +416,12 @@ func (s *StateMutatorSuite) Test_ReplicateFails() {
 	s.parentState.On("Replicate", s.latestProtocolVersion).Return(nil, exception).Once()
 
 	// `SetupTest` initializes the mock factories to expect to be called, so we overwrite the mocks here:
-	s.kvStateMachineFactories[0] = protocol_statemock.NewKeyValueStoreStateMachineFactory(s.T())
-	s.kvStateMachineFactories[1] = protocol_statemock.NewKeyValueStoreStateMachineFactory(s.T())
+	s.kvStateMachineFactories[0] = *protocol_statemock.NewKeyValueStoreStateMachineFactory(s.T())
+	s.kvStateMachineFactories[1] = *protocol_statemock.NewKeyValueStoreStateMachineFactory(s.T())
 
 	_, dbUpdates, err := s.mutableState.EvolveState(s.candidate.ParentID, s.candidate.View, []*flow.Seal{})
 	require.ErrorIs(s.T(), err, exception)
-	require.True(s.T(), len(dbUpdates) == 0)
+	require.Empty(s.T(), dbUpdates)
 }
 
 // Test_StateMachineFactoryFails verifies that errors received while creating the sub-state machines are escalated to the caller.
@@ -450,23 +435,27 @@ func (s *StateMutatorSuite) Test_ReplicateFails() {
 //
 // This test also verifies that the `MutableProtocolState` does not engage in step (ii) or (iii) before the completing step (i) on all state machines.
 func (s *StateMutatorSuite) Test_StateMachineFactoryFails() {
+	workingFactory := *protocol_statemock.NewKeyValueStoreStateMachineFactory(s.T())
 	stateMachine := protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T()) // we expect no methods to be called on this state machine
+	workingFactory.On("Create", s.candidate.View, s.candidate.ParentID, &s.parentState, &s.evolvingState).Return(stateMachine, nil).Maybe()
+
 	exception := errors.New("exception")
+	failingFactory := *protocol_statemock.NewKeyValueStoreStateMachineFactory(s.T())
+	failingFactory.On("Create", s.candidate.View, s.candidate.ParentID, &s.parentState, &s.evolvingState).Return(nil, exception).Once()
 
 	s.Run("failing factory is last", func() {
-		s.kvStateMachines[0], s.kvErrors[0] = stateMachine, nil
-		s.kvStateMachines[1], s.kvErrors[1] = nil, exception
+		s.kvStateMachineFactories[0], s.kvStateMachineFactories[1] = workingFactory, failingFactory //nolint:govet
 		_, dbUpdates, err := s.mutableState.EvolveState(s.candidate.ParentID, s.candidate.View, []*flow.Seal{})
 		require.ErrorIs(s.T(), err, exception)
-		require.True(s.T(), len(dbUpdates) == 0)
+		require.Empty(s.T(), dbUpdates)
 	})
 
+	failingFactory.On("Create", s.candidate.View, s.candidate.ParentID, &s.parentState, &s.evolvingState).Return(nil, exception).Once()
 	s.Run("failing factory is first", func() {
-		s.kvStateMachines[0], s.kvErrors[0] = nil, exception
-		s.kvStateMachines[1], s.kvErrors[1] = stateMachine, nil
+		s.kvStateMachineFactories[0], s.kvStateMachineFactories[1] = failingFactory, workingFactory //nolint:govet
 		_, dbUpdates, err := s.mutableState.EvolveState(s.candidate.ParentID, s.candidate.View, []*flow.Seal{})
 		require.ErrorIs(s.T(), err, exception)
-		require.True(s.T(), len(dbUpdates) == 0)
+		require.Empty(s.T(), dbUpdates)
 	})
 }
 
@@ -484,11 +473,11 @@ func (s *StateMutatorSuite) Test_StateMachineFactoryFails() {
 //
 // This test also verifies that the `MutableProtocolState` does not engage in step (iii) before the completing step (ii) on all state machines.
 func (s *StateMutatorSuite) Test_StateMachineProcessingServiceEventsFails() {
-	workingStateMachine := protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T())
+	workingStateMachine := *protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T())
 	workingStateMachine.On("EvolveState", mock.MatchedBy(emptySlice[flow.ServiceEvent]())).Return(nil).Once()
 
 	exception := errors.New("exception")
-	failingStateMachine := protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T())
+	failingStateMachine := *protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T())
 	failingStateMachine.On("EvolveState", mock.MatchedBy(emptySlice[flow.ServiceEvent]())).Return(exception).Once()
 
 	s.Run("failing state machine is last", func() {
@@ -496,7 +485,7 @@ func (s *StateMutatorSuite) Test_StateMachineProcessingServiceEventsFails() {
 		_, dbUpdates, err := s.mutableState.EvolveState(s.candidate.ParentID, s.candidate.View, []*flow.Seal{})
 		require.ErrorIs(s.T(), err, exception)
 		require.False(s.T(), protocol.IsInvalidServiceEventError(err))
-		require.True(s.T(), len(dbUpdates) == 0)
+		require.Empty(s.T(), dbUpdates)
 	})
 
 	failingStateMachine.On("EvolveState", mock.MatchedBy(emptySlice[flow.ServiceEvent]())).Return(exception).Once()
@@ -505,7 +494,7 @@ func (s *StateMutatorSuite) Test_StateMachineProcessingServiceEventsFails() {
 		_, dbUpdates, err := s.mutableState.EvolveState(s.candidate.ParentID, s.candidate.View, []*flow.Seal{})
 		require.ErrorIs(s.T(), err, exception)
 		require.False(s.T(), protocol.IsInvalidServiceEventError(err))
-		require.True(s.T(), len(dbUpdates) == 0)
+		require.Empty(s.T(), dbUpdates)
 	})
 }
 
@@ -513,12 +502,12 @@ func (s *StateMutatorSuite) Test_StateMachineProcessingServiceEventsFails() {
 // during their `Build` step. Specifically, the state machine should handle invalid events internally and only escalate internal
 // errors in case of an irrecoverable problem.
 func (s *StateMutatorSuite) Test_StateMachineBuildFails() {
-	workingStateMachine := protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T())
+	workingStateMachine := *protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T())
 	workingStateMachine.On("EvolveState", mock.MatchedBy(emptySlice[flow.ServiceEvent]())).Return(nil).Twice()
 	workingStateMachine.On("Build").Return([]storage.BlockIndexingBatchWrite{}, nil).Maybe()
 
 	exception := errors.New("exception")
-	failingStateMachine := protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T())
+	failingStateMachine := *protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](s.T())
 	failingStateMachine.On("EvolveState", mock.MatchedBy(emptySlice[flow.ServiceEvent]())).Return(nil).Twice()
 	failingStateMachine.On("Build").Return(nil, exception).Once()
 
@@ -527,7 +516,7 @@ func (s *StateMutatorSuite) Test_StateMachineBuildFails() {
 		_, dbUpdates, err := s.mutableState.EvolveState(s.candidate.ParentID, s.candidate.View, []*flow.Seal{})
 		require.ErrorIs(s.T(), err, exception)
 		require.False(s.T(), protocol.IsInvalidServiceEventError(err))
-		require.True(s.T(), len(dbUpdates) == 0)
+		require.Empty(s.T(), dbUpdates)
 	})
 
 	failingStateMachine.On("Build").Return(nil, exception).Once()
@@ -536,7 +525,7 @@ func (s *StateMutatorSuite) Test_StateMachineBuildFails() {
 		_, dbUpdates, err := s.mutableState.EvolveState(s.candidate.ParentID, s.candidate.View, []*flow.Seal{})
 		require.ErrorIs(s.T(), err, exception)
 		require.False(s.T(), protocol.IsInvalidServiceEventError(err))
-		require.True(s.T(), len(dbUpdates) == 0)
+		require.Empty(s.T(), dbUpdates)
 	})
 }
 
@@ -632,7 +621,7 @@ func (m *mockStateTransition) DuringEvolveState(fn func(mock.Arguments)) *mockSt
 }
 
 // Mock constructs and configures the OrthogonalStoreStateMachine mock.
-func (m *mockStateTransition) Mock() *protocol_statemock.OrthogonalStoreStateMachine[protocol.KVStoreReader] {
+func (m *mockStateTransition) Mock() protocol_statemock.OrthogonalStoreStateMachine[protocol.KVStoreReader] {
 	evolveStateCalled := false
 	stateMachine := protocol_statemock.NewOrthogonalStoreStateMachine[protocol.KVStoreReader](m.T)
 	if m.expectedServiceEvents == nil {
@@ -652,5 +641,5 @@ func (m *mockStateTransition) Mock() *protocol_statemock.OrthogonalStoreStateMac
 			return nil
 		},
 	}, nil).Once()
-	return stateMachine //nolint:govet
+	return *stateMachine //nolint:govet
 }

--- a/storage/collections.go
+++ b/storage/collections.go
@@ -13,15 +13,16 @@ type CollectionsReader interface {
 	//   - `storage.ErrNotFound` if no light collection was found.
 	ByID(collID flow.Identifier) (*flow.Collection, error)
 
-	// LightByID returns collection with the given ID. Only retrieves
-	// transaction hashes.
+	// LightByID returns a reduced representation of the collection with the given ID.
+	// The reduced collection references the constituent transactions by their hashes.
 	//
 	// Expected errors during normal operation:
 	//   - `storage.ErrNotFound` if no light collection was found.
 	LightByID(collID flow.Identifier) (*flow.LightCollection, error)
 
-	// LightByTransactionID returns the collection for the given transaction ID. Only retrieves
-	// transaction hashes.
+	// LightByTransactionID returns a reduced representation of the collection
+	// holding the given transaction ID. The reduced collection references the
+	// constituent transactions by their hashes.
 	//
 	// Expected errors during normal operation:
 	//   - `storage.ErrNotFound` if no light collection was found.

--- a/storage/operation/collections.go
+++ b/storage/operation/collections.go
@@ -43,11 +43,11 @@ func RemoveCollectionPayloadIndices(w storage.Writer, blockID flow.Identifier) e
 	return RemoveByKey(w, MakePrefix(codeIndexCollection, blockID))
 }
 
-// UnsafeIndexCollectionByTransaction inserts a collection id keyed by a transaction id
-// Unsafe because a transaction can belong to multiple collections, indexing collection by a transaction
-// will overwrite the previous collection id that was indexed by the same transaction id
-// To prevent overwritting, the caller must check if the transaction is already indexed, and make sure there
-// is no dirty read before the writing by using locks.
+// UnsafeIndexCollectionByTransaction indexes a collection id keyed by a transaction id.
+// It is unsafe, because a transaction can belong to multiple collections; indexing a collection
+// by a transaction will overwrite the collection previously memorized to contain the transaction.
+// To prevent overwriting, the caller must check if the transaction is already indexed, and make
+// sure there is no dirty read before the writing by using locks.
 func UnsafeIndexCollectionByTransaction(w storage.Writer, txID flow.Identifier, collectionID flow.Identifier) error {
 	return UpsertByKey(w, MakePrefix(codeIndexCollectionByTransaction, txID), collectionID)
 }

--- a/storage/store/collections.go
+++ b/storage/store/collections.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/operation"
+	"github.com/onflow/flow-go/utils/logging"
 )
 
 type Collections struct {
@@ -155,8 +156,12 @@ func (c *Collections) batchStoreLightAndIndexByTransaction(collection *flow.Ligh
 			// so if transaction is already indexed by a collection, check if it's the same collection.
 			// TODO: For now we log a warning, but eventually we need to handle Byzantine clusters
 			if collectionID != differentColTxIsIn {
-				log.Error().Msgf("sanity check failed: transaction %v in collection %v is already indexed by a different collection %v",
-					txID, collectionID, differentColTxIsIn)
+				log.Error().
+					Str(logging.KeySuspicious, "true").
+					Hex("transaction hash", txID[:]).
+					Hex("previously persisted collection containing transactions", differentColTxIsIn[:]).
+					Hex("newly encountered collection containing transactions", collectionID[:]).
+					Msgf("sanity check failed: transaction contained in multiple collections -- this is a symptom of a byzantine collector cluster (or a bug)")
 			}
 			continue
 		}

--- a/storage/store/collections.go
+++ b/storage/store/collections.go
@@ -52,7 +52,11 @@ func (c *Collections) Store(collection *flow.Collection) error {
 	})
 }
 
-// ByID retrieves a collection by its ID.
+// ByID returns the collection with the given ID, including all
+// transactions within the collection.
+//
+// Expected errors during normal operation:
+//   - `storage.ErrNotFound` if no light collection was found.
 func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 	var (
 		light      flow.LightCollection
@@ -76,7 +80,11 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 	return &collection, nil
 }
 
-// LightByID retrieves a light collection by its ID.
+// LightByID returns a reduced representation of the collection with the given ID.
+// The reduced collection references the constituent transactions by their hashes.
+//
+// Expected errors during normal operation:
+//   - `storage.ErrNotFound` if no light collection was found.
 func (c *Collections) LightByID(colID flow.Identifier) (*flow.LightCollection, error) {
 	var collection flow.LightCollection
 
@@ -163,9 +171,20 @@ func (c *Collections) batchStoreLightAndIndexByTransaction(collection *flow.Ligh
 	return nil
 }
 
-// StoreLightAndIndexByTransaction stores a light collection and indexes it by transaction ID.
-// It's concurrent-safe.
-// any error returned are exceptions
+// StoreLightAndIndexByTransaction inserts the light collection (only
+// transaction IDs) and adds a transaction id index for each of the
+// transactions within the collection (transaction_id->collection_id).
+//
+// NOTE: Currently it is possible in rare circumstances for two collections
+// to be guaranteed which both contain the same transaction (see https://github.com/dapperlabs/flow-go/issues/3556).
+// The second of these will revert upon reaching the execution node, so
+// this doesn't impact the execution state, but it can result in the Access
+// node processing two collections which both contain the same transaction (see https://github.com/dapperlabs/flow-go/issues/5337).
+// To handle this, we skip indexing the affected transaction when inserting
+// the transaction_id->collection_id index when an index for the transaction
+// already exists.
+//
+// No errors are expected during normal operation.
 func (c *Collections) StoreLightAndIndexByTransaction(collection *flow.LightCollection) error {
 	// - This lock is to ensure there is no race condition when indexing collection by transaction ID
 	// - The access node uses this index to report the transaction status. It's done by first
@@ -186,7 +205,12 @@ func (c *Collections) StoreLightAndIndexByTransaction(collection *flow.LightColl
 	})
 }
 
-// LightByTransactionID retrieves a light collection by a transaction ID.
+// LightByTransactionID returns a reduced representation of the collection
+// holding the given transaction ID. The reduced collection references the
+// constituent transactions by their hashes.
+//
+// Expected errors during normal operation:
+//   - `storage.ErrNotFound` if no light collection was found.
 func (c *Collections) LightByTransactionID(txID flow.Identifier) (*flow.LightCollection, error) {
 	collID := &flow.Identifier{}
 	err := operation.LookupCollectionByTransaction(c.db.Reader(), txID, collID)

--- a/storage/store/epoch_commits_test.go
+++ b/storage/store/epoch_commits_test.go
@@ -23,7 +23,7 @@ func TestEpochCommitStoreAndRetrieve(t *testing.T) {
 		_, err := s.ByID(unittest.IdentifierFixture())
 		assert.ErrorIs(t, err, storage.ErrNotFound)
 
-		// s a commit in db
+		// store a commit in db
 		expected := unittest.EpochCommitFixture()
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return s.BatchStore(rw, expected)

--- a/storage/store/epoch_protocol_state_test.go
+++ b/storage/store/epoch_protocol_state_test.go
@@ -29,7 +29,7 @@ func TestProtocolStateStorage(t *testing.T) {
 
 		// store protocol state and auxiliary info
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-			// s epoch events to be able to retrieve them later
+			// store epoch events to be able to retrieve them later
 			err := setups.BatchStore(rw, expected.PreviousEpochSetup)
 			require.NoError(t, err)
 			err = setups.BatchStore(rw, expected.CurrentEpochSetup)
@@ -115,9 +115,9 @@ func TestProtocolStateMergeParticipants(t *testing.T) {
 		identity.Address = newAddress
 		protocolStateID := stateEntry.ID()
 
-		// s protocol state and auxiliary info
+		// store protocol state and auxiliary info
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-			// s epoch events to be able to retrieve them later
+			// store epoch events to be able to retrieve them later
 			err := setups.BatchStore(rw, stateEntry.PreviousEpochSetup)
 			require.NoError(t, err)
 			err = setups.BatchStore(rw, stateEntry.CurrentEpochSetup)
@@ -157,9 +157,9 @@ func TestProtocolStateRootSnapshot(t *testing.T) {
 		protocolStateID := expected.ID()
 		blockID := unittest.IdentifierFixture()
 
-		// s protocol state and auxiliary info
+		// store protocol state and auxiliary info
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-			// s epoch events to be able to retrieve them later
+			// store epoch events to be able to retrieve them later
 			err := setups.BatchStore(rw, expected.CurrentEpochSetup)
 			require.NoError(t, err)
 			err = commits.BatchStore(rw, expected.CurrentEpochCommit)

--- a/storage/store/epoch_setups_test.go
+++ b/storage/store/epoch_setups_test.go
@@ -24,7 +24,7 @@ func TestEpochSetupStoreAndRetrieve(t *testing.T) {
 		_, err := s.ByID(unittest.IdentifierFixture())
 		assert.ErrorIs(t, err, storage.ErrNotFound)
 
-		// s a setup in db
+		// store a setup in db
 		expected := unittest.EpochSetupFixture()
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return s.BatchStore(rw, expected)

--- a/storage/store/epoch_setups_test.go
+++ b/storage/store/epoch_setups_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/onflow/flow-go/storage/store"
 )
 
-// TestEpochSetupStoreAndRetrieve tests that a setup can be sd, retrieved and attempted to be sd again without an error
+// TestEpochSetupStoreAndRetrieve tests that a setup can be sd, retrieved and attempted to be stored again without an error
 func TestEpochSetupStoreAndRetrieve(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
 		metrics := metrics.NewNoopCollector()

--- a/storage/store/payloads_test.go
+++ b/storage/store/payloads_test.go
@@ -26,7 +26,7 @@ func TestPayloadStoreRetrieve(t *testing.T) {
 		blockID := unittest.IdentifierFixture()
 		expected := unittest.PayloadFixture(unittest.WithAllTheFixins)
 
-		// s payload
+		// store payload
 		err := s.Store(blockID, &expected)
 		require.NoError(t, err)
 

--- a/storage/store/seals_test.go
+++ b/storage/store/seals_test.go
@@ -26,7 +26,7 @@ func TestRetrieveWithoutStore(t *testing.T) {
 	})
 }
 
-// TestSealStoreRetrieve verifies that a seal can be sd and retrieved by its ID
+// TestSealStoreRetrieve verifies that a seal can be stored and retrieved by its ID
 func TestSealStoreRetrieve(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
 		metrics := metrics.NewNoopCollector()

--- a/storage/store/seals_test.go
+++ b/storage/store/seals_test.go
@@ -33,7 +33,7 @@ func TestSealStoreRetrieve(t *testing.T) {
 		s := store.NewSeals(metrics, db)
 
 		expected := unittest.Seal.Fixture()
-		// s seal
+		// store seal
 		err := s.Store(expected)
 		require.NoError(t, err)
 
@@ -57,7 +57,7 @@ func TestSealIndexAndRetrieve(t *testing.T) {
 		expectedSeal := unittest.Seal.Fixture()
 		blockID := unittest.IdentifierFixture()
 
-		// s the seal first
+		// store the seal first
 		err := s.Store(expectedSeal)
 		require.NoError(t, err)
 
@@ -85,7 +85,7 @@ func TestSealedBlockIndexAndRetrieve(t *testing.T) {
 		blockID := unittest.IdentifierFixture()
 		expectedSeal.BlockID = blockID
 
-		// s the seal first
+		// store the seal first
 		err := s.Store(expectedSeal)
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Context: 

[PR 7262](https://github.com/onflow/flow-go/pull/7262) introduces a subtle but potentially important change to the test [`state/protocol/protocol_state/state/mutable_protocol_state_test.go`](https://github.com/onflow/flow-go/blob/53f2fcff62158a4c913c0646ce069eaf095d91fa/state/protocol/protocol_state/state/mutable_protocol_state_test.go), which I think overall weakens the test. Hence, this PR reverts the questionable portion of the changes.

## Details

[PR 7262](https://github.com/onflow/flow-go/pull/7262) changes the [**variables holding mocks** from **value types** to **pointer types**](https://github.com/onflow/flow-go/blob/53f2fcff62158a4c913c0646ce069eaf095d91fa/state/protocol/protocol_state/state/mutable_protocol_state_test.go#L37-L38):

<img width="978" height="91" alt="Screenshot 2025-08-12 at 6 28 02 PM" src="https://github.com/user-attachments/assets/c8d2dff5-fb06-4b39-b7bb-7afbeb4229f5" />

### Note that there is an important reason why mocks are being represented by a value variable:

* When you instantiate a new Mock with the provided constructor ([like this](https://github.com/onflow/flow-go/blob/2064aa29347b763372a650ed838c81dd9146c29c/state/protocol/protocol_state/state/mutable_protocol_state_test.go#L82)), the [mock registers with the testing framework](https://github.com/onflow/flow-go/blob/84f63e4fb7f3a21faccd36bcc40c415786573fed/state/protocol/protocol_state/mock/key_value_store_state_machine_factory.go#L58) and tells the testing framework to assert that all expected calls have been done when the test concludes. 
* In test setups, we like to pre-instantiate Mocks, so we don't have to do it in every test individually. Lets assume there are 99 tests that all are expected to call method `X` on some `mock`. But a single test should not call `X`.
   - Do I write in all tests individually `mock.On("X").Return(..)`? That's a lot of work. Furthermore, there is a risk of forgetting in a single test to write `mock.On("X").Return(..)` and a bug slipping through.
   - Instead, I write in the tests setup `mock.On("X").Return(..)` so _all_ tests will uniformly require `X` to be called, _unless_ I explicitly specify something different. 
* This is how I deal with the one test where `mock.X()` is _not_ supposed to be called:
   * Avoid referencing the mock via a pointer. Do not write:
      ```golang
      mock := NewMock() // mock is a pointer, because mockery constructors return a pointer
      ```
      In other words, do _not_ do what you have just changed the code to. 
   * Instead use a value type for the mock (like the code was before). 
      ```golang
      mock := *NewMock() // mock is a value type
      ```
   * In that one test, where we do not expect `mock.X()` to be called, you just overwrite the mock:
      ```golang
      mock = *NewMock() // into the same memory that previously held the mock, we are now writing a newly initialized mock
      ```
      It works because:
       - the testing framework references the mock via a pointer and asks it: "all the calls you expected, did all those happens" ([code here](https://github.com/onflow/flow-go/blob/84f63e4fb7f3a21faccd36bcc40c415786573fed/state/protocol/protocol_state/mock/key_value_store_state_machine_factory.go#L58))
       - When you overwrite the mock, you also overwrite the mock's expectations.


**How was the tests weakened specifically?**
We introduced a `Maybe` ([here](https://github.com/onflow/flow-go/blob/53f2fcff62158a4c913c0646ce069eaf095d91fa/state/protocol/protocol_state/state/mutable_protocol_state_test.go#L94)) where previously we _required_ the constructors to be called. In other words, a buggy implementation that failed to call _some_ of the factories would now erroneously pass the test, while previously the tests would fail. 