### PR TITLE
Kan/hotfix passkeys branch acess api test

### DIFF
--- a/integration/testnet/client.go
+++ b/integration/testnet/client.go
@@ -8,22 +8,20 @@ import (
 	"slices"
 	"time"
 
-	"github.com/onflow/crypto/hash"
-	"github.com/onflow/flow-go-sdk/templates"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-
 	"github.com/onflow/cadence"
-
+	"github.com/onflow/crypto/hash"
 	sdk "github.com/onflow/flow-go-sdk"
 	client "github.com/onflow/flow-go-sdk/access/grpc"
 	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
-	"github.com/onflow/flow-go/fvm/crypto"
+	"github.com/onflow/flow-go-sdk/templates"
 
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/fvm/crypto"
 	"github.com/onflow/flow-go/model/encoding/rlp"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol/inmem"

--- a/integration/testnet/client.go
+++ b/integration/testnet/client.go
@@ -191,7 +191,7 @@ func (c *Client) SignTransactionWebAuthN(tx *sdk.Transaction) (*sdk.Transaction,
 		return nil, err
 	}
 	tx.AddEnvelopeSignature(tx.Payer, tx.ProposalKey.KeyIndex, sig)
-	tx.EnvelopeSignatures[0].ExtensionData = extensionData
+	tx.EnvelopeSignatures[0].ExtensionData = slices.Concat([]byte{1}, extensionData)
 	return tx, nil
 }
 

--- a/integration/testnet/client.go
+++ b/integration/testnet/client.go
@@ -174,6 +174,10 @@ func (c *Client) SignTransaction(tx *sdk.Transaction) (*sdk.Transaction, error) 
 	return tx, err
 }
 
+func (c *Client) SignWebAuthnExtensionData(extensionData []byte) ([]byte, error) {
+	return c.signer.Sign(extensionData)
+}
+
 // SendTransaction submits the transaction to the Access API. The caller must
 // set up the transaction, including signing it.
 func (c *Client) SendTransaction(ctx context.Context, tx *sdk.Transaction) error {

--- a/integration/testnet/client.go
+++ b/integration/testnet/client.go
@@ -2,9 +2,13 @@ package testnet
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
+	"github.com/onflow/crypto/hash"
 	"github.com/onflow/flow-go-sdk/templates"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -16,10 +20,11 @@ import (
 
 	sdk "github.com/onflow/flow-go-sdk"
 	client "github.com/onflow/flow-go-sdk/access/grpc"
-	"github.com/onflow/flow-go-sdk/crypto"
 	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
+	"github.com/onflow/flow-go/fvm/crypto"
 
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/model/encoding/rlp"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol/inmem"
 	"github.com/onflow/flow-go/utils/dsl"
@@ -61,7 +66,7 @@ func NewClientWithKey(accessAddr string, accountAddr sdk.Address, key sdkcrypto.
 
 	accountKey := acc.Keys[0]
 
-	mySigner, err := crypto.NewInMemorySigner(key, accountKey.HashAlgo)
+	mySigner, err := sdkcrypto.NewInMemorySigner(key, accountKey.HashAlgo)
 	if err != nil {
 		return nil, fmt.Errorf("could not create a signer: %w", err)
 	}
@@ -174,8 +179,58 @@ func (c *Client) SignTransaction(tx *sdk.Transaction) (*sdk.Transaction, error) 
 	return tx, err
 }
 
-func (c *Client) SignWebAuthnExtensionData(extensionData []byte) ([]byte, error) {
-	return c.signer.Sign(extensionData)
+func (c *Client) SignTransactionWebAuthN(tx *sdk.Transaction) (*sdk.Transaction, error) {
+	transactionMessage := tx.EnvelopeMessage()
+
+	extensionData, messageToSign, err := c.validWebAuthnExtensionData(transactionMessage)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := c.signer.Sign(messageToSign)
+	if err != nil {
+		return nil, err
+	}
+	tx.AddEnvelopeSignature(tx.Payer, tx.ProposalKey.KeyIndex, sig)
+	tx.EnvelopeSignatures[0].ExtensionData = extensionData
+	return tx, nil
+}
+
+func (c *Client) validWebAuthnExtensionData(transactionMessage []byte) ([]byte, []byte, error) {
+	hasher, err := crypto.NewPrefixedHashing(hash.SHA2_256, flow.TransactionTagString)
+	if err != nil {
+		return nil, nil, err
+	}
+	authNChallenge := hasher.ComputeHash(transactionMessage)
+	authNChallengeBase64Url := base64.URLEncoding.EncodeToString(authNChallenge)
+	validUserFlag := byte(0x01)
+	validClientDataOrigin := "https://testing.com"
+	rpIDHash := unittest.RandomBytes(32)
+	sigCounter := unittest.RandomBytes(4)
+
+	// For use in cases where you're testing the other value
+	validAuthenticatorData := slices.Concat(rpIDHash, []byte{validUserFlag}, sigCounter)
+	validClientDataJSON := map[string]string{
+		"type":      crypto.WebAuthnTypeGet,
+		"challenge": authNChallengeBase64Url,
+		"origin":    validClientDataOrigin,
+	}
+
+	clientDataJsonBytes, err := json.Marshal(validClientDataJSON)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	extensionData := crypto.WebAuthnExtensionData{
+		AuthenticatorData: validAuthenticatorData,
+		ClientDataJson:    clientDataJsonBytes,
+	}
+	extensionDataRLPBytes := rlp.NewMarshaler().MustMarshal(extensionData)
+
+	var clientDataHash [hash.HashLenSHA2_256]byte
+	hash.ComputeSHA2_256(&clientDataHash, clientDataJsonBytes)
+	messageToSign := slices.Concat(validAuthenticatorData, clientDataHash[:])
+
+	return extensionDataRLPBytes, messageToSign, nil
 }
 
 // SendTransaction submits the transaction to the Access API. The caller must

--- a/integration/tests/access/cohort1/access_api_test.go
+++ b/integration/tests/access/cohort1/access_api_test.go
@@ -844,10 +844,13 @@ func (s *AccessAPISuite) TestTransactionSignatureWebAuthnExtensionData() {
 	convertToMessageSigWithExtensionData := func(sigs []sdk.TransactionSignature, extensionData []byte) []*entities.Transaction_Signature {
 		msgSigs := make([]*entities.Transaction_Signature, len(sigs))
 		for i, sig := range sigs {
+			sigBytes, err := serviceClient.SignWebAuthnExtensionData(sig.ExtensionData)
+			s.Require().NoError(err)
+
 			msgSigs[i] = &entities.Transaction_Signature{
 				Address:       sig.Address.Bytes(),
 				KeyId:         uint32(sig.KeyIndex),
-				Signature:     sig.Signature,
+				Signature:     sigBytes,
 				ExtensionData: extensionData,
 			}
 		}

--- a/integration/tests/access/cohort1/access_api_test.go
+++ b/integration/tests/access/cohort1/access_api_test.go
@@ -903,15 +903,15 @@ func (s *AccessAPISuite) TestTransactionSignatureWebAuthnExtensionData() {
 					KeyId:          uint32(tx.ProposalKey.KeyIndex),
 					SequenceNumber: tx.ProposalKey.SequenceNumber,
 				},
-				Payer:              tx.Payer.Bytes(),
-				Authorizers:        authorizers,
-				PayloadSignatures:  convertToMessageSigWithExtensionData(tx.PayloadSignatures, nil),
-				EnvelopeSignatures: convertToMessageSigWithExtensionData(tx.EnvelopeSignatures, tc.extensionData),
+				Payer:             tx.Payer.Bytes(),
+				Authorizers:       authorizers,
+				PayloadSignatures: convertToMessageSigWithExtensionData(tx.PayloadSignatures, nil),
 			}
 
 			if tc.name == "webauthn_valid" {
 				tc.extensionData = s.validWebAuthnExtensionData(transactionMsg)
 			}
+			transactionMsg.EnvelopeSignatures = convertToMessageSigWithExtensionData(tx.EnvelopeSignatures, tc.extensionData)
 
 			// Send and subscribe to the transaction status using the access API
 			subClient, err := accessClient.SendAndSubscribeTransactionStatuses(s.ctx, &accessproto.SendAndSubscribeTransactionStatusesRequest{


### PR DESCRIPTION
Fixes problem with WebAuthN AN integration test as pointed out by https://github.com/onflow/flow-go/pull/7466/files#r2305091629

Refactors the `TestTransactionSignatureWebAuthnExtensionData` tests to actually sign like a client would for WebAuthN use cases. Mimic this using a new `SignTransactionWebAuthN` function on the integration/testnet/Client, and move `validWebAuthnExtensionData` into this file/client as well