### PR TITLE
[Testing] Refactor testing lock manager usage

### DIFF
--- a/cmd/util/cmd/common/state.go
+++ b/cmd/util/cmd/common/state.go
@@ -12,7 +12,7 @@ import (
 	"github.com/onflow/flow-go/storage/store"
 )
 
-func InitProtocolState(lockManager lockctx.Manager, db storage.DB, storages *store.All) (protocol.State, error) {
+func OpenProtocolState(lockManager lockctx.Manager, db storage.DB, storages *store.All) (protocol.State, error) {
 	metrics := &metrics.NoopCollector{}
 
 	protocolState, err := protocolbadger.OpenState(
@@ -32,7 +32,7 @@ func InitProtocolState(lockManager lockctx.Manager, db storage.DB, storages *sto
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("could not init protocol state: %w", err)
+		return nil, fmt.Errorf("could not open protocol state: %w", err)
 	}
 
 	return protocolState, nil

--- a/cmd/util/cmd/common/state.go
+++ b/cmd/util/cmd/common/state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jordanschalm/lockctx"
+
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/state/protocol"
 	protocolbadger "github.com/onflow/flow-go/state/protocol/badger"

--- a/cmd/util/cmd/common/state.go
+++ b/cmd/util/cmd/common/state.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 
+	"github.com/jordanschalm/lockctx"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/state/protocol"
 	protocolbadger "github.com/onflow/flow-go/state/protocol/badger"
@@ -10,9 +11,8 @@ import (
 	"github.com/onflow/flow-go/storage/store"
 )
 
-func InitProtocolState(db storage.DB, storages *store.All) (protocol.State, error) {
+func InitProtocolState(lockManager lockctx.Manager, db storage.DB, storages *store.All) (protocol.State, error) {
 	metrics := &metrics.NoopCollector{}
-	lockManager := storage.NewTestingLockManager()
 
 	protocolState, err := protocolbadger.OpenState(
 		metrics,

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -53,6 +53,7 @@ func TestExtractExecutionState(t *testing.T) {
 	})
 
 	t.Run("retrieves block->state mapping", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 
 		withDirs(t, func(datadir, execdir, outdir string) {
 			// Initialize a proper Badger database instead of using empty directory
@@ -66,14 +67,13 @@ func TestExtractExecutionState(t *testing.T) {
 			blockID := unittest.IdentifierFixture()
 			stateCommitment := unittest.StateCommitmentFixture()
 
+			lctx := lockManager.NewContext()
+			require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))
 			require.NoError(t, storageDB.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				// Store the state commitment for the block ID
-				lockManager := storage.NewTestingLockManager()
-				lctx := lockManager.NewContext()
-				defer lctx.Release()
-				require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))
 				return operation.IndexStateCommitment(lctx, rw, blockID, stateCommitment)
 			}))
+			lctx.Release()
 
 			retrievedStateCommitment, err := commits.ByBlockID(blockID)
 			require.NoError(t, err)
@@ -93,6 +93,7 @@ func TestExtractExecutionState(t *testing.T) {
 	})
 
 	t.Run("happy path", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 
 		withDirs(t, func(datadir, execdir, _ string) {
 
@@ -139,13 +140,12 @@ func TestExtractExecutionState(t *testing.T) {
 				// generate random block and map it to state commitment
 				blockID := unittest.IdentifierFixture()
 
+				lctx := lockManager.NewContext()
+				require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))
 				require.NoError(t, storageDB.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-					lockManager := storage.NewTestingLockManager()
-					lctx := lockManager.NewContext()
-					defer lctx.Release()
-					require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))
 					return operation.IndexStateCommitment(lctx, rw, blockID, flow.StateCommitment(stateCommitment))
 				}))
+				lctx.Release()
 
 				data := make(map[string]keyPair, len(keys))
 				for j, key := range keys {

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -37,7 +37,6 @@ func TestExtractExecutionState(t *testing.T) {
 	metr := &metrics.NoopCollector{}
 
 	t.Run("missing block->state commitment mapping", func(t *testing.T) {
-
 		withDirs(t, func(datadir, execdir, outdir string) {
 			// Initialize a proper Badger database instead of using empty directory
 			db := unittest.PebbleDB(t, datadir)
@@ -96,7 +95,6 @@ func TestExtractExecutionState(t *testing.T) {
 		lockManager := storage.NewTestingLockManager()
 
 		withDirs(t, func(datadir, execdir, _ string) {
-
 			const (
 				checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
 				checkpointsToKeep  = 1

--- a/cmd/util/cmd/export-json-transactions/cmd.go
+++ b/cmd/util/cmd/export-json-transactions/cmd.go
@@ -74,9 +74,9 @@ func ExportTransactions(lockManager lockctx.Manager, dataDir string, outputDir s
 	storages := common.InitStorages(db)
 	defer db.Close()
 
-	state, err := common.InitProtocolState(lockManager, db, storages)
+	state, err := common.OpenProtocolState(lockManager, db, storages)
 	if err != nil {
-		return fmt.Errorf("could not init protocol state: %w", err)
+		return fmt.Errorf("could not open protocol state: %w", err)
 	}
 
 	// create finder

--- a/cmd/util/cmd/export-json-transactions/transactions/range_test.go
+++ b/cmd/util/cmd/export-json-transactions/transactions/range_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestFindBlockTransactions(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		// prepare two blocks
 		// block 1 has 2 collections
 		// block 2 has 1 collection
@@ -59,7 +60,8 @@ func TestFindBlockTransactions(t *testing.T) {
 		state.On("AtHeight", uint64(5)).Return(snap5, nil)
 
 		// store into database
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
+		lctx := lockManager.NewContext()
+		require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
 		defer lctx.Release()
 		require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			err := storages.Blocks.BatchStore(lctx, rw, &b1)

--- a/cmd/util/cmd/find-inconsistent-result/cmd.go
+++ b/cmd/util/cmd/find-inconsistent-result/cmd.go
@@ -101,9 +101,9 @@ func createStorages(dir string, lockManager lockctx.Manager) (
 	}
 
 	storages := common.InitStorages(db)
-	state, err := common.InitProtocolState(lockManager, db, storages)
+	state, err := common.OpenProtocolState(lockManager, db, storages)
 	if err != nil {
-		return nil, nil, nil, nil, db, fmt.Errorf("could not init protocol state: %v", err)
+		return nil, nil, nil, nil, db, fmt.Errorf("could not open protocol state: %v", err)
 	}
 
 	return storages.Headers, storages.Results, storages.Seals, state, db, err

--- a/cmd/util/cmd/find-inconsistent-result/cmd.go
+++ b/cmd/util/cmd/find-inconsistent-result/cmd.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jordanschalm/lockctx"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
@@ -36,7 +37,8 @@ func init() {
 }
 
 func run(*cobra.Command, []string) {
-	err := findFirstMismatch(flagDatadir, flagStartHeight, flagEndHeight)
+	lockManager := storage.MakeSingletonLockManager()
+	err := findFirstMismatch(flagDatadir, flagStartHeight, flagEndHeight, lockManager)
 	if err != nil {
 		if errors.Is(err, NoMissmatchFoundError) {
 			fmt.Printf("no mismatch found: %v\n", err)
@@ -46,9 +48,9 @@ func run(*cobra.Command, []string) {
 	}
 }
 
-func findFirstMismatch(datadir string, startHeight, endHeight uint64) error {
+func findFirstMismatch(datadir string, startHeight, endHeight uint64, lockManager lockctx.Manager) error {
 	fmt.Printf("initializing database\n")
-	headers, results, seals, state, db, err := createStorages(datadir)
+	headers, results, seals, state, db, err := createStorages(datadir, lockManager)
 	defer db.Close()
 	if err != nil {
 		return fmt.Errorf("could not create storages: %v", err)
@@ -91,7 +93,7 @@ func findFirstMismatch(datadir string, startHeight, endHeight uint64) error {
 	return nil
 }
 
-func createStorages(dir string) (
+func createStorages(dir string, lockManager lockctx.Manager) (
 	storage.Headers, storage.ExecutionResults, storage.Seals, protocol.State, storage.DB, error) {
 	db, err := common.InitStorage(dir)
 	if err != nil {
@@ -99,7 +101,7 @@ func createStorages(dir string) (
 	}
 
 	storages := common.InitStorages(db)
-	state, err := common.InitProtocolState(db, storages)
+	state, err := common.InitProtocolState(lockManager, db, storages)
 	if err != nil {
 		return nil, nil, nil, nil, db, fmt.Errorf("could not init protocol state: %v", err)
 	}

--- a/cmd/util/cmd/read-light-block/read_light_block_test.go
+++ b/cmd/util/cmd/read-light-block/read_light_block_test.go
@@ -17,10 +17,9 @@ import (
 func TestReadClusterRange(t *testing.T) {
 
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		chain := unittest.ClusterBlockChainFixture(5)
 		parent, blocks := chain[0], chain[1:]
-
-		lockManager := storage.NewTestingLockManager()
 
 		lctx := lockManager.NewContext()
 		require.NoError(t, lctx.AcquireLock(storage.LockInsertOrFinalizeClusterBlock))

--- a/cmd/util/cmd/read-protocol-state/cmd/blocks.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/blocks.go
@@ -148,10 +148,11 @@ func (r *Reader) IsExecuted(blockID flow.Identifier) (bool, error) {
 }
 
 func runE(*cobra.Command, []string) error {
+	lockManager := storage.MakeSingletonLockManager()
 	flagDBs := common.ReadDBFlags()
 	return common.WithStorage(flagDBs, func(db storage.DB) error {
 		storages := common.InitStorages(db)
-		state, err := common.InitProtocolState(db, storages)
+		state, err := common.InitProtocolState(lockManager, db, storages)
 
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not init protocol state")

--- a/cmd/util/cmd/read-protocol-state/cmd/blocks.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/blocks.go
@@ -152,7 +152,7 @@ func runE(*cobra.Command, []string) error {
 	flagDBs := common.ReadDBFlags()
 	return common.WithStorage(flagDBs, func(db storage.DB) error {
 		storages := common.InitStorages(db)
-		state, err := common.InitProtocolState(lockManager, db, storages)
+		state, err := common.OpenProtocolState(lockManager, db, storages)
 
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not init protocol state")

--- a/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
@@ -50,9 +50,10 @@ func init() {
 }
 
 func runSnapshotE(*cobra.Command, []string) error {
+	lockManager := storage.MakeSingletonLockManager()
 	return common.WithStorage(common.ReadDBFlags(), func(db storage.DB) error {
 		storages := common.InitStorages(db)
-		state, err := common.InitProtocolState(db, storages)
+		state, err := common.InitProtocolState(lockManager, db, storages)
 		if err != nil {
 			return fmt.Errorf("could not init protocol state")
 		}

--- a/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
@@ -53,7 +53,7 @@ func runSnapshotE(*cobra.Command, []string) error {
 	lockManager := storage.MakeSingletonLockManager()
 	return common.WithStorage(common.ReadDBFlags(), func(db storage.DB) error {
 		storages := common.InitStorages(db)
-		state, err := common.InitProtocolState(lockManager, db, storages)
+		state, err := common.OpenProtocolState(lockManager, db, storages)
 		if err != nil {
 			return fmt.Errorf("could not init protocol state")
 		}

--- a/cmd/util/cmd/reindex/cmd/results.go
+++ b/cmd/util/cmd/reindex/cmd/results.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
+	"github.com/onflow/flow-go/storage"
 )
 
 func init() {
@@ -15,13 +16,14 @@ var resultsCmd = &cobra.Command{
 	Use:   "results",
 	Short: "reindex sealed result IDs by block ID",
 	Run: func(cmd *cobra.Command, args []string) {
+		lockManager := storage.MakeSingletonLockManager()
 		db, err := common.InitStorage(flagDatadir)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not initialize storage")
 		}
 		defer db.Close()
 		storages := common.InitStorages(db)
-		state, err := common.InitProtocolState(db, storages)
+		state, err := common.InitProtocolState(lockManager, db, storages)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not init protocol state")
 		}

--- a/cmd/util/cmd/reindex/cmd/results.go
+++ b/cmd/util/cmd/reindex/cmd/results.go
@@ -23,9 +23,9 @@ var resultsCmd = &cobra.Command{
 		}
 		defer db.Close()
 		storages := common.InitStorages(db)
-		state, err := common.InitProtocolState(lockManager, db, storages)
+		state, err := common.OpenProtocolState(lockManager, db, storages)
 		if err != nil {
-			log.Fatal().Err(err).Msg("could not init protocol state")
+			log.Fatal().Err(err).Msg("could not open protocol state")
 		}
 
 		results := storages.Results

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height.go
@@ -66,9 +66,9 @@ func runE(*cobra.Command, []string) error {
 		return err
 	}
 	storages := common.InitStorages(db)
-	state, err := common.InitProtocolState(lockManager, db, storages)
+	state, err := common.OpenProtocolState(lockManager, db, storages)
 	if err != nil {
-		return fmt.Errorf("could not init protocol states: %w", err)
+		return fmt.Errorf("could not open protocol states: %w", err)
 	}
 
 	metrics := &metrics.NoopCollector{}

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height.go
@@ -47,6 +47,8 @@ func init() {
 }
 
 func runE(*cobra.Command, []string) error {
+	lockManager := storage.MakeSingletonLockManager()
+
 	log.Info().
 		Str("datadir", flagDataDir).
 		Str("chunk_data_pack_dir", flagChunkDataPackDir).
@@ -64,7 +66,7 @@ func runE(*cobra.Command, []string) error {
 		return err
 	}
 	storages := common.InitStorages(db)
-	state, err := common.InitProtocolState(db, storages)
+	state, err := common.InitProtocolState(lockManager, db, storages)
 	if err != nil {
 		return fmt.Errorf("could not init protocol states: %w", err)
 	}

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -52,7 +52,7 @@ func TestReExecuteBlock(t *testing.T) {
 			events := store.NewEvents(metrics, db)
 			serviceEvents := store.NewServiceEvents(metrics, db)
 
-			withLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
+			unittest.WithLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
 				return db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 					return blocks.BatchStore(lctx, rw, &genesis)
 				})
@@ -173,14 +173,6 @@ func TestReExecuteBlock(t *testing.T) {
 	})
 }
 
-func withLock(t *testing.T, manager lockctx.Manager, lockID string, fn func(lctx lockctx.Context) error) {
-	t.Helper()
-	lctx := manager.NewContext()
-	require.NoError(t, lctx.AcquireLock(lockID))
-	defer lctx.Release()
-	require.NoError(t, fn(lctx))
-}
-
 // Test save block execution related data, then remove it, and then
 // save again with different result should work
 func TestReExecuteBlockWithDifferentResult(t *testing.T) {
@@ -213,7 +205,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		chunkDataPacks := store.NewChunkDataPacks(metrics, pebbleimpl.ToDB(pdb), collections, bstorage.DefaultCacheSize)
 		txResults := store.NewTransactionResults(metrics, db, bstorage.DefaultCacheSize)
 
-		withLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
+		unittest.WithLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
 			return db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return blocks.BatchStore(lctx, rw, &genesis)
 			})
@@ -250,7 +242,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 			&unittest.GenesisStateCommitment)
 		header := executableBlock.Block.Header
 
-		withLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
+		unittest.WithLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
 			return db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return blocks.BatchStore(lctx, rw, executableBlock.Block)
 			})

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -25,9 +25,9 @@ import (
 // Test save block execution related data, then remove it, and then
 // save again should still work
 func TestReExecuteBlock(t *testing.T) {
-	lockManager := storage.NewTestingLockManager()
 	unittest.RunWithBadgerDB(t, func(bdb *badger.DB) {
 		unittest.RunWithPebbleDB(t, func(pdb *pebble.DB) {
+			lockManager := storage.NewTestingLockManager()
 
 			// bootstrap to init highest executed height
 			bootstrapper := bootstrap.NewBootstrapper(unittest.Logger())
@@ -52,7 +52,8 @@ func TestReExecuteBlock(t *testing.T) {
 			events := store.NewEvents(metrics, db)
 			serviceEvents := store.NewServiceEvents(metrics, db)
 
-			lockManager, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
+			lctx := lockManager.NewContext()
+			require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
 			err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return blocks.BatchStore(lctx, rw, &genesis)
 			})

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -25,6 +25,7 @@ import (
 // Test save block execution related data, then remove it, and then
 // save again should still work
 func TestReExecuteBlock(t *testing.T) {
+	lockManager := storage.NewTestingLockManager()
 	unittest.RunWithBadgerDB(t, func(bdb *badger.DB) {
 		unittest.RunWithPebbleDB(t, func(pdb *pebble.DB) {
 
@@ -33,7 +34,6 @@ func TestReExecuteBlock(t *testing.T) {
 			genesis := unittest.BlockFixture()
 			rootSeal := unittest.Seal.Fixture(unittest.Seal.WithBlock(genesis.Header))
 			db := badgerimpl.ToDB(bdb)
-			lockManager := storage.NewTestingLockManager()
 			err := bootstrapper.BootstrapExecutionDatabase(lockManager, db, rootSeal)
 			require.NoError(t, err)
 
@@ -185,6 +185,7 @@ func withLock(t *testing.T, manager lockctx.Manager, lockID string, fn func(lctx
 // Test save block execution related data, then remove it, and then
 // save again with different result should work
 func TestReExecuteBlockWithDifferentResult(t *testing.T) {
+	lockManager := storage.NewTestingLockManager()
 	unittest.RunWithPebbleDB(t, func(pdb *pebble.DB) {
 
 		// bootstrap to init highest executed height
@@ -194,7 +195,6 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		unittest.Seal.WithBlock(genesis.Header)(rootSeal)
 
 		db := pebbleimpl.ToDB(pdb)
-		lockManager := storage.NewTestingLockManager()
 		err := bootstrapper.BootstrapExecutionDatabase(lockManager, db, rootSeal)
 		require.NoError(t, err)
 

--- a/cmd/util/cmd/snapshot/cmd.go
+++ b/cmd/util/cmd/snapshot/cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/storage"
 )
 
 var (
@@ -43,6 +44,7 @@ func init() {
 }
 
 func run(*cobra.Command, []string) {
+	lockManager := storage.MakeSingletonLockManager()
 
 	db, err := common.InitStorage(flagDatadir)
 	if err != nil {
@@ -51,7 +53,7 @@ func run(*cobra.Command, []string) {
 	defer db.Close()
 
 	storages := common.InitStorages(db)
-	state, err := common.InitProtocolState(db, storages)
+	state, err := common.InitProtocolState(lockManager, db, storages)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not init protocol state")
 	}

--- a/cmd/util/cmd/snapshot/cmd.go
+++ b/cmd/util/cmd/snapshot/cmd.go
@@ -53,9 +53,9 @@ func run(*cobra.Command, []string) {
 	defer db.Close()
 
 	storages := common.InitStorages(db)
-	state, err := common.InitProtocolState(lockManager, db, storages)
+	state, err := common.OpenProtocolState(lockManager, db, storages)
 	if err != nil {
-		log.Fatal().Err(err).Msg("could not init protocol state")
+		log.Fatal().Err(err).Msg("could not open protocol state")
 	}
 
 	log := log.With().Uint64("block_height", flagHeight).Logger()

--- a/cmd/util/cmd/verify_execution_result/cmd.go
+++ b/cmd/util/cmd/verify_execution_result/cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/onflow/flow-go/engine/verification/verifier"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
 )
 
 var (
@@ -60,6 +61,7 @@ func init() {
 }
 
 func run(*cobra.Command, []string) {
+	lockManager := storage.MakeSingletonLockManager()
 	chainID := flow.ChainID(flagChain)
 	_ = chainID.Chain()
 
@@ -84,7 +86,7 @@ func run(*cobra.Command, []string) {
 		}
 
 		lg.Info().Msgf("verifying range from %d to %d", from, to)
-		err = verifier.VerifyRange(from, to, chainID, flagDatadir, flagChunkDataPackDir, flagWorkerCount, flagStopOnMismatch, flagtransactionFeesDisabled)
+		err = verifier.VerifyRange(lockManager, from, to, chainID, flagDatadir, flagChunkDataPackDir, flagWorkerCount, flagStopOnMismatch, flagtransactionFeesDisabled)
 		if err != nil {
 			lg.Fatal().Err(err).Msgf("could not verify range from %d to %d", from, to)
 		}
@@ -92,7 +94,7 @@ func run(*cobra.Command, []string) {
 
 	} else {
 		lg.Info().Msgf("verifying last %d sealed blocks", flagLastK)
-		err := verifier.VerifyLastKHeight(flagLastK, chainID, flagDatadir, flagChunkDataPackDir, flagWorkerCount, flagStopOnMismatch, flagtransactionFeesDisabled)
+		err := verifier.VerifyLastKHeight(lockManager, flagLastK, chainID, flagDatadir, flagChunkDataPackDir, flagWorkerCount, flagStopOnMismatch, flagtransactionFeesDisabled)
 		if err != nil {
 			lg.Fatal().Err(err).Msg("could not verify last k height")
 		}

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/gammazero/workerpool"
-	"github.com/jordanschalm/lockctx"
 	"github.com/onflow/crypto"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
@@ -140,7 +139,6 @@ func (p *ConsensusParticipants) Update(epochCounter uint64, data *run.Participan
 
 type Node struct {
 	db                fstorage.DB
-	lockManager       lockctx.Manager
 	dbCloser          io.Closer
 	dbDir             string
 	index             int

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -1417,8 +1417,7 @@ func (suite *Suite) TestLastFinalizedBlockHeightResult() {
 		newFinalizedBlock := unittest.BlockWithParentFixture(block.Header)
 
 		db := badgerimpl.ToDB(badgerdb)
-		testLockManager := storage.NewTestingLockManager()
-		lctx := testLockManager.NewContext()
+		lctx := suite.lockManager.NewContext()
 		err := lctx.AcquireLock(storage.LockInsertBlock)
 		require.NoError(suite.T(), err)
 		defer lctx.Release()

--- a/engine/access/ingestion2/engine_test.go
+++ b/engine/access/ingestion2/engine_test.go
@@ -98,8 +98,6 @@ func (s *Suite) SetupTest() {
 	s.db, s.dbDir = unittest.TempBadgerDB(s.T())
 	s.lockManager = storerr.NewTestingLockManager()
 
-	s.lockManager = storerr.NewTestingLockManager()
-
 	s.obsIdentity = unittest.IdentityFixture(unittest.WithRole(flow.RoleAccess))
 
 	s.blocks = storage.NewBlocks(s.T())

--- a/engine/access/rpc/backend/script_executor_test.go
+++ b/engine/access/rpc/backend/script_executor_test.go
@@ -97,6 +97,7 @@ func (s *ScriptExecutorSuite) bootstrap() {
 // SetupTest sets up the test environment for each test in the suite.
 // This includes initializing various components and mock objects needed for the tests.
 func (s *ScriptExecutorSuite) SetupTest() {
+	lockManager := storage.NewTestingLockManager()
 	s.log = unittest.Logger()
 	s.chain = flow.Emulator.Chain()
 
@@ -141,7 +142,7 @@ func (s *ScriptExecutorSuite) SetupTest() {
 		s.chain,
 		derivedChainData,
 		module.CollectionExecutedMetric(metrics.NewNoopCollector()),
-		storage.NewTestingLockManager(),
+		lockManager,
 	)
 	s.Require().NoError(err)
 

--- a/engine/common/follower/integration_test.go
+++ b/engine/common/follower/integration_test.go
@@ -44,10 +44,10 @@ import (
 // Each worker submits batchesPerWorker*blocksPerBatch blocks
 // In total we will submit workers*batchesPerWorker*blocksPerBatch
 func TestFollowerHappyPath(t *testing.T) {
-	lockManager := storage.NewTestingLockManager()
 	allIdentities := unittest.CompleteIdentitySet()
 	rootSnapshot := unittest.RootSnapshotFixture(allIdentities)
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		tracer := trace.NewNoopTracer()
 		log := unittest.Logger()

--- a/engine/common/follower/integration_test.go
+++ b/engine/common/follower/integration_test.go
@@ -44,6 +44,7 @@ import (
 // Each worker submits batchesPerWorker*blocksPerBatch blocks
 // In total we will submit workers*batchesPerWorker*blocksPerBatch
 func TestFollowerHappyPath(t *testing.T) {
+	lockManager := storage.NewTestingLockManager()
 	allIdentities := unittest.CompleteIdentitySet()
 	rootSnapshot := unittest.RootSnapshotFixture(allIdentities)
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
@@ -51,7 +52,6 @@ func TestFollowerHappyPath(t *testing.T) {
 		tracer := trace.NewNoopTracer()
 		log := unittest.Logger()
 		consumer := events.NewNoop()
-		lockManager := storage.NewTestingLockManager()
 		all := bstorage.InitAll(metrics, db)
 
 		// bootstrap root snapshot

--- a/engine/execution/pruner/core_test.go
+++ b/engine/execution/pruner/core_test.go
@@ -49,12 +49,12 @@ func TestLoopPruneExecutionDataFromRootToLatestSealed(t *testing.T) {
 			// indexed by height
 			chunks := make([]*verification.VerifiableChunkData, lastFinalizedHeight+2)
 			parentID := genesis.ID()
-			lctx := lockManager.NewContext()
-			require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
+			lctxGenesis := lockManager.NewContext()
+			require.NoError(t, lctxGenesis.AcquireLock(storage.LockInsertBlock))
 			require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-				return blockstore.BatchStore(lctx, rw, genesis)
+				return blockstore.BatchStore(lctxGenesis, rw, genesis)
 			}))
-			lctx.Release()
+			lctxGenesis.Release()
 
 			for i := 1; i <= lastFinalizedHeight; i++ {
 				chunk, block := unittest.VerifiableChunkDataFixture(0, func(header *flow.Header) {
@@ -62,18 +62,18 @@ func TestLoopPruneExecutionDataFromRootToLatestSealed(t *testing.T) {
 					header.ParentID = parentID
 				})
 				chunks[i] = chunk // index by height
-				lctx := lockManager.NewContext()
-				require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
+				lctxBlock := lockManager.NewContext()
+				require.NoError(t, lctxBlock.AcquireLock(storage.LockInsertBlock))
 				require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-					return blockstore.BatchStore(lctx, rw, block)
+					return blockstore.BatchStore(lctxBlock, rw, block)
 				}))
-				lctx.Release()
-				lctx = lockManager.NewContext()
-				require.NoError(t, lctx.AcquireLock(storage.LockFinalizeBlock))
+				lctxBlock.Release()
+				lctxFinality := lockManager.NewContext()
+				require.NoError(t, lctxFinality.AcquireLock(storage.LockFinalizeBlock))
 				require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-					return operation.IndexFinalizedBlockByHeight(lctx, rw, chunk.Header.Height, chunk.Header.ID())
+					return operation.IndexFinalizedBlockByHeight(lctxFinality, rw, chunk.Header.Height, chunk.Header.ID())
 				}))
-				lctx.Release()
+				lctxFinality.Release()
 				require.NoError(t, results.Store(chunk.Result))
 				require.NoError(t, results.Index(chunk.Result.BlockID, chunk.Result.ID()))
 				require.NoError(t, chunkDataPacks.Store([]*flow.ChunkDataPack{chunk.ChunkDataPack}))

--- a/engine/execution/pruner/core_test.go
+++ b/engine/execution/pruner/core_test.go
@@ -62,13 +62,13 @@ func TestLoopPruneExecutionDataFromRootToLatestSealed(t *testing.T) {
 					header.ParentID = parentID
 				})
 				chunks[i] = chunk // index by height
-				lctx := manager.NewContext()
+				lctx := lockManager.NewContext()
 				require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
 				require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 					return blockstore.BatchStore(lctx, rw, block)
 				}))
 				lctx.Release()
-				lctx = manager.NewContext()
+				lctx = lockManager.NewContext()
 				require.NoError(t, lctx.AcquireLock(storage.LockFinalizeBlock))
 				require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 					return operation.IndexFinalizedBlockByHeight(lctx, rw, chunk.Header.Height, chunk.Header.ID())

--- a/engine/execution/state/state_storehouse_test.go
+++ b/engine/execution/state/state_storehouse_test.go
@@ -38,6 +38,7 @@ import (
 
 func prepareStorehouseTest(f func(t *testing.T, es state.ExecutionState, l *ledger.Ledger, headers *storagemock.Headers, commits *storagemock.Commits, finalized *testutil.MockFinalizedReader)) func(*testing.T) {
 	return func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		unittest.RunWithBadgerDB(t, func(badgerDB *badger.DB) {
 			metricsCollector := &metrics.NoopCollector{}
 			diskWal := &fixtures.NoopWAL{}
@@ -66,7 +67,6 @@ func prepareStorehouseTest(f func(t *testing.T, es state.ExecutionState, l *ledg
 			results.On("BatchIndex", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			myReceipts := storagemock.NewMyExecutionReceipts(t)
 			myReceipts.On("BatchStoreMyReceipt", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-			lockManager := storage.NewTestingLockManager()
 
 			withRegisterStore(t, func(t *testing.T,
 				rs *storehouse.RegisterStore,

--- a/engine/execution/state/state_test.go
+++ b/engine/execution/state/state_test.go
@@ -25,6 +25,7 @@ import (
 
 func prepareTest(f func(t *testing.T, es state.ExecutionState, l *ledger.Ledger, headers *storage.Headers, commits *storage.Commits)) func(*testing.T) {
 	return func(t *testing.T) {
+		lockManager := storageerr.NewTestingLockManager()
 		unittest.RunWithBadgerDB(t, func(badgerDB *badger.DB) {
 			metricsCollector := &metrics.NoopCollector{}
 			diskWal := &fixtures.NoopWAL{}
@@ -51,7 +52,6 @@ func prepareTest(f func(t *testing.T, es state.ExecutionState, l *ledger.Ledger,
 				return 0, nil
 			}
 
-			lockManager := storageerr.NewTestingLockManager()
 			db := badgerimpl.ToDB(badgerDB)
 			es := state.NewExecutionState(
 				ls, stateCommitments, blocks, headers, chunkDataPacks, results, myReceipts, events, serviceEvents, txResults, db, getLatestFinalized, trace.NewNoopTracer(),

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -1048,7 +1048,7 @@ func VerificationNode(t testing.TB,
 			node.Me,
 			chunkVerifier,
 			approvalStorage,
-			lockManager,
+			node.LockManager,
 		)
 		require.NoError(t, err)
 	}

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -289,7 +289,6 @@ func CollectionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ro
 	require.NoError(t, err)
 	node.Me, err = local.New(identity.Identity().IdentitySkeleton, privKeys.StakingKey)
 	require.NoError(t, err)
-	lockManager := storage.NewTestingLockManager()
 
 	pools := epochs.NewTransactionPools(
 		func(_ uint64) mempool.Transactions {
@@ -328,7 +327,7 @@ func CollectionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ro
 
 	clusterStateFactory, err := factories.NewClusterStateFactory(
 		db,
-		lockManager,
+		node.LockManager,
 		node.Metrics,
 		node.Tracer,
 	)
@@ -337,7 +336,7 @@ func CollectionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ro
 	builderFactory, err := factories.NewBuilderFactory(
 		db,
 		node.State,
-		lockManager,
+		node.LockManager,
 		node.Headers,
 		node.Tracer,
 		node.Metrics,
@@ -619,8 +618,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ide
 	require.Equal(t, fmt.Sprint(rootSeal.FinalState), fmt.Sprint(commit))
 	require.Equal(t, rootSeal.ResultID, rootResult.ID())
 
-	lockManager := storage.NewTestingLockManager()
-	err = bootstrapper.BootstrapExecutionDatabase(lockManager, db, rootSeal)
+	err = bootstrapper.BootstrapExecutionDatabase(node.LockManager, db, rootSeal)
 	require.NoError(t, err)
 
 	registerDir := unittest.TempPebblePath(t)
@@ -657,7 +655,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ide
 		// TODO: test with register store
 		registerStore,
 		storehouseEnabled,
-		lockManager,
+		node.LockManager,
 	)
 
 	requestEngine, err := requester.New(
@@ -1027,7 +1025,6 @@ func VerificationNode(t testing.TB,
 	if node.ProcessedBlockHeight == nil {
 		node.ProcessedBlockHeight = store.NewConsumerProgress(badgerimpl.ToDB(node.PublicDB), module.ConsumeProgressVerificationBlockHeight)
 	}
-	lockManager := storage.NewTestingLockManager()
 	if node.VerifierEngine == nil {
 		vm := fvm.NewVirtualMachine()
 

--- a/engine/verification/verifier/engine_test.go
+++ b/engine/verification/verifier/engine_test.go
@@ -48,6 +48,7 @@ type VerifierEngineTestSuite struct {
 	metrics       *mockmodule.VerificationMetrics // mocks performance monitoring metrics
 	approvals     *mockstorage.ResultApprovals
 	chunkVerifier *mockmodule.ChunkVerifier
+	lockManager   lockctx.Manager
 }
 
 func TestVerifierEngine(t *testing.T) {
@@ -55,6 +56,7 @@ func TestVerifierEngine(t *testing.T) {
 }
 
 func (suite *VerifierEngineTestSuite) SetupTest() {
+	suite.lockManager = storage.NewTestingLockManager()
 	suite.state = new(protocol.State)
 	suite.net = mocknetwork.NewNetwork(suite.T())
 	suite.tracer = trace.NewNoopTracer()
@@ -108,7 +110,7 @@ func (suite *VerifierEngineTestSuite) getTestNewEngine() *verifier.Engine {
 		suite.me,
 		suite.chunkVerifier,
 		suite.approvals,
-		storage.NewTestingLockManager(),
+		suite.lockManager,
 	)
 	require.NoError(suite.T(), err)
 

--- a/engine/verification/verifier/verifiers.go
+++ b/engine/verification/verifier/verifiers.go
@@ -239,9 +239,9 @@ func initStorages(
 	}
 
 	storages := common.InitStorages(db)
-	state, err := common.InitProtocolState(lockManager, db, storages)
+	state, err := common.OpenProtocolState(lockManager, db, storages)
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("could not init protocol state: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("could not open protocol state: %w", err)
 	}
 
 	// require the chunk data pack data must exist before returning the storage module

--- a/engine/verification/verifier/verifiers.go
+++ b/engine/verification/verifier/verifiers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/jordanschalm/lockctx"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -31,6 +32,7 @@ import (
 // pruned.
 // Note, it returns nil if certain block is not executed, in this case warning will be logged
 func VerifyLastKHeight(
+	lockManager lockctx.Manager,
 	k uint64,
 	chainID flow.ChainID,
 	protocolDataDir string,
@@ -39,7 +41,7 @@ func VerifyLastKHeight(
 	stopOnMismatch bool,
 	transactionFeesDisabled bool,
 ) (err error) {
-	closer, storages, chunkDataPacks, state, verifier, err := initStorages(chainID, protocolDataDir, chunkDataPackDir, transactionFeesDisabled)
+	closer, storages, chunkDataPacks, state, verifier, err := initStorages(lockManager, chainID, protocolDataDir, chunkDataPackDir, transactionFeesDisabled)
 	if err != nil {
 		return fmt.Errorf("could not init storages: %w", err)
 	}
@@ -86,6 +88,7 @@ func VerifyLastKHeight(
 // VerifyRange verifies all chunks in the results of the blocks in the given range.
 // Note, it returns nil if certain block is not executed, in this case warning will be logged
 func VerifyRange(
+	lockManager lockctx.Manager,
 	from, to uint64,
 	chainID flow.ChainID,
 	protocolDataDir string, chunkDataPackDir string,
@@ -93,7 +96,7 @@ func VerifyRange(
 	stopOnMismatch bool,
 	transactionFeesDisabled bool,
 ) (err error) {
-	closer, storages, chunkDataPacks, state, verifier, err := initStorages(chainID, protocolDataDir, chunkDataPackDir, transactionFeesDisabled)
+	closer, storages, chunkDataPacks, state, verifier, err := initStorages(lockManager, chainID, protocolDataDir, chunkDataPackDir, transactionFeesDisabled)
 	if err != nil {
 		return fmt.Errorf("could not init storages: %w", err)
 	}
@@ -217,6 +220,7 @@ func verifyConcurrently(
 }
 
 func initStorages(
+	lockManager lockctx.Manager,
 	chainID flow.ChainID,
 	dataDir string,
 	chunkDataPackDir string,
@@ -235,7 +239,7 @@ func initStorages(
 	}
 
 	storages := common.InitStorages(db)
-	state, err := common.InitProtocolState(db, storages)
+	state, err := common.InitProtocolState(lockManager, db, storages)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("could not init protocol state: %w", err)
 	}

--- a/integration/testnet/container.go
+++ b/integration/testnet/container.go
@@ -384,6 +384,7 @@ func (c *Container) Connect() error {
 }
 
 func (c *Container) OpenState() (*state.State, error) {
+	lockManager := storage.NewTestingLockManager()
 	badgerdb, err := c.DB()
 	if err != nil {
 		return nil, err
@@ -408,7 +409,6 @@ func (c *Container) OpenState() (*state.State, error) {
 		store.DefaultProtocolKVStoreCacheSize, store.DefaultProtocolKVStoreByBlockIDCacheSize)
 	versionBeacons := store.NewVersionBeacons(db)
 
-	lockManager := storage.NewTestingLockManager()
 	return state.OpenState(
 		metrics,
 		db,

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -679,7 +679,8 @@ func PrepareFlowNetwork(t *testing.T, networkConf NetworkConfig, chainID flow.Ch
 	return flowNetwork
 }
 
-func (net *FlowNetwork) addConsensusFollower(t *testing.T, rootProtocolSnapshotPath string, followerConf ConsensusFollowerConfig, containers []ContainerConfig) {
+func (net *FlowNetwork) addConsensusFollower(t *testing.T, rootProtocolSnapshotPath string, followerConf ConsensusFollowerConfig, _ []ContainerConfig) {
+	lockManager := storage.NewTestingLockManager()
 	tmpdir := makeTempSubDir(t, net.baseTempdir, "flow-consensus-follower")
 
 	// create a directory for the follower database
@@ -717,7 +718,7 @@ func (net *FlowNetwork) addConsensusFollower(t *testing.T, rootProtocolSnapshotP
 		consensus_follower.WithPebbleDB(pebbleDB),
 		consensus_follower.WithBootstrapDir(followerBootstrapDir),
 		// each consenesus follower will have a different lock manager singleton
-		consensus_follower.WithLockManager(storage.NewTestingLockManager()),
+		consensus_follower.WithLockManager(lockManager),
 	)
 
 	stakedANContainer := net.ContainerByID(followerConf.StakedNodeID)

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -680,7 +680,6 @@ func PrepareFlowNetwork(t *testing.T, networkConf NetworkConfig, chainID flow.Ch
 }
 
 func (net *FlowNetwork) addConsensusFollower(t *testing.T, rootProtocolSnapshotPath string, followerConf ConsensusFollowerConfig, _ []ContainerConfig) {
-	lockManager := storage.NewTestingLockManager()
 	tmpdir := makeTempSubDir(t, net.baseTempdir, "flow-consensus-follower")
 
 	// create a directory for the follower database
@@ -707,6 +706,7 @@ func (net *FlowNetwork) addConsensusFollower(t *testing.T, rootProtocolSnapshotP
 		WithValueLogMaxEntries(100000) // Default is 1000000
 	badgerDB, err := badgerstorage.InitPublic(dbOpts)
 	require.NoError(t, err)
+	lockManager := storage.NewTestingLockManager()
 
 	bindAddr := gonet.JoinHostPort("localhost", testingdock.RandomPort(t))
 	opts := append(

--- a/module/block_iterator/iterator_test.go
+++ b/module/block_iterator/iterator_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestIterateHeight(t *testing.T) {
+	lockManager := storage.NewTestingLockManager()
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
 		// create blocks with siblings
 		b1 := &flow.Header{Height: 1}
@@ -24,7 +25,6 @@ func TestIterateHeight(t *testing.T) {
 		bs := []*flow.Header{b1, b2, b3}
 
 		// index height
-		lockManager := storage.NewTestingLockManager()
 		for _, b := range bs {
 			lctx := lockManager.NewContext()
 			require.NoError(t, lctx.AcquireLock(storage.LockFinalizeBlock))

--- a/module/builder/collection/builder_test.go
+++ b/module/builder/collection/builder_test.go
@@ -69,7 +69,7 @@ type BuilderSuite struct {
 // runs before each test runs
 func (suite *BuilderSuite) SetupTest() {
 	fmt.Println("SetupTest>>>>")
-	lockManager := storage.NewTestingLockManager()
+	suite.lockManager = storage.NewTestingLockManager()
 	var err error
 
 	suite.genesis = model.Genesis()
@@ -80,7 +80,6 @@ func (suite *BuilderSuite) SetupTest() {
 	suite.dbdir = unittest.TempDir(suite.T())
 	suite.badgerDB = unittest.BadgerDB(suite.T(), suite.dbdir)
 	suite.db = badgerimpl.ToDB(suite.badgerDB)
-	suite.lockManager = lockManager
 
 	metrics := metrics.NewNoopCollector()
 	tracer := trace.NewNoopTracer()
@@ -131,16 +130,16 @@ func (suite *BuilderSuite) SetupTest() {
 	root.Payload.ProtocolStateID = rootProtocolState.ID()
 	clusterStateRoot, err := clusterkv.NewStateRoot(suite.genesis, clusterQC, suite.epochCounter)
 	suite.Require().NoError(err)
-	clusterState, err := clusterkv.Bootstrap(suite.db, lockManager, clusterStateRoot)
+	clusterState, err := clusterkv.Bootstrap(suite.db, suite.lockManager, clusterStateRoot)
 	suite.Require().NoError(err)
 
-	suite.state, err = clusterkv.NewMutableState(clusterState, lockManager, tracer, suite.headers, suite.payloads)
+	suite.state, err = clusterkv.NewMutableState(clusterState, suite.lockManager, tracer, suite.headers, suite.payloads)
 	suite.Require().NoError(err)
 
 	state, err := pbadger.Bootstrap(
 		metrics,
 		suite.db,
-		lockManager,
+		suite.lockManager,
 		all.Headers,
 		all.Seals,
 		all.Results,
@@ -177,7 +176,7 @@ func (suite *BuilderSuite) SetupTest() {
 		suite.Assert().True(added)
 	}
 
-	suite.builder, _ = builder.NewBuilder(suite.db, tracer, lockManager, suite.protoState, suite.state, suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(), suite.epochCounter)
+	suite.builder, _ = builder.NewBuilder(suite.db, tracer, suite.lockManager, suite.protoState, suite.state, suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(), suite.epochCounter)
 }
 
 // runs after each test finishes
@@ -200,15 +199,15 @@ func (suite *BuilderSuite) InsertBlock(block model.Block) {
 }
 
 func (suite *BuilderSuite) FinalizeBlock(block model.Block) {
-	err := suite.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+	lctx := suite.lockManager.NewContext()
+	defer lctx.Release()
+	err := lctx.AcquireLock(storage.LockInsertOrFinalizeClusterBlock)
+	suite.Assert().NoError(err)
+
+	err = suite.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 		var refBlock flow.Header
 		err := operation.RetrieveHeader(rw.GlobalReader(), block.Payload.ReferenceBlockID, &refBlock)
 		if err != nil {
-			return err
-		}
-		lctx := suite.lockManager.NewContext()
-		defer lctx.Release()
-		if err := lctx.AcquireLock(storage.LockInsertOrFinalizeClusterBlock); err != nil {
 			return err
 		}
 		err = procedure.FinalizeClusterBlock(lctx, rw, block.ID())
@@ -1122,7 +1121,6 @@ func benchmarkBuildOn(b *testing.B, size int) {
 		block := unittest.ClusterBlockWithParent(final)
 		lctx := suite.lockManager.NewContext()
 		require.NoError(b, lctx.AcquireLock(storage.LockInsertOrFinalizeClusterBlock))
-
 		err := suite.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return procedure.InsertClusterBlock(lctx, rw, &block)
 		})

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -178,7 +178,6 @@ func (bs *BuilderSuite) chainSeal(incorporatedResult *flow.IncorporatedResult) {
 // For the verifiers to start checking a result R, they need a source of randomness for the block _incorporating_
 // result R. The result for block [A3] is incorporated in [parent], which does _not_ have a child yet.
 func (bs *BuilderSuite) SetupTest() {
-
 	lockManager := storage.NewTestingLockManager()
 	// set up no-op dependencies
 	noopMetrics := metrics.NewNoopCollector()

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -178,7 +178,6 @@ func (bs *BuilderSuite) chainSeal(incorporatedResult *flow.IncorporatedResult) {
 // For the verifiers to start checking a result R, they need a source of randomness for the block _incorporating_
 // result R. The result for block [A3] is incorporated in [parent], which does _not_ have a child yet.
 func (bs *BuilderSuite) SetupTest() {
-	lockManager := storage.NewTestingLockManager()
 	// set up no-op dependencies
 	noopMetrics := metrics.NewNoopCollector()
 	noopTracer := trace.NewNoopTracer()
@@ -250,6 +249,8 @@ func (bs *BuilderSuite) SetupTest() {
 
 	// set up temporary database for tests
 	bs.db, bs.dir = unittest.TempBadgerDB(bs.T())
+	lockManager := storage.NewTestingLockManager()
+
 	lctx := lockManager.NewContext()
 	require.NoError(bs.T(), lctx.AcquireLock(storage.LockFinalizeBlock))
 	defer lctx.Release()

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -179,6 +179,7 @@ func (bs *BuilderSuite) chainSeal(incorporatedResult *flow.IncorporatedResult) {
 // result R. The result for block [A3] is incorporated in [parent], which does _not_ have a child yet.
 func (bs *BuilderSuite) SetupTest() {
 
+	lockManager := storage.NewTestingLockManager()
 	// set up no-op dependencies
 	noopMetrics := metrics.NewNoopCollector()
 	noopTracer := trace.NewNoopTracer()
@@ -250,7 +251,8 @@ func (bs *BuilderSuite) SetupTest() {
 
 	// set up temporary database for tests
 	bs.db, bs.dir = unittest.TempBadgerDB(bs.T())
-	_, lctx := unittest.LockManagerWithContext(bs.T(), storage.LockFinalizeBlock)
+	lctx := lockManager.NewContext()
+	require.NoError(bs.T(), lctx.AcquireLock(storage.LockFinalizeBlock))
 	defer lctx.Release()
 
 	// insert finalized height and root height

--- a/module/execution/scripts_test.go
+++ b/module/execution/scripts_test.go
@@ -61,7 +61,7 @@ func (s *scriptTestSuite) TestScriptExecution() {
 	s.Run("Get Block", func() {
 		code := []byte(fmt.Sprintf(`access(all) fun main(): UInt64 {
 			getBlock(at: %d)!
-			return getCurrentBlock().height 
+			return getCurrentBlock().height
 		}`, s.height))
 
 		result, err := s.scripts.ExecuteAtBlockHeight(context.Background(), code, nil, s.height)
@@ -153,6 +153,7 @@ func (s *scriptTestSuite) TestGetAccountKeys() {
 }
 
 func (s *scriptTestSuite) SetupTest() {
+	lockManager := storage.NewTestingLockManager()
 	logger := unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 	entropyProvider := testutil.ProtocolStateWithSourceFixture(nil)
 	blockchain := unittest.BlockchainFixture(10)
@@ -190,7 +191,7 @@ func (s *scriptTestSuite) SetupTest() {
 		flow.Testnet.Chain(),
 		derivedChainData,
 		nil,
-		storage.NewTestingLockManager(),
+		lockManager,
 	)
 	s.Require().NoError(err)
 

--- a/module/executiondatasync/optimistic_sync/core_impl_test.go
+++ b/module/executiondatasync/optimistic_sync/core_impl_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jordanschalm/lockctx"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -27,6 +28,7 @@ type CoreImplSuite struct {
 	txResultErrMsgsRequester      *txerrmsgsmock.Requester
 	txResultErrMsgsRequestTimeout time.Duration
 	db                            *storagemock.DB
+	lockManager                   lockctx.Manager
 	persistentRegisters           *storagemock.RegisterIndex
 	persistentEvents              *storagemock.Events
 	persistentCollections         *storagemock.Collections
@@ -42,6 +44,7 @@ func TestCoreImplSuiteSuite(t *testing.T) {
 }
 
 func (c *CoreImplSuite) SetupTest() {
+	c.lockManager = storage.NewTestingLockManager()
 	t := c.T()
 	c.logger = zerolog.Nop()
 
@@ -82,7 +85,6 @@ func (c *CoreImplSuite) SetupTest() {
 func (c *CoreImplSuite) createTestCoreImpl() *CoreImpl {
 	block := unittest.BlockFixture()
 	executionResult := unittest.ExecutionResultFixture(unittest.WithBlock(&block))
-	lockManager := storage.NewTestingLockManager()
 
 	return NewCoreImpl(
 		c.logger,
@@ -98,7 +100,7 @@ func (c *CoreImplSuite) createTestCoreImpl() *CoreImpl {
 		c.persistentTxResultErrMsg,
 		c.latestPersistedSealedResult,
 		c.db,
-		lockManager,
+		c.lockManager,
 	)
 }
 

--- a/module/executiondatasync/optimistic_sync/pipeline_functional_test.go
+++ b/module/executiondatasync/optimistic_sync/pipeline_functional_test.go
@@ -110,12 +110,12 @@ func (p *PipelineFunctionalSuite) SetupTest() {
 	insertLctx := lockManager.NewContext()
 	err = insertLctx.AcquireLock(storage.LockInsertBlock)
 	p.Require().NoError(err)
-	defer insertLctx.Release()
 
 	err = p.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 		return operation.InsertHeader(insertLctx, rw, rootBlock.ID(), rootBlock)
 	})
 	p.Require().NoError(err)
+	insertLctx.Release()
 
 	lctx := p.lockManager.NewContext()
 	require.NoError(t, lctx.AcquireLock(storage.LockFinalizeBlock))

--- a/module/executiondatasync/optimistic_sync/pipeline_functional_test.go
+++ b/module/executiondatasync/optimistic_sync/pipeline_functional_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/dgraph-io/badger/v2"
+	"github.com/jordanschalm/lockctx"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -43,6 +44,7 @@ type PipelineFunctionalSuite struct {
 	bdb                           *badger.DB
 	pdb                           *pebble.DB
 	db                            storage.DB
+	lockManager                   lockctx.Manager
 	persistentRegisters           *pebbleStorage.Registers
 	persistentEvents              storage.Events
 	persistentCollections         *store.Collections
@@ -73,6 +75,7 @@ func TestPipelineFunctionalSuite(t *testing.T) {
 // the core implementation with all required dependencies.
 func (p *PipelineFunctionalSuite) SetupTest() {
 	t := p.T()
+	p.lockManager = storage.NewTestingLockManager()
 
 	p.tmpDir = unittest.TempDir(t)
 	p.logger = zerolog.Nop()
@@ -110,8 +113,7 @@ func (p *PipelineFunctionalSuite) SetupTest() {
 	p.Require().NoError(err)
 	insertLctx.Release()
 
-	manager := storage.NewTestingLockManager()
-	lctx := manager.NewContext()
+	lctx := p.lockManager.NewContext()
 	require.NoError(t, lctx.AcquireLock(storage.LockFinalizeBlock))
 	err = p.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 		return operation.IndexFinalizedBlockByHeight(lctx, rw, rootBlock.Height, rootBlock.ID())
@@ -120,7 +122,7 @@ func (p *PipelineFunctionalSuite) SetupTest() {
 	lctx.Release()
 
 	// store and index the latest sealed block header
-	insertLctx2 := manager.NewContext()
+	insertLctx2 := p.lockManager.NewContext()
 	require.NoError(t, insertLctx2.AcquireLock(storage.LockInsertBlock))
 	err = p.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 		return operation.InsertHeader(insertLctx2, rw, sealedBlock.Header.ID(), sealedBlock.Header)
@@ -128,7 +130,7 @@ func (p *PipelineFunctionalSuite) SetupTest() {
 	p.Require().NoError(err)
 	insertLctx2.Release()
 
-	lctx = manager.NewContext()
+	lctx = p.lockManager.NewContext()
 	require.NoError(t, lctx.AcquireLock(storage.LockFinalizeBlock))
 	err = p.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 		return operation.IndexFinalizedBlockByHeight(lctx, rw, sealedBlock.Header.Height, sealedBlock.ID())
@@ -431,7 +433,6 @@ func (p *PipelineFunctionalSuite) WithRunningPipeline(
 	testFunc func(pipeline Pipeline, updateChan chan State, errChan chan error, cancel context.CancelFunc),
 	pipelineConfig PipelineConfig,
 ) {
-	lockManager := storage.NewTestingLockManager()
 
 	p.core = NewCoreImpl(
 		p.logger,
@@ -447,7 +448,7 @@ func (p *PipelineFunctionalSuite) WithRunningPipeline(
 		p.persistentTxResultErrMsg,
 		p.persistentLatestSealedResult,
 		p.db,
-		lockManager,
+		p.lockManager,
 	)
 
 	pipelineStateConsumer := NewMockStateConsumer()

--- a/module/executiondatasync/optimistic_sync/pipeline_functional_test.go
+++ b/module/executiondatasync/optimistic_sync/pipeline_functional_test.go
@@ -111,7 +111,7 @@ func (p *PipelineFunctionalSuite) SetupTest() {
 	err = insertLctx.AcquireLock(storage.LockInsertBlock)
 	p.Require().NoError(err)
 	defer insertLctx.Release()
-	
+
 	err = p.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 		return operation.InsertHeader(insertLctx, rw, rootBlock.ID(), rootBlock)
 	})

--- a/module/executiondatasync/optimistic_sync/pipeline_functional_test.go
+++ b/module/executiondatasync/optimistic_sync/pipeline_functional_test.go
@@ -106,8 +106,7 @@ func (p *PipelineFunctionalSuite) SetupTest() {
 	// store and index the root header
 	p.headers = store.NewHeaders(p.metrics, p.db)
 
-	lockManager := storage.NewTestingLockManager()
-	insertLctx := lockManager.NewContext()
+	insertLctx := p.lockManager.NewContext()
 	err = insertLctx.AcquireLock(storage.LockInsertBlock)
 	p.Require().NoError(err)
 

--- a/module/finalizedreader/finalizedreader_test.go
+++ b/module/finalizedreader/finalizedreader_test.go
@@ -25,6 +25,7 @@ func withLock(t *testing.T, manager lockctx.Manager, lockID string, fn func(lctx
 
 func TestFinalizedReader(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		// prepare the storage.Headers instance
 		metrics := metrics.NewNoopCollector()
 		all := store.InitAll(metrics, db)
@@ -33,7 +34,6 @@ func TestFinalizedReader(t *testing.T) {
 		block1 := unittest.BlockFixture()
 
 		// store `block1`
-		lockManager := storage.NewTestingLockManager()
 		withLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
 			return db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return blocks.BatchStore(lctx, rw, &block1)

--- a/module/finalizedreader/finalizedreader_test.go
+++ b/module/finalizedreader/finalizedreader_test.go
@@ -15,14 +15,6 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-func withLock(t *testing.T, manager lockctx.Manager, lockID string, fn func(lctx lockctx.Context) error) {
-	t.Helper()
-	lctx := manager.NewContext()
-	require.NoError(t, lctx.AcquireLock(lockID))
-	defer lctx.Release()
-	require.NoError(t, fn(lctx))
-}
-
 func TestFinalizedReader(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
 		lockManager := storage.NewTestingLockManager()
@@ -34,14 +26,14 @@ func TestFinalizedReader(t *testing.T) {
 		block1 := unittest.BlockFixture()
 
 		// store `block1`
-		withLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
+		unittest.WithLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
 			return db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return blocks.BatchStore(lctx, rw, &block1)
 			})
 		})
 
 		// finalize `block1`
-		withLock(t, lockManager, storage.LockFinalizeBlock, func(lctx lockctx.Context) error {
+		unittest.WithLock(t, lockManager, storage.LockFinalizeBlock, func(lctx lockctx.Context) error {
 			return db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return operation.IndexFinalizedBlockByHeight(lctx, rw, block1.Header.Height, block1.ID())
 			})
@@ -60,12 +52,12 @@ func TestFinalizedReader(t *testing.T) {
 
 		// store and finalize one more block
 		block2 := unittest.BlockWithParentFixture(block1.Header)
-		withLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
+		unittest.WithLock(t, lockManager, storage.LockInsertBlock, func(lctx lockctx.Context) error {
 			return db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return blocks.BatchStore(lctx, rw, block2)
 			})
 		})
-		withLock(t, lockManager, storage.LockFinalizeBlock, func(lctx lockctx.Context) error {
+		unittest.WithLock(t, lockManager, storage.LockFinalizeBlock, func(lctx lockctx.Context) error {
 			return db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return operation.IndexFinalizedBlockByHeight(lctx, rw, block2.Header.Height, block2.ID())
 			})

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -60,7 +60,6 @@ func TestFinalizer(t *testing.T) {
 			defer lctx.Release()
 			state, err = cluster.Bootstrap(db, lockManager, stateRoot)
 			require.NoError(t, err)
-			lockManager := storage.NewTestingLockManager()
 			insertLctx := lockManager.NewContext()
 			err = insertLctx.AcquireLock(storage.LockInsertBlock)
 			require.NoError(t, err)

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -65,7 +65,7 @@ func TestFinalizer(t *testing.T) {
 			err = insertLctx.AcquireLock(storage.LockInsertBlock)
 			require.NoError(t, err)
 			defer insertLctx.Release()
-			
+
 			err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return operation.InsertHeader(insertLctx, rw, refBlock.ID(), refBlock)
 			})

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -27,6 +27,7 @@ func TestFinalizer(t *testing.T) {
 	// This test has to build on top of badgerdb, because the cleanup method depends
 	// on the badgerdb.DropAll method to wipe the database, which pebble does not support.
 	unittest.RunWithBadgerDB(t, func(badgerdb *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		db := badgerimpl.ToDB(badgerdb)
 		// reference block on the main consensus chain
 		refBlock := unittest.BlockHeaderFixture()
@@ -50,7 +51,6 @@ func TestFinalizer(t *testing.T) {
 			}
 		}
 
-		lockManager := storage.NewTestingLockManager()
 		// a helper function to bootstrap with the genesis block
 		bootstrap := func() {
 			stateRoot, err := cluster.NewStateRoot(genesis, unittest.QuorumCertificateFixture(), 0)

--- a/module/finalizer/consensus/finalizer_test.go
+++ b/module/finalizer/consensus/finalizer_test.go
@@ -64,14 +64,13 @@ func TestMakeFinalValidChain(t *testing.T) {
 	var list []flow.Identifier
 
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		dbImpl := badgerimpl.ToDB(db)
+
 		// set up lock context
 		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		err := lctx.AcquireLock(storage.LockFinalizeBlock)
 		require.NoError(t, err)
-		defer lctx.Release()
-
-		dbImpl := badgerimpl.ToDB(db)
 
 		// insert the latest finalized height
 		err = dbImpl.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
@@ -84,9 +83,9 @@ func TestMakeFinalValidChain(t *testing.T) {
 			return operation.IndexFinalizedBlockByHeight(lctx, rw, final.Height, final.ID())
 		})
 		require.NoError(t, err)
+		lctx.Release()
 
 		// insert the finalized block header into the DB
-
 		insertLctx := lockManager.NewContext()
 		require.NoError(t, insertLctx.AcquireLock(storage.LockInsertBlock))
 		err = dbImpl.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
@@ -145,14 +144,13 @@ func TestMakeFinalInvalidHeight(t *testing.T) {
 	var list []flow.Identifier
 
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		dbImpl := badgerimpl.ToDB(db)
+
 		// set up lock context
 		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		err := lctx.AcquireLock(storage.LockFinalizeBlock)
 		require.NoError(t, err)
-		defer lctx.Release()
-
-		dbImpl := badgerimpl.ToDB(db)
 
 		// insert the latest finalized height
 		err = dbImpl.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
@@ -165,6 +163,7 @@ func TestMakeFinalInvalidHeight(t *testing.T) {
 			return operation.IndexFinalizedBlockByHeight(lctx, rw, final.Height, final.ID())
 		})
 		require.NoError(t, err)
+		lctx.Release()
 
 		// insert the finalized block header into the DB
 		insertLctx := lockManager.NewContext()
@@ -219,14 +218,12 @@ func TestMakeFinalDuplicate(t *testing.T) {
 	var list []flow.Identifier
 
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		dbImpl := badgerimpl.ToDB(db)
 		// set up lock context
 		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		err := lctx.AcquireLock(storage.LockFinalizeBlock)
 		require.NoError(t, err)
-		defer lctx.Release()
-
-		dbImpl := badgerimpl.ToDB(db)
 
 		// insert the latest finalized height
 		err = dbImpl.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
@@ -239,6 +236,7 @@ func TestMakeFinalDuplicate(t *testing.T) {
 			return operation.IndexFinalizedBlockByHeight(lctx, rw, final.Height, final.ID())
 		})
 		require.NoError(t, err)
+		lctx.Release()
 
 		// insert the finalized block header into the DB
 		insertLctx := lockManager.NewContext()

--- a/module/state_synchronization/indexer/in_memory_indexer_test.go
+++ b/module/state_synchronization/indexer/in_memory_indexer_test.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"testing"
 
+	"github.com/jordanschalm/lockctx"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,10 +18,11 @@ import (
 )
 
 func TestNewInMemoryIndexer(t *testing.T) {
+	lockManager := storage.NewTestingLockManager()
 	header := unittest.BlockHeaderFixture()
 	block := unittest.BlockWithParentFixture(header)
 	exeResult := unittest.ExecutionResultFixture(unittest.WithBlock(block))
-	indexer, _ := createInMemoryIndexer(exeResult, header)
+	indexer, _ := createInMemoryIndexer(lockManager, exeResult, header)
 
 	assert.NotNil(t, indexer)
 	assert.Equal(t, header.Height, indexer.registers.LatestHeight())
@@ -28,11 +30,12 @@ func TestNewInMemoryIndexer(t *testing.T) {
 
 func TestInMemoryIndexer_IndexBlockData(t *testing.T) {
 	t.Run("Index Single Chunk and Single Register", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		header := unittest.BlockHeaderFixture()
 		block := unittest.BlockWithParentFixture(header)
 		blockID := block.ID()
 		exeResult := unittest.ExecutionResultFixture(unittest.WithBlock(block))
-		indexer, _ := createInMemoryIndexer(exeResult, header)
+		indexer, _ := createInMemoryIndexer(lockManager, exeResult, header)
 
 		trie := TrieUpdateRandomLedgerPayloadsFixture(t)
 		require.NotEmpty(t, trie.Payloads)
@@ -70,11 +73,12 @@ func TestInMemoryIndexer_IndexBlockData(t *testing.T) {
 	})
 
 	t.Run("Index Multiple Chunks and Merge Same Register Updates", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		header := unittest.BlockHeaderFixture()
 		block := unittest.BlockWithParentFixture(header)
 		blockID := block.ID()
 		exeResult := unittest.ExecutionResultFixture(unittest.WithBlock(block))
-		indexer, _ := createInMemoryIndexer(exeResult, header)
+		indexer, _ := createInMemoryIndexer(lockManager, exeResult, header)
 
 		tries := []*ledger.TrieUpdate{TrieUpdateRandomLedgerPayloadsFixture(t), TrieUpdateRandomLedgerPayloadsFixture(t)}
 		// Make sure we have two register updates that are updating the same value
@@ -114,11 +118,12 @@ func TestInMemoryIndexer_IndexBlockData(t *testing.T) {
 	})
 
 	t.Run("Index Events", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		header := unittest.BlockHeaderFixture()
 		block := unittest.BlockWithParentFixture(header)
 		blockID := block.ID()
 		exeResult := unittest.ExecutionResultFixture(unittest.WithBlock(block))
-		indexer, _ := createInMemoryIndexer(exeResult, header)
+		indexer, _ := createInMemoryIndexer(lockManager, exeResult, header)
 
 		expectedEvents := unittest.EventsFixture(20)
 		collection := unittest.CollectionFixture(0)
@@ -149,11 +154,12 @@ func TestInMemoryIndexer_IndexBlockData(t *testing.T) {
 	})
 
 	t.Run("Index Tx Results", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		header := unittest.BlockHeaderFixture()
 		block := unittest.BlockWithParentFixture(header)
 		blockID := block.ID()
 		exeResult := unittest.ExecutionResultFixture(unittest.WithBlock(block))
-		indexer, _ := createInMemoryIndexer(exeResult, header)
+		indexer, _ := createInMemoryIndexer(lockManager, exeResult, header)
 
 		expectedResults := unittest.LightTransactionResultsFixture(20)
 		collection := unittest.CollectionFixture(0)
@@ -185,11 +191,12 @@ func TestInMemoryIndexer_IndexBlockData(t *testing.T) {
 	})
 
 	t.Run("Index Collections", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		header := unittest.BlockHeaderFixture()
 		block := unittest.BlockWithParentFixture(header)
 		blockID := block.ID()
 		exeResult := unittest.ExecutionResultFixture(unittest.WithBlock(block))
-		indexer, transactions := createInMemoryIndexer(exeResult, header)
+		indexer, transactions := createInMemoryIndexer(lockManager, exeResult, header)
 
 		// Create collections and store them directly first
 		expectedCollections := unittest.CollectionListFixture(2)
@@ -233,11 +240,12 @@ func TestInMemoryIndexer_IndexBlockData(t *testing.T) {
 	})
 
 	t.Run("Index AllTheThings", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		header := unittest.BlockHeaderFixture()
 		block := unittest.BlockWithParentFixture(header)
 		blockID := block.ID()
 		exeResult := unittest.ExecutionResultFixture(unittest.WithBlock(block))
-		indexer, _ := createInMemoryIndexer(exeResult, header)
+		indexer, _ := createInMemoryIndexer(lockManager, exeResult, header)
 
 		expectedEvents := unittest.EventsFixture(20)
 		expectedResults := unittest.LightTransactionResultsFixture(20)
@@ -310,10 +318,11 @@ func TestInMemoryIndexer_IndexBlockData(t *testing.T) {
 	})
 
 	t.Run("Index Transaction Error Messages", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		header := unittest.BlockHeaderFixture()
 		block := unittest.BlockWithParentFixture(header)
 		exeResult := unittest.ExecutionResultFixture(unittest.WithBlock(block))
-		indexer, _ := createInMemoryIndexer(exeResult, header)
+		indexer, _ := createInMemoryIndexer(lockManager, exeResult, header)
 
 		txResultErrMsgsData := make([]flow.TransactionResultErrorMessage, 2)
 		for i := 0; i < 2; i++ {
@@ -336,16 +345,17 @@ func TestInMemoryIndexer_IndexBlockData(t *testing.T) {
 
 // Helper functions
 
-func createInMemoryIndexer(executionResult *flow.ExecutionResult, header *flow.Header) (*InMemoryIndexer, *unsynchronized.Transactions) {
+func createInMemoryIndexer(lockManager lockctx.Manager, executionResult *flow.ExecutionResult, header *flow.Header) (*InMemoryIndexer, *unsynchronized.Transactions) {
 	transactions := unsynchronized.NewTransactions()
 	return NewInMemoryIndexer(zerolog.Nop(),
-			unsynchronized.NewRegisters(header.Height),
-			unsynchronized.NewEvents(),
-			unsynchronized.NewCollections(transactions),
-			unsynchronized.NewLightTransactionResults(),
-			unsynchronized.NewTransactionResultErrorMessages(),
-			executionResult,
-			header,
-			storage.NewTestingLockManager()),
-		transactions
+		unsynchronized.NewRegisters(header.Height),
+		unsynchronized.NewEvents(),
+		unsynchronized.NewCollections(transactions),
+		unsynchronized.NewLightTransactionResults(),
+		unsynchronized.NewTransactionResultErrorMessages(),
+		executionResult,
+		header,
+		lockManager,
+	), transactions
+
 }

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -625,6 +625,7 @@ func trieRegistersPayloadComparer(t *testing.T, triePayloads []*ledger.Payload, 
 }
 
 func TestIndexerIntegration_StoreAndGet(t *testing.T) {
+	lockManager := storage.NewTestingLockManager()
 	regOwnerAddress := unittest.RandomAddressFixture()
 	regOwner := string(regOwnerAddress.Bytes())
 	regKey := "code"
@@ -643,7 +644,6 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 
 	// this test makes sure index values for a single register are correctly updated and always last value is returned
 	t.Run("Single Index Value Changes", func(t *testing.T) {
-		lockManager := storage.NewTestingLockManager()
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
 			index, err := New(
 				logger,
@@ -679,7 +679,6 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// this test makes sure if a register is not found the value returned is nil and without an error in order for this to be
 	// up to the specification script executor requires
 	t.Run("Missing Register", func(t *testing.T) {
-		lockManager := storage.NewTestingLockManager()
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
 			index, err := New(
 				logger,
@@ -708,7 +707,6 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// the correct highest height indexed value is returned.
 	// e.g. we index A{h(1) -> X}, A{h(2) -> Y}, when we request h(4) we get value Y
 	t.Run("Single Index Value At Later Heights", func(t *testing.T) {
-		lockManager := storage.NewTestingLockManager()
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
 			index, err := New(
 				logger,
@@ -754,7 +752,6 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 
 	// this test makes sure we correctly handle weird payloads
 	t.Run("Empty and Nil Payloads", func(t *testing.T) {
-		lockManager := storage.NewTestingLockManager()
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
 			index, err := New(
 				logger,

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -181,6 +181,7 @@ func (i *indexCoreTest) useDefaultTransactionResults() *indexCoreTest {
 }
 
 func (i *indexCoreTest) initIndexer() *indexCoreTest {
+	lockManager := storage.NewTestingLockManager()
 	db, dbDir := unittest.TempBadgerDB(i.t)
 	i.t.Cleanup(func() {
 		require.NoError(i.t, db.Close())
@@ -229,7 +230,7 @@ func (i *indexCoreTest) initIndexer() *indexCoreTest {
 		flow.Testnet.Chain(),
 		derivedChainData,
 		collectionExecutedMetric,
-		storage.NewTestingLockManager(),
+		lockManager,
 	)
 	require.NoError(i.t, err)
 	i.indexer = indexer
@@ -642,6 +643,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 
 	// this test makes sure index values for a single register are correctly updated and always last value is returned
 	t.Run("Single Index Value Changes", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
 			index, err := New(
 				logger,
@@ -656,7 +658,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 				flow.Testnet.Chain(),
 				derivedChainData,
 				nil,
-				storage.NewTestingLockManager(),
+				lockManager,
 			)
 			require.NoError(t, err)
 
@@ -677,6 +679,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// this test makes sure if a register is not found the value returned is nil and without an error in order for this to be
 	// up to the specification script executor requires
 	t.Run("Missing Register", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
 			index, err := New(
 				logger,
@@ -691,7 +694,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 				flow.Testnet.Chain(),
 				derivedChainData,
 				nil,
-				storage.NewTestingLockManager(),
+				lockManager,
 			)
 			require.NoError(t, err)
 
@@ -705,6 +708,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// the correct highest height indexed value is returned.
 	// e.g. we index A{h(1) -> X}, A{h(2) -> Y}, when we request h(4) we get value Y
 	t.Run("Single Index Value At Later Heights", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
 			index, err := New(
 				logger,
@@ -719,7 +723,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 				flow.Testnet.Chain(),
 				derivedChainData,
 				nil,
-				storage.NewTestingLockManager(),
+				lockManager,
 			)
 			require.NoError(t, err)
 
@@ -750,6 +754,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 
 	// this test makes sure we correctly handle weird payloads
 	t.Run("Empty and Nil Payloads", func(t *testing.T) {
+		lockManager := storage.NewTestingLockManager()
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
 			index, err := New(
 				logger,
@@ -764,7 +769,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 				flow.Testnet.Chain(),
 				derivedChainData,
 				nil,
-				storage.NewTestingLockManager(),
+				lockManager,
 			)
 			require.NoError(t, err)
 

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -65,8 +65,7 @@ func (suite *MutatorSuite) SetupTest() {
 	suite.dbdir = unittest.TempDir(suite.T())
 	suite.badgerdb = unittest.BadgerDB(suite.T(), suite.dbdir)
 	suite.db = badgerimpl.ToDB(suite.badgerdb)
-	lockManager := storage.NewTestingLockManager()
-	suite.lockManager = lockManager
+	suite.lockManager = storage.NewTestingLockManager()
 
 	metrics := metrics.NewNoopCollector()
 	tracer := trace.NewNoopTracer()
@@ -104,7 +103,7 @@ func (suite *MutatorSuite) SetupTest() {
 	state, err := pbadger.Bootstrap(
 		metrics,
 		suite.db,
-		lockManager,
+		suite.lockManager,
 		all.Headers,
 		all.Seals,
 		all.Results,

--- a/state/protocol/util/testing.go
+++ b/state/protocol/util/testing.go
@@ -68,9 +68,9 @@ func MockSealValidator(sealsDB storage.Seals) module.SealValidator {
 
 func RunWithBootstrapState(t testing.TB, rootSnapshot protocol.Snapshot, f func(*badger.DB, *pbadger.State)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		all := bstorage.InitAll(metrics, db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),
@@ -94,12 +94,12 @@ func RunWithBootstrapState(t testing.TB, rootSnapshot protocol.Snapshot, f func(
 
 func RunWithFullProtocolState(t testing.TB, rootSnapshot protocol.Snapshot, f func(*badger.DB, *pbadger.ParticipantState)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := bstorage.InitAll(metrics, db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),
@@ -138,11 +138,11 @@ func RunWithFullProtocolState(t testing.TB, rootSnapshot protocol.Snapshot, f fu
 
 func RunWithFullProtocolStateAndMetrics(t testing.TB, rootSnapshot protocol.Snapshot, metrics module.ComplianceMetrics, f func(*badger.DB, *pbadger.ParticipantState)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := bstorage.InitAll(mmetrics.NewNoopCollector(), db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),
@@ -182,12 +182,12 @@ func RunWithFullProtocolStateAndMetrics(t testing.TB, rootSnapshot protocol.Snap
 
 func RunWithFullProtocolStateAndValidator(t testing.TB, rootSnapshot protocol.Snapshot, validator module.ReceiptValidator, f func(*badger.DB, *pbadger.ParticipantState)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := bstorage.InitAll(metrics, db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),
@@ -225,12 +225,12 @@ func RunWithFullProtocolStateAndValidator(t testing.TB, rootSnapshot protocol.Sn
 
 func RunWithFollowerProtocolState(t testing.TB, rootSnapshot protocol.Snapshot, f func(*badger.DB, *pbadger.FollowerState)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := bstorage.InitAll(metrics, db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),
@@ -265,11 +265,11 @@ func RunWithFollowerProtocolState(t testing.TB, rootSnapshot protocol.Snapshot, 
 
 func RunWithFullProtocolStateAndConsumer(t testing.TB, rootSnapshot protocol.Snapshot, consumer protocol.Consumer, f func(*badger.DB, *pbadger.ParticipantState)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		all := bstorage.InitAll(metrics, db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),
@@ -308,10 +308,10 @@ func RunWithFullProtocolStateAndConsumer(t testing.TB, rootSnapshot protocol.Sna
 
 func RunWithFullProtocolStateAndMetricsAndConsumer(t testing.TB, rootSnapshot protocol.Snapshot, metrics module.ComplianceMetrics, consumer protocol.Consumer, f func(*badger.DB, *pbadger.ParticipantState, protocol.MutableProtocolState)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		all := bstorage.InitAll(mmetrics.NewNoopCollector(), db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),
@@ -360,12 +360,12 @@ func RunWithFullProtocolStateAndMetricsAndConsumer(t testing.TB, rootSnapshot pr
 
 func RunWithFollowerProtocolStateAndHeaders(t testing.TB, rootSnapshot protocol.Snapshot, f func(*badger.DB, *pbadger.FollowerState, storage.Headers, storage.Index)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := bstorage.InitAll(metrics, db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),
@@ -400,12 +400,12 @@ func RunWithFollowerProtocolStateAndHeaders(t testing.TB, rootSnapshot protocol.
 
 func RunWithFullProtocolStateAndMutator(t testing.TB, rootSnapshot protocol.Snapshot, f func(*badger.DB, *pbadger.ParticipantState, protocol.MutableProtocolState)) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := bstorage.InitAll(metrics, db)
-		lockManager := storage.NewTestingLockManager()
 		state, err := pbadger.Bootstrap(
 			metrics,
 			badgerimpl.ToDB(db),

--- a/storage/operation/children_test.go
+++ b/storage/operation/children_test.go
@@ -23,12 +23,12 @@ func TestBlockChildrenIndexUpdateLookup(t *testing.T) {
 		lctx := lockManager.NewContext()
 		err := lctx.AcquireLock(storage.LockInsertBlock)
 		require.NoError(t, err)
-		defer lctx.Release()
 
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return operation.UpsertBlockChildren(lctx, rw.Writer(), blockID, childrenIDs)
 		})
 		require.NoError(t, err)
+		lctx.Release()
 		err = operation.RetrieveBlockChildren(db.Reader(), blockID, &retrievedIDs)
 		require.NoError(t, err)
 		assert.Equal(t, childrenIDs, retrievedIDs)

--- a/storage/operation/children_test.go
+++ b/storage/operation/children_test.go
@@ -15,22 +15,26 @@ import (
 
 func TestBlockChildrenIndexUpdateLookup(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		blockID := unittest.IdentifierFixture()
 		childrenIDs := unittest.IdentifierListFixture(8)
 		var retrievedIDs flow.IdentifierList
 
-		manager, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
-		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockInsertBlock)
+		require.NoError(t, err)
+		defer lctx.Release()
+
+		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return operation.UpsertBlockChildren(lctx, rw.Writer(), blockID, childrenIDs)
 		})
 		require.NoError(t, err)
-		lctx.Release()
 		err = operation.RetrieveBlockChildren(db.Reader(), blockID, &retrievedIDs)
 		require.NoError(t, err)
 		assert.Equal(t, childrenIDs, retrievedIDs)
 
 		altIDs := unittest.IdentifierListFixture(4)
-		lctx = manager.NewContext()
+		lctx = lockManager.NewContext()
 		require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return operation.UpsertBlockChildren(lctx, rw.Writer(), blockID, altIDs)

--- a/storage/operation/cluster_test.go
+++ b/storage/operation/cluster_test.go
@@ -79,6 +79,7 @@ func TestClusterHeights(t *testing.T) {
 // Test_RetrieveClusterFinalizedHeight verifies proper retrieval of the latest finalized cluster block height.
 func Test_RetrieveClusterFinalizedHeight(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		var (
 			clusterID flow.ChainID = "cluster"
 			expected  uint64       = 42
@@ -93,7 +94,6 @@ func Test_RetrieveClusterFinalizedHeight(t *testing.T) {
 		})
 
 		t.Run("insert/retrieve", func(t *testing.T) {
-			lockManager := storage.NewTestingLockManager()
 
 			lctx := lockManager.NewContext()
 			require.NoError(t, lctx.AcquireLock(storage.LockInsertOrFinalizeClusterBlock))
@@ -122,7 +122,6 @@ func Test_RetrieveClusterFinalizedHeight(t *testing.T) {
 			// and only memorizes the last value stored (irrespective of cluster ID).
 			clusterFinalizedHeights := []uint64{117, 11, 791}
 			clusterIDs := []flow.ChainID{"cluster-0", "cluster-1", "cluster-2"}
-			lockManager := storage.NewTestingLockManager()
 			var actual uint64
 			for i := 0; i < len(clusterFinalizedHeights); i++ {
 				err = operation.RetrieveClusterFinalizedHeight(db.Reader(), clusterIDs[i], &actual)
@@ -145,8 +144,8 @@ func Test_RetrieveClusterFinalizedHeight(t *testing.T) {
 }
 
 func TestClusterBlockByReferenceHeight(t *testing.T) {
-	lockManager := storage.NewTestingLockManager()
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		t.Run("should be able to index cluster block by reference height", func(t *testing.T) {
 			id := unittest.IdentifierFixture()
 			height := rand.Uint64()

--- a/storage/operation/cluster_test.go
+++ b/storage/operation/cluster_test.go
@@ -166,6 +166,7 @@ func TestClusterBlockByReferenceHeight(t *testing.T) {
 	})
 
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		t.Run("should be able to index multiple cluster blocks at same reference height", func(t *testing.T) {
 			ids := unittest.IdentifierListFixture(10)
 			height := rand.Uint64()
@@ -188,6 +189,7 @@ func TestClusterBlockByReferenceHeight(t *testing.T) {
 	})
 
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		t.Run("should be able to lookup cluster blocks across height range", func(t *testing.T) {
 			ids := unittest.IdentifierListFixture(100)
 			nextHeight := rand.Uint64()

--- a/storage/operation/commits_test.go
+++ b/storage/operation/commits_test.go
@@ -14,13 +14,13 @@ import (
 
 func TestStateCommitments(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		expected := unittest.StateCommitmentFixture()
 		id := unittest.IdentifierFixture()
+		lctx := lockManager.NewContext()
+		defer lctx.Release()
+		require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))
 		require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-			lockManager := storage.NewTestingLockManager()
-			lctx := lockManager.NewContext()
-			defer lctx.Release()
-			require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))
 			return operation.IndexStateCommitment(lctx, rw, id, expected)
 		}))
 

--- a/storage/operation/guarantees_test.go
+++ b/storage/operation/guarantees_test.go
@@ -23,7 +23,7 @@ func TestGuaranteeInsertRetrieve(t *testing.T) {
 		err := lctx.AcquireLock(storage.LockInsertBlock)
 		require.NoError(t, err)
 		defer lctx.Release()
-		
+
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return operation.UnsafeInsertGuarantee(lctx, rw.Writer(), g.CollectionID, g)
 		})
@@ -53,7 +53,7 @@ func TestIndexGuaranteedCollectionByBlockHashInsertRetrieve(t *testing.T) {
 		err := lctx.AcquireLock(storage.LockInsertBlock)
 		require.NoError(t, err)
 		defer lctx.Release()
-		
+
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			for _, guarantee := range guarantees {
 				if err := operation.UnsafeInsertGuarantee(lctx, rw.Writer(), guarantee.ID(), guarantee); err != nil {
@@ -101,7 +101,7 @@ func TestIndexGuaranteedCollectionByBlockHashMultipleBlocks(t *testing.T) {
 		err := lctx1.AcquireLock(storage.LockInsertBlock)
 		require.NoError(t, err)
 		defer lctx1.Release()
-		
+
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			for _, guarantee := range set1 {
 				if err := operation.UnsafeInsertGuarantee(lctx1, rw.Writer(), guarantee.CollectionID, guarantee); err != nil {

--- a/storage/operation/headers_test.go
+++ b/storage/operation/headers_test.go
@@ -29,10 +29,13 @@ func TestHeaderInsertCheckRetrieve(t *testing.T) {
 		}
 		blockID := expected.ID()
 
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
+		lockManager := storage.NewTestingLockManager()
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockInsertBlock)
+		require.NoError(t, err)
 		defer lctx.Release()
 
-		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return operation.InsertHeader(lctx, rw, expected.ID(), expected)
 		})
 		require.NoError(t, err)
@@ -69,10 +72,13 @@ func TestBlockHeightIndexLookup(t *testing.T) {
 		height := uint64(1337)
 		expected := flow.Identifier{0x01, 0x02, 0x03}
 
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockFinalizeBlock)
+		lockManager := storage.NewTestingLockManager()
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockFinalizeBlock)
+		require.NoError(t, err)
 		defer lctx.Release()
 
-		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return operation.IndexFinalizedBlockByHeight(lctx, rw, height, expected)
 		})
 		require.NoError(t, err)

--- a/storage/operation/payload_test.go
+++ b/storage/operation/payload_test.go
@@ -46,7 +46,7 @@ func TestSealIndexAndLookup(t *testing.T) {
 		err := lctx.AcquireLock(storage.LockInsertBlock)
 		require.NoError(t, err)
 		defer lctx.Release()
-		
+
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			for _, seal := range seals {
 				if err := operation.InsertSeal(rw.Writer(), seal.ID(), seal); err != nil {

--- a/storage/procedure/children_test.go
+++ b/storage/procedure/children_test.go
@@ -15,12 +15,16 @@ import (
 // after indexing a block by its parent, it should be able to retrieve the child block by the parentID
 func TestIndexAndLookupChild(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
+		lockManager := storage.NewTestingLockManager()
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockInsertBlock)
+		require.NoError(t, err)
+		defer lctx.Release()
 
 		parentID := unittest.IdentifierFixture()
 		childID := unittest.IdentifierFixture()
 
-		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return procedure.IndexNewBlock(lctx, rw, childID, parentID)
 		})
 		require.NoError(t, err)
@@ -40,14 +44,18 @@ func TestIndexAndLookupChild(t *testing.T) {
 // was indexed.
 func TestIndexTwiceAndRetrieve(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
+		lockManager := storage.NewTestingLockManager()
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockInsertBlock)
+		require.NoError(t, err)
+		defer lctx.Release()
 
 		parentID := unittest.IdentifierFixture()
 		child1ID := unittest.IdentifierFixture()
 		child2ID := unittest.IdentifierFixture()
 
 		// index the first child
-		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return procedure.IndexNewBlock(lctx, rw, child1ID, parentID)
 		})
 		require.NoError(t, err)
@@ -69,11 +77,15 @@ func TestIndexTwiceAndRetrieve(t *testing.T) {
 // if parent is zero, then we don't index it
 func TestIndexZeroParent(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
+		lockManager := storage.NewTestingLockManager()
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockInsertBlock)
+		require.NoError(t, err)
+		defer lctx.Release()
 
 		childID := unittest.IdentifierFixture()
 
-		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return procedure.IndexNewBlock(lctx, rw, childID, flow.ZeroID)
 		})
 		require.NoError(t, err)
@@ -88,14 +100,18 @@ func TestIndexZeroParent(t *testing.T) {
 // lookup block children will only return direct childrens
 func TestDirectChildren(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
+		lockManager := storage.NewTestingLockManager()
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockInsertBlock)
+		require.NoError(t, err)
+		defer lctx.Release()
 
 		b1 := unittest.IdentifierFixture()
 		b2 := unittest.IdentifierFixture()
 		b3 := unittest.IdentifierFixture()
 		b4 := unittest.IdentifierFixture()
 
-		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return procedure.IndexNewBlock(lctx, rw, b2, b1)
 		})
 		require.NoError(t, err)

--- a/storage/procedure/cluster_test.go
+++ b/storage/procedure/cluster_test.go
@@ -23,7 +23,7 @@ func TestInsertRetrieveClusterBlock(t *testing.T) {
 		err := lctx.AcquireLock(storage.LockInsertOrFinalizeClusterBlock)
 		require.NoError(t, err)
 		defer lctx.Release()
-		
+
 		require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return InsertClusterBlock(lctx, rw, &block)
 		}))

--- a/storage/procedure/cluster_test.go
+++ b/storage/procedure/cluster_test.go
@@ -18,14 +18,18 @@ func TestInsertRetrieveClusterBlock(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
 		block := unittest.ClusterBlockFixture()
 
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockInsertOrFinalizeClusterBlock)
+		lockManager := storage.NewTestingLockManager()
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockInsertOrFinalizeClusterBlock)
+		require.NoError(t, err)
 		defer lctx.Release()
+		
 		require.NoError(t, db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return InsertClusterBlock(lctx, rw, &block)
 		}))
 
 		var retrieved cluster.Block
-		err := RetrieveClusterBlock(db.Reader(), block.ID(), &retrieved)
+		err = RetrieveClusterBlock(db.Reader(), block.ID(), &retrieved)
 		require.NoError(t, err)
 
 		require.Equal(t, block, retrieved)

--- a/storage/store/blocks_test.go
+++ b/storage/store/blocks_test.go
@@ -14,15 +14,19 @@ import (
 
 func TestBlockStoreAndRetrieve(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		cacheMetrics := &metrics.NoopCollector{}
 		// verify after storing a block should be able to retrieve it back
 		blocks := store.InitAll(cacheMetrics, db).Blocks
 		block := unittest.FullBlockFixture()
 		block.SetPayload(unittest.PayloadFixture(unittest.WithAllTheFixins))
 
-		_, lctx := unittest.LockManagerWithContext(t, storage.LockInsertBlock)
+		lctx := lockManager.NewContext()
+		err := lctx.AcquireLock(storage.LockInsertBlock)
+		require.NoError(t, err)
 		defer lctx.Release()
-		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+
+		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			return blocks.BatchStore(lctx, rw, &block)
 		})
 		require.NoError(t, err)

--- a/storage/store/collections_test.go
+++ b/storage/store/collections_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestCollections(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 
 		metrics := metrics.NewNoopCollector()
 		transactions := store.NewTransactions(metrics, db)
@@ -26,7 +27,6 @@ func TestCollections(t *testing.T) {
 		expected := unittest.CollectionFixture(3)
 
 		// Create a lock manager and context for testing
-		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		err := lctx.AcquireLock(storage.LockInsertCollection)
 		require.NoError(t, err)
@@ -80,6 +80,7 @@ func TestCollections(t *testing.T) {
 // indexed by the tx will be the one that is indexed in storage
 func TestCollections_IndexDuplicateTx(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		transactions := store.NewTransactions(metrics, db)
 		collections := store.NewCollections(db, transactions)
@@ -92,7 +93,6 @@ func TestCollections_IndexDuplicateTx(t *testing.T) {
 		col2.Transactions = append(col2.Transactions, dupTx)
 
 		// Create a lock manager and context for testing
-		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		err := lctx.AcquireLock(storage.LockInsertCollection)
 		require.NoError(t, err)
@@ -129,6 +129,7 @@ func TestCollections_IndexDuplicateTx(t *testing.T) {
 // different collection both will succeed, and one of the collection will be indexed by the tx
 func TestCollections_ConcurrentIndexByTx(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		transactions := store.NewTransactions(metrics, db)
 		collections := store.NewCollections(db, transactions)
@@ -143,7 +144,6 @@ func TestCollections_ConcurrentIndexByTx(t *testing.T) {
 		col2.Transactions[0] = sharedTx
 
 		// Create a lock manager and context for testing
-		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		err := lctx.AcquireLock(storage.LockInsertCollection)
 		require.NoError(t, err)

--- a/storage/store/commits_test.go
+++ b/storage/store/commits_test.go
@@ -18,6 +18,7 @@ import (
 // TestCommitsStoreAndRetrieve tests that a commit can be store1d, retrieved and attempted to be stored again without an error
 func TestCommitsStoreAndRetrieve(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		store1 := store.NewCommits(metrics, db)
 
@@ -28,7 +29,6 @@ func TestCommitsStoreAndRetrieve(t *testing.T) {
 		// store a commit in db
 		blockID := unittest.IdentifierFixture()
 		expected := unittest.StateCommitmentFixture()
-		lockManager := storage.NewTestingLockManager()
 		err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			lctx := lockManager.NewContext()
 			defer lctx.Release()
@@ -55,13 +55,13 @@ func TestCommitsStoreAndRetrieve(t *testing.T) {
 
 func TestCommitStoreAndRemove(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		store := store.NewCommits(metrics, db)
 
 		// Create and store a commit
 		blockID := unittest.IdentifierFixture()
 		expected := unittest.StateCommitmentFixture()
-		lockManager := storage.NewTestingLockManager()
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			lctx := lockManager.NewContext()
 			defer lctx.Release()

--- a/storage/store/commits_test.go
+++ b/storage/store/commits_test.go
@@ -62,9 +62,9 @@ func TestCommitStoreAndRemove(t *testing.T) {
 		// Create and store a commit
 		blockID := unittest.IdentifierFixture()
 		expected := unittest.StateCommitmentFixture()
+		lctx := lockManager.NewContext()
+		defer lctx.Release()
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-			lctx := lockManager.NewContext()
-			defer lctx.Release()
 			require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))
 			return store.BatchStore(lctx, blockID, expected, rw)
 		})

--- a/storage/store/my_receipts_test.go
+++ b/storage/store/my_receipts_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/jordanschalm/lockctx"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"
@@ -15,20 +16,20 @@ import (
 )
 
 func TestMyExecutionReceiptsStorage(t *testing.T) {
-	withStore := func(t *testing.T, f func(storage.MyExecutionReceipts, storage.ExecutionResults, storage.ExecutionReceipts, storage.DB)) {
+	withStore := func(t *testing.T, f func(storage.MyExecutionReceipts, storage.ExecutionResults, storage.ExecutionReceipts, storage.DB, lockctx.Manager)) {
 		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			lockManager := storage.NewTestingLockManager()
 			metrics := metrics.NewNoopCollector()
 			results := store.NewExecutionResults(metrics, db)
 			receipts := store.NewExecutionReceipts(metrics, db, results, 100)
 			myReceipts := store.NewMyExecutionReceipts(metrics, db, receipts)
 
-			f(myReceipts, results, receipts, db)
+			f(myReceipts, results, receipts, db, lockManager)
 		})
 	}
 
 	t.Run("myReceipts store and retrieve from different storage layers", func(t *testing.T) {
-		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB) {
-			lockManager := storage.NewTestingLockManager()
+		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB, lockManager lockctx.Manager) {
 			block := unittest.BlockFixture()
 			receipt1 := unittest.ReceiptForBlockFixture(&block)
 
@@ -60,8 +61,7 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 	})
 
 	t.Run("myReceipts store identical receipt for the same block", func(t *testing.T) {
-		withStore(t, func(myReceipts storage.MyExecutionReceipts, _ storage.ExecutionResults, _ storage.ExecutionReceipts, db storage.DB) {
-			lockManager := storage.NewTestingLockManager()
+		withStore(t, func(myReceipts storage.MyExecutionReceipts, _ storage.ExecutionResults, _ storage.ExecutionReceipts, db storage.DB, lockManager lockctx.Manager) {
 			block := unittest.BlockFixture()
 			receipt1 := unittest.ReceiptForBlockFixture(&block)
 
@@ -84,8 +84,7 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 	})
 
 	t.Run("store different receipt for same block should fail", func(t *testing.T) {
-		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB) {
-			lockManager := storage.NewTestingLockManager()
+		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB, lockManager lockctx.Manager) {
 			block := unittest.BlockFixture()
 
 			executor1 := unittest.IdentifierFixture()
@@ -114,8 +113,7 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 	})
 
 	t.Run("concurrent store different receipt for same block should fail", func(t *testing.T) {
-		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB) {
-			lockManager := storage.NewTestingLockManager()
+		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB, lockManager lockctx.Manager) {
 			block := unittest.BlockFixture()
 
 			executor1 := unittest.IdentifierFixture()
@@ -173,9 +171,7 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 	})
 
 	t.Run("concurrent store of 10 different receipts for different blocks should succeed", func(t *testing.T) {
-		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB) {
-			lockManager := storage.NewTestingLockManager()
-
+		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB, lockManager lockctx.Manager) {
 			var startSignal sync.WaitGroup // goroutines attempting store operations will wait for this signal to start concurrently
 			startSignal.Add(1)             // expecting one signal from the main thread to start both goroutines
 			var doneSinal sync.WaitGroup   // the main thread will wait on this for goroutines attempting store operations to finish
@@ -213,11 +209,10 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 	})
 
 	t.Run("store and remove", func(t *testing.T) {
-		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB) {
+		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB, lockManager lockctx.Manager) {
 			block := unittest.BlockFixture()
 			receipt1 := unittest.ReceiptForBlockFixture(&block)
 
-			lockManager := storage.NewTestingLockManager()
 			lctx := lockManager.NewContext()
 			defer lctx.Release()
 			require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))
@@ -253,6 +248,7 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 
 func TestMyExecutionReceiptsStorageMultipleStoreInSameBatch(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		results := store.NewExecutionResults(metrics, db)
 		receipts := store.NewExecutionReceipts(metrics, db, results, 100)
@@ -262,7 +258,6 @@ func TestMyExecutionReceiptsStorageMultipleStoreInSameBatch(t *testing.T) {
 		receipt1 := unittest.ReceiptForBlockFixture(&block)
 		receipt2 := unittest.ReceiptForBlockFixture(&block)
 
-		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		defer lctx.Release()
 		require.NoError(t, lctx.AcquireLock(storage.LockInsertOwnReceipt))

--- a/storage/store/protocol_kv_store_test.go
+++ b/storage/store/protocol_kv_store_test.go
@@ -16,6 +16,7 @@ import (
 // TesKeyValueStoreStorage tests if the KV store is stored, retrieved and indexed correctly
 func TestKeyValueStoreStorage(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		store := NewProtocolKVStore(metrics, db, DefaultProtocolKVStoreCacheSize, DefaultProtocolKVStoreByBlockIDCacheSize)
 
@@ -27,7 +28,6 @@ func TestKeyValueStoreStorage(t *testing.T) {
 		blockID := unittest.IdentifierFixture()
 
 		// store protocol state and auxiliary info
-		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
@@ -56,6 +56,7 @@ func TestKeyValueStoreStorage(t *testing.T) {
 //   - if we request to store a _different_  KV-store snapshot, an `storage.ErrDataMismatch` should be returned.
 func TestProtocolKVStore_StoreTx(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		store := NewProtocolKVStore(metrics, db, DefaultProtocolKVStoreCacheSize, DefaultProtocolKVStoreByBlockIDCacheSize)
 
@@ -65,7 +66,6 @@ func TestProtocolKVStore_StoreTx(t *testing.T) {
 			Data:    unittest.RandomBytes(32),
 		}
 
-		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
@@ -110,13 +110,13 @@ func TestProtocolKVStore_StoreTx(t *testing.T) {
 //   - if we request to index a different ID, an `storage.ErrDataMismatch` should be returned.
 func TestProtocolKVStore_IndexTx(t *testing.T) {
 	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		lockManager := storage.NewTestingLockManager()
 		metrics := metrics.NewNoopCollector()
 		store := NewProtocolKVStore(metrics, db, DefaultProtocolKVStoreCacheSize, DefaultProtocolKVStoreByBlockIDCacheSize)
 
 		stateID := unittest.IdentifierFixture()
 		blockID := unittest.IdentifierFixture()
 
-		lockManager := storage.NewTestingLockManager()
 		lctx := lockManager.NewContext()
 		require.NoError(t, lctx.AcquireLock(storage.LockInsertBlock))
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {

--- a/storage/store/seals_test.go
+++ b/storage/store/seals_test.go
@@ -56,7 +56,7 @@ func TestSealIndexAndRetrieve(t *testing.T) {
 		err := lctx.AcquireLock(storage.LockInsertBlock)
 		require.NoError(t, err)
 		defer lctx.Release()
-		
+
 		metrics := metrics.NewNoopCollector()
 		s := store.NewSeals(metrics, db)
 

--- a/utils/unittest/locks.go
+++ b/utils/unittest/locks.go
@@ -1,0 +1,16 @@
+package unittest
+
+import (
+	"testing"
+
+	"github.com/jordanschalm/lockctx"
+	"github.com/stretchr/testify/require"
+)
+
+func WithLock(t *testing.T, manager lockctx.Manager, lockID string, fn func(lctx lockctx.Context) error) {
+	t.Helper()
+	lctx := manager.NewContext()
+	require.NoError(t, lctx.AcquireLock(lockID))
+	defer lctx.Release()
+	require.NoError(t, fn(lctx))
+}

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/dgraph-io/badger/v2"
-	"github.com/jordanschalm/lockctx"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/onflow/crypto"
 	"github.com/stretchr/testify/assert"
@@ -29,7 +28,6 @@ import (
 	cborcodec "github.com/onflow/flow-go/network/codec/cbor"
 	"github.com/onflow/flow-go/network/p2p/keyutils"
 	"github.com/onflow/flow-go/network/topology"
-	"github.com/onflow/flow-go/storage"
 )
 
 type SkipReason int
@@ -454,18 +452,6 @@ func RunWithTypedPebbleDB(
 		}()
 		f(db)
 	})
-}
-
-// LockManagerWithContext creates a new lock manager, creates a new context and acquires the
-// specified locks within that context. Lock manager and context are returned.
-func LockManagerWithContext(t *testing.T, locks ...string) (lockctx.Manager, lockctx.Context) {
-	lockManager := storage.NewTestingLockManager()
-	lctx := lockManager.NewContext()
-	for _, lock := range locks {
-		err := lctx.AcquireLock(lock)
-		require.NoError(t, err)
-	}
-	return lockManager, lctx
 }
 
 func Concurrently(n int, f func(int)) {


### PR DESCRIPTION
This PR refactors the usage of storage.NewTestingLockManager, mentioned in https://github.com/onflow/flow-go/issues/7682. 

1. It ensures each test case creates a single storage.NewTestingLockManager by creating the lockManager at the beginning of each test case or right after the database is created.

2. It removes LockManagerWithContext in order to eliminate this function being used multiple times accidentally in a test case.

3. lock context should be created and released outside of WithReaderBatchWriter.

4. Using `WithLock` to refactor the usage of locks (IMO, we should use this in production code as well, rather than only tests)