### PR TITLE
Address bugs in transit tooling

### DIFF
--- a/cmd/bootstrap/transit/cmd/generate_root_block_vote.go
+++ b/cmd/bootstrap/transit/cmd/generate_root_block_vote.go
@@ -52,8 +52,13 @@ func generateVote(c *cobra.Command, args []string) {
 	}
 
 	// load DKG private key
-	path := fmt.Sprintf(bootstrap.PathRandomBeaconPriv, nodeID)
-	data, err := io.ReadFile(filepath.Join(flagBootDir, path))
+	path := filepath.Join(flagBootDir, fmt.Sprintf(bootstrap.PathRandomBeaconPriv, nodeID))
+	// If output directory is specified, use it for the root-block.json
+	if flagOutputDir != "" {
+		path = filepath.Join(flagOutputDir, bootstrap.FilenameRandomBeaconPriv)
+	}
+
+	data, err := io.ReadFile(path)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not read DKG private key file")
 	}

--- a/cmd/bootstrap/transit/cmd/pull_root_block.go
+++ b/cmd/bootstrap/transit/cmd/pull_root_block.go
@@ -78,7 +78,7 @@ func pullRootBlock(c *cobra.Command, args []string) {
 	// this will set the path used to download the random beacon file and unwrap it
 	if flagOutputDir != "" {
 		fullRandomBeaconPath = filepath.Join(flagOutputDir, filepath.Base(objectName))
-		unWrappedRandomBeaconPath = filepath.Join(flagOutputDir, filepath.Base(objectName))
+		unWrappedRandomBeaconPath = filepath.Join(flagOutputDir, bootstrap.FilenameRandomBeaconPriv)
 	}
 
 	log.Info().Msgf("downloading random beacon key: %s", objectName)


### PR DESCRIPTION
## Description
When testing the `transit` tool, we identified two bugs that this PR addresses.

1. When generating the root block vote, we were not reading the random beacon key from the output folder. This led to failures as we were reading the root block vote from the one folder while it was being downloaded to a separate folder.
2. When setting the path for the unwrapped random beacon key, we were writing it to the wrong path. We were writing it back to the `.enc` path while it should be the unwrapped file name.