### PR TITLE
Fix localnet startup

### DIFF
--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -13,7 +13,7 @@ STAKINGLEN=2000                 # 0 means use default
 DKGLEN=2000                     # 0 means use default
 KVSTORE_VERSION=default
 EPOCH_EXTENSION_VIEW_COUNT=50
-FINALIZATIONSAFETYTHRESHOLD=1000 # 0 means use default
+FINALIZATION_SAFETY_THRESHOLD=1000 # 0 means use default
 CONSENSUS_DELAY=800ms
 COLLECTION_DELAY=950ms
 
@@ -69,7 +69,7 @@ else
 		-epoch-dkg-phase-length=$(DKGLEN) \
 		-kvstore-version=$(KVSTORE_VERSION) \
        	-kvstore-epoch-extension-view-count=$(EPOCH_EXTENSION_VIEW_COUNT) \
-        -kvstore-finalization-safety-threshold=$(FINALIZATION_SAFETY_THRESHOLD)\
+        -kvstore-finalization-safety-threshold=$(FINALIZATION_SAFETY_THRESHOLD) \
 		-profiler=$(PROFILER) \
 		-profile-uploader=$(PROFILE_UPLOADER) \
 		-tracing=$(TRACING) \


### PR DESCRIPTION
I noticed the automation fot TPS measurements had some issues starting up localnet, and I found this issue.

the error was:
```
Aug 27 14:59:12 tps-automation-001 run.sh[704223]: 3. Bootstrap
Aug 27 14:59:12 tps-automation-001 run.sh[704522]: go run \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -ldflags="-X 'github.com/onflow/flow-go/cmd/build.commit=d03f481a9f8379e9e1ec25924b80bb11c4d6c451' \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -X  'github.com/onflow/flow-go/cmd/build.semver=v0.43.0-dev-malleability.3-135-gd03f4-localnetbuild'" \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         builder/*.go \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -loglevel=INFO \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -collection=9 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -consensus=2 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -execution=2 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -verification=12 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -access=1 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -observer=0 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -test-execution=0 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -nclusters=3 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -epoch-length=100000 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -epoch-staking-phase-length=20000 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -epoch-dkg-phase-length=20000 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -kvstore-version=default \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:                -kvstore-epoch-extension-view-count=50 \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -kvstore-finalization-safety-threshold=\
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -profiler=false \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -profile-uploader=false \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -tracing=true \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -cadence-tracing=false \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -extensive-tracing=false \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -consensus-delay=800ms \
Aug 27 14:59:12 tps-automation-001 run.sh[704522]:         -collection-delay=950ms
Aug 27 14:59:16 tps-automation-001 run.sh[704956]: invalid value "" for flag -kvstore-finalization-safety-threshold: parse error
```