### PR TITLE
Update CI workflow to leverage environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,10 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2204
     env:
       CADENCE_DEPLOY_KEY: ${{ secrets.CADENCE_DEPLOY_KEY }}
+    # Set the environment based on the author association of the pull request.
+    # This is used to determine whether the build should be run in an internal or external environment.
+    # If the author is a member or collaborator, use the internal environment; otherwise, use the external environment that will require approval
+    environment: ${{ (github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR') && 'internal ci' || 'external ci' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
     # Set the environment based on the author association of the pull request.
     # This is used to determine whether the build should be run in an internal or external environment.
     # If the author is a member or collaborator, use the internal environment; otherwise, use the external environment that will require approval
-    environment: ${{ (github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR') && 'internal ci' || 'external ci' }}
+    environment: ${{ (github.event_name == 'merge_group' || (github.event.pull_request && (github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR'))) && 'internal-ci' || 'external-ci' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
The following PR updates our CI workflow to leverage environments for accessing the Docker secrets. This will enable us to properly use the secrets with PRs from forks. The condition that is used to set the environment name enables us to leverage an `internal ci` for PRs from members associated with the org. The `external ci` environment will be used for non team members, and this will require a secondary approval by the protocol team before the environment can be accessed.