### PR TITLE
[Immutable Models M2] messages.ChunkDataRequest, messages.ChunkDataResponse and messages.RangeRequest: message/internal split + validation

### DIFF
--- a/engine/collection/synchronization/engine.go
+++ b/engine/collection/synchronization/engine.go
@@ -258,7 +258,7 @@ func (e *Engine) Process(channel channels.Channel, originID flow.Identifier, eve
 //   - All other errors are potential symptoms of internal state corruption or bugs (fatal).
 func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 	switch event.(type) {
-	case *messages.RangeRequest, *messages.BatchRequest, *messages.SyncRequest:
+	case *flow.RangeRequest, *messages.BatchRequest, *messages.SyncRequest:
 		return e.requestHandler.process(originID, event)
 	case *messages.SyncResponse, *messages.ClusterBlockResponse:
 		return e.responseMessageHandler.Process(originID, event)

--- a/engine/collection/synchronization/engine_test.go
+++ b/engine/collection/synchronization/engine_test.go
@@ -219,7 +219,7 @@ func (ss *SyncSuite) TestOnSyncResponse() {
 func (ss *SyncSuite) TestOnRangeRequest() {
 	// generate originID and range request
 	originID := unittest.IdentifierFixture()
-	req := &messages.RangeRequest{
+	req := &flow.RangeRequest{
 		Nonce:      rand.Uint64(),
 		FromHeight: 0,
 		ToHeight:   0,

--- a/engine/collection/synchronization/request_handler.go
+++ b/engine/collection/synchronization/request_handler.go
@@ -146,7 +146,7 @@ func (r *RequestHandlerEngine) setupRequestMessageHandler() {
 		},
 		engine.Pattern{
 			Match: func(msg *engine.Message) bool {
-				_, ok := msg.Payload.(*messages.RangeRequest)
+				_, ok := msg.Payload.(*flow.RangeRequest)
 				if ok {
 					r.metrics.MessageReceived(metrics.EngineClusterSynchronization, metrics.MessageRangeRequest)
 				}
@@ -201,7 +201,7 @@ func (r *RequestHandlerEngine) onSyncRequest(originID flow.Identifier, req *mess
 }
 
 // onRangeRequest processes a request for a range of blocks by height.
-func (r *RequestHandlerEngine) onRangeRequest(originID flow.Identifier, req *messages.RangeRequest) error {
+func (r *RequestHandlerEngine) onRangeRequest(originID flow.Identifier, req *flow.RangeRequest) error {
 	r.log.Debug().Str("origin_id", originID.String()).Msg("received new range request")
 	// get the latest final state to know if we can fulfill the request
 	head, err := r.state.Final().Head()
@@ -358,7 +358,7 @@ func (r *RequestHandlerEngine) processAvailableRequests() error {
 
 		msg, ok = r.pendingRangeRequests.Get()
 		if ok {
-			err := r.onRangeRequest(msg.OriginID, msg.Payload.(*messages.RangeRequest))
+			err := r.onRangeRequest(msg.OriginID, msg.Payload.(*flow.RangeRequest))
 			if err != nil {
 				return fmt.Errorf("processing range request failed: %w", err)
 			}

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -239,7 +239,7 @@ func (e *Engine) process(channel channels.Channel, originID flow.Identifier, eve
 			irrecoverable.Throw(context.TODO(), fmt.Errorf("failed to validate batch request from %x: %w", originID[:], err))
 		}
 		return e.requestHandler.Process(channel, originID, event)
-	case *messages.RangeRequest:
+	case *flow.RangeRequest:
 		err := e.validateRangeRequestForALSP(originID, message)
 		if err != nil {
 			irrecoverable.Throw(context.TODO(), fmt.Errorf("failed to validate range request from %x: %w", originID[:], err))
@@ -571,7 +571,7 @@ func (e *Engine) validateBlockResponseForALSP(channel channels.Channel, id flow.
 // - rangeRequest: the range request to validate
 // Returns:
 // - error: If an error is encountered while validating the range request. Error is assumed to be irrecoverable because of internal processes that didn't allow validation to complete.
-func (e *Engine) validateRangeRequestForALSP(originID flow.Identifier, rangeRequest *messages.RangeRequest) error {
+func (e *Engine) validateRangeRequestForALSP(originID flow.Identifier, rangeRequest *flow.RangeRequest) error {
 	// Generate a random integer between 0 and spamProbabilityMultiplier (exclusive)
 	n, err := rand.Uint32n(spamProbabilityMultiplier)
 	if err != nil {

--- a/engine/common/synchronization/engine_spam_test.go
+++ b/engine/common/synchronization/engine_spam_test.go
@@ -248,7 +248,7 @@ func (ss *SyncSuite) TestLoad_Process_RangeRequest_SometimesReportSpam() {
 
 			// generate origin and request message
 			originID := unittest.IdentifierFixture()
-			req := &messages.RangeRequest{
+			req := &flow.RangeRequest{
 				Nonce:      nonce,
 				FromHeight: loadGroup.fromHeight,
 				ToHeight:   loadGroup.toHeight,

--- a/engine/common/synchronization/engine_test.go
+++ b/engine/common/synchronization/engine_test.go
@@ -124,7 +124,7 @@ func (ss *SyncSuite) TestOnRangeRequest() {
 
 	// generate originID and range request
 	originID := unittest.IdentifierFixture()
-	req := &messages.RangeRequest{
+	req := &flow.RangeRequest{
 		Nonce:      nonce,
 		FromHeight: 0,
 		ToHeight:   0,

--- a/engine/common/synchronization/request_handler.go
+++ b/engine/common/synchronization/request_handler.go
@@ -125,7 +125,7 @@ func (r *RequestHandler) setupRequestMessageHandler() {
 		},
 		engine.Pattern{
 			Match: func(msg *engine.Message) bool {
-				_, ok := msg.Payload.(*messages.RangeRequest)
+				_, ok := msg.Payload.(*flow.RangeRequest)
 				if ok {
 					r.metrics.MessageReceived(metrics.EngineSynchronization, metrics.MessageRangeRequest)
 				}
@@ -187,7 +187,7 @@ func (r *RequestHandler) onSyncRequest(originID flow.Identifier, req *messages.S
 
 // onRangeRequest processes a request for a range of blocks by height.
 // No errors are expected during normal operation.
-func (r *RequestHandler) onRangeRequest(originID flow.Identifier, req *messages.RangeRequest) error {
+func (r *RequestHandler) onRangeRequest(originID flow.Identifier, req *flow.RangeRequest) error {
 	logger := r.log.With().Str("origin_id", originID.String()).Logger()
 	logger.Debug().Msg("received new range request")
 
@@ -351,7 +351,7 @@ func (r *RequestHandler) processAvailableRequests(ctx context.Context) error {
 
 		msg, ok = r.pendingRangeRequests.Get()
 		if ok {
-			err := r.onRangeRequest(msg.OriginID, msg.Payload.(*messages.RangeRequest))
+			err := r.onRangeRequest(msg.OriginID, msg.Payload.(*flow.RangeRequest))
 			if err != nil {
 				return fmt.Errorf("processing range request failed: %w", err)
 			}

--- a/engine/execution/provider/engine.go
+++ b/engine/execution/provider/engine.go
@@ -109,10 +109,10 @@ func New(
 		engine.NewNotifier(),
 		engine.Pattern{
 			// Match is called on every new message coming to this engine.
-			// Provider enigne only expects ChunkDataRequests.
+			// Provider engine only expects ChunkDataRequests.
 			// Other message types are discarded by Match.
 			Match: func(message *engine.Message) bool {
-				chdpReq, ok := message.Payload.(*messages.ChunkDataRequest)
+				chdpReq, ok := message.Payload.(*flow.ChunkDataRequest)
 				if ok {
 					log.Info().
 						Hex("chunk_id", logging.ID(chdpReq.ChunkID)).
@@ -125,7 +125,7 @@ func New(
 			// ChunkDataRequests.
 			// It replaces the payload of message with requested chunk id.
 			Map: func(message *engine.Message) (*engine.Message, bool) {
-				chdpReq := message.Payload.(*messages.ChunkDataRequest)
+				chdpReq := message.Payload.(*flow.ChunkDataRequest)
 				return &engine.Message{
 					OriginID: message.OriginID,
 					Payload:  chdpReq.ChunkID,

--- a/engine/execution/provider/engine.go
+++ b/engine/execution/provider/engine.go
@@ -342,7 +342,7 @@ func (e *Engine) deliverChunkDataResponse(chunkDataPack *flow.ChunkDataPack, req
 	}
 
 	response := &messages.ChunkDataResponse{
-		ChunkDataPack: *chunkDataPack,
+		ChunkDataPack: (flow.UntrustedChunkDataPack)(*chunkDataPack),
 		Nonce:         nonce,
 	}
 

--- a/engine/execution/provider/engine_test.go
+++ b/engine/execution/provider/engine_test.go
@@ -40,7 +40,7 @@ func TestProviderEngine_onChunkDataRequest(t *testing.T) {
 
 		chunkID := unittest.IdentifierFixture()
 
-		req := &messages.ChunkDataRequest{
+		req := &flow.ChunkDataRequest{
 			ChunkID: chunkID,
 			Nonce:   rand.Uint64(),
 		}
@@ -89,7 +89,7 @@ func TestProviderEngine_onChunkDataRequest(t *testing.T) {
 
 		es.On("ChunkDataPackByChunkID", chunkID).Return(chunkDataPack, nil)
 
-		req := &messages.ChunkDataRequest{
+		req := &flow.ChunkDataRequest{
 			ChunkID: chunkID,
 			Nonce:   rand.Uint64(),
 		}

--- a/engine/ghost/engine/rpc.go
+++ b/engine/ghost/engine/rpc.go
@@ -252,6 +252,8 @@ func internalToMessage(event interface{}) (messages.UntrustedMessage, error) {
 			ChunkDataPack: flow.UntrustedChunkDataPack(internal.ChunkDataPack),
 			Nonce:         internal.Nonce,
 		}, nil
+	case *flow.RangeRequest:
+		return (*messages.RangeRequest)(internal), nil
 	case messages.UntrustedMessage:
 		// Already a valid UntrustedMessage
 		// TODO(immutable M2): expand when ToInternal changes for other M2 types

--- a/engine/ghost/engine/rpc.go
+++ b/engine/ghost/engine/rpc.go
@@ -245,6 +245,13 @@ func internalToMessage(event interface{}) (messages.UntrustedMessage, error) {
 		return (*messages.Proposal)(internal), nil
 	case *cluster.Proposal:
 		return (*messages.ClusterProposal)(internal), nil
+	case *flow.ChunkDataRequest:
+		return (*messages.ChunkDataRequest)(internal), nil
+	case *flow.ChunkDataResponse:
+		return &messages.ChunkDataResponse{
+			ChunkDataPack: flow.UntrustedChunkDataPack(internal.ChunkDataPack),
+			Nonce:         internal.Nonce,
+		}, nil
 	case messages.UntrustedMessage:
 		// Already a valid UntrustedMessage
 		// TODO(immutable M2): expand when ToInternal changes for other M2 types

--- a/engine/verification/requester/requester.go
+++ b/engine/verification/requester/requester.go
@@ -155,7 +155,7 @@ func (e *Engine) Done() <-chan struct{} {
 // the peer-to-peer network.
 func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 	switch resource := event.(type) {
-	case *messages.ChunkDataResponse:
+	case *flow.ChunkDataResponse:
 		e.handleChunkDataPackWithTracing(originID, &resource.ChunkDataPack)
 	default:
 		return fmt.Errorf("invalid event type (%T)", event)

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -77,7 +77,7 @@ func (c CompleteExecutionReceiptList) ChunkDataResponseOf(t *testing.T, chunkID 
 
 	// publishes the chunk data pack response to the network
 	res := &messages.ChunkDataResponse{
-		ChunkDataPack: *receiptData.ChunkDataPacks[chunkIndex],
+		ChunkDataPack: flow.UntrustedChunkDataPack(*receiptData.ChunkDataPacks[chunkIndex]),
 		Nonce:         rand.Uint64(),
 	}
 

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -23,7 +23,6 @@ import (
 	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
-	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/mock"
@@ -80,7 +79,7 @@ func SetupChunkDataPackProvider(t *testing.T,
 			// request should be dispatched by a verification node.
 			require.Contains(t, participants.Filter(filter.HasRole[flow.Identity](flow.RoleVerification)).NodeIDs(), originID)
 
-			req, ok := args[2].(*messages.ChunkDataRequest)
+			req, ok := args[2].(*flow.ChunkDataRequest)
 			require.True(t, ok)
 			require.Contains(t, assignedChunkIDs, req.ChunkID) // only assigned chunks should be requested.
 

--- a/integration/tests/execution/chunk_data_pack_test.go
+++ b/integration/tests/execution/chunk_data_pack_test.go
@@ -76,7 +76,7 @@ func (gs *ChunkDataPacksSuite) TestVerificationNodesRequestChunkDataPacks() {
 
 	// wait for ChunkDataResponse
 	msg2 := gs.MsgState.WaitForMsgFrom(gs.T(), lib.MsgIsChunkDataPackResponse, gs.exe1ID, "chunk data response from execution node")
-	pack2 := msg2.(*messages.ChunkDataResponse)
+	pack2 := msg2.(*flow.ChunkDataResponse)
 	require.Equal(gs.T(), chunkID, pack2.ChunkDataPack.ChunkID)
 	require.Equal(gs.T(), erExe1BlockB.ExecutionResult.Chunks[0].StartState, pack2.ChunkDataPack.StartState)
 

--- a/integration/tests/lib/msg_state.go
+++ b/integration/tests/lib/msg_state.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/model/messages"
 )
 
 const msgStateTimeout = 20 * time.Second
@@ -78,7 +77,7 @@ func (ms *MsgState) WaitForMsgFrom(t *testing.T, predicate func(msg interface{})
 }
 
 func MsgIsChunkDataPackResponse(msg interface{}) bool {
-	_, ok := msg.(*messages.ChunkDataResponse)
+	_, ok := msg.(*flow.ChunkDataResponse)
 	return ok
 }
 

--- a/integration/tests/lib/msg_state.go
+++ b/integration/tests/lib/msg_state.go
@@ -77,11 +77,6 @@ func (ms *MsgState) WaitForMsgFrom(t *testing.T, predicate func(msg interface{})
 	return m
 }
 
-func MsgIsChunkDataRequest(msg interface{}) bool {
-	_, ok := msg.(*messages.ChunkDataRequest)
-	return ok
-}
-
 func MsgIsChunkDataPackResponse(msg interface{}) bool {
 	_, ok := msg.(*messages.ChunkDataResponse)
 	return ok

--- a/integration/tests/lib/testnet_state_tracker.go
+++ b/integration/tests/lib/testnet_state_tracker.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/onflow/flow-go/engine/ghost/client"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/model/messages"
 )
 
 type TestnetStateTracker struct {
@@ -112,7 +111,7 @@ func (tst *TestnetStateTracker) Track(t *testing.T, ctx context.Context, ghost *
 					finalState,
 					m.ExecutionResult.ID(),
 					len(m.ExecutionResult.Chunks))
-			case *messages.ChunkDataResponse:
+			case *flow.ChunkDataResponse:
 				// consuming this explicitly to avoid logging full msg which is usually very large because of proof
 				t.Logf("%x chunk data pack received from %x\n",
 					m.ChunkDataPack.ChunkID,

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -321,6 +321,13 @@ func (b *BlockExecutionDataRoot) UnmarshalMsgpack(data []byte) error {
 	return nil
 }
 
+// ChunkDataRequest represents a request for the chunk data pack
+// which is specified by a chunk ID.
+type ChunkDataRequest struct {
+	ChunkID Identifier
+	Nonce   uint64
+}
+
 // Helper function to convert a slice of cid.Cid to a slice of strings
 func cidsToStrings(cids []cid.Cid) []string {
 	if cids == nil {

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -328,6 +328,13 @@ type ChunkDataRequest struct {
 	Nonce   uint64
 }
 
+// ChunkDataResponse is the structurally validated response to a chunk data pack request.
+// It contains the chunk data pack of the interest.
+type ChunkDataResponse struct {
+	ChunkDataPack ChunkDataPack
+	Nonce         uint64
+}
+
 // Helper function to convert a slice of cid.Cid to a slice of strings
 func cidsToStrings(cids []cid.Cid) []string {
 	if cids == nil {

--- a/model/flow/synchronization.go
+++ b/model/flow/synchronization.go
@@ -1,0 +1,11 @@
+package flow
+
+// RangeRequest is part of the synchronization protocol and represents an active
+// (pulling) attempt to synchronize with the consensus state of the network. It
+// requests finalized blocks by a range of block heights, including from and to
+// heights.
+type RangeRequest struct {
+	Nonce      uint64
+	FromHeight uint64
+	ToHeight   uint64
+}

--- a/model/messages/execution.go
+++ b/model/messages/execution.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -18,17 +20,20 @@ func (c *ChunkDataRequest) ToInternal() (any, error) {
 // ChunkDataResponse is the response to a chunk data pack request.
 // It contains the chunk data pack of the interest.
 type ChunkDataResponse struct {
-	ChunkDataPack flow.ChunkDataPack
+	ChunkDataPack flow.UntrustedChunkDataPack
 	Nonce         uint64 // so that we aren't deduplicated by the network layer
 }
 
-// ToInternal converts the untrusted ChunkDataResponse into its trusted internal
-// representation.
+// ToInternal returns the internal type representation for ChunkDataResponse.
 //
-// This stub returns the receiver unchanged. A proper implementation
-// must perform validation checks and return a constructed internal
-// object.
+// All errors indicate that the decode target contains a structurally invalid representation of the internal flow.ChunkDataResponse.
 func (c *ChunkDataResponse) ToInternal() (any, error) {
-	// TODO(malleability, #7716) implement with validation checks
-	return c, nil
+	chunkDataPack, err := flow.NewChunkDataPack(c.ChunkDataPack)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert %T to internal type: %w", c.ChunkDataPack, err)
+	}
+	return &flow.ChunkDataResponse{
+		Nonce:         c.Nonce,
+		ChunkDataPack: *chunkDataPack,
+	}, nil
 }

--- a/model/messages/execution.go
+++ b/model/messages/execution.go
@@ -4,22 +4,15 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// ChunkDataRequest represents a request for the a chunk data pack
+// ChunkDataRequest represents a request for the chunk data pack
 // which is specified by a chunk ID.
-type ChunkDataRequest struct {
-	ChunkID flow.Identifier
-	Nonce   uint64 // so that we aren't deduplicated by the network layer
-}
+type ChunkDataRequest flow.ChunkDataRequest
 
-// ToInternal converts the untrusted ChunkDataRequest into its trusted internal
-// representation.
+// ToInternal returns the internal type representation for ChunkDataRequest.
 //
-// This stub returns the receiver unchanged. A proper implementation
-// must perform validation checks and return a constructed internal
-// object.
+// All errors indicate that the decode target contains a structurally invalid representation of the internal flow.ChunkDataRequest.
 func (c *ChunkDataRequest) ToInternal() (any, error) {
-	// TODO(malleability, #7715) implement with validation checks
-	return c, nil
+	return (*flow.ChunkDataRequest)(c), nil
 }
 
 // ChunkDataResponse is the response to a chunk data pack request.

--- a/model/messages/synchronization.go
+++ b/model/messages/synchronization.go
@@ -53,21 +53,13 @@ func (s *SyncResponse) ToInternal() (any, error) {
 // heights.
 // All RangeRequest messages are validated before being processed. If validation fails, then a misbehavior report is created.
 // See synchronization.validateRangeRequestForALSP for more details.
-type RangeRequest struct {
-	Nonce      uint64
-	FromHeight uint64
-	ToHeight   uint64
-}
+type RangeRequest flow.RangeRequest
 
-// ToInternal converts the untrusted RangeRequest into its trusted internal
-// representation.
+// ToInternal returns the internal type representation for RangeRequest.
 //
-// This stub returns the receiver unchanged. A proper implementation
-// must perform validation checks and return a constructed internal
-// object.
+// All errors indicate that the decode target contains a structurally invalid representation of the internal flow.RangeRequest.
 func (r *RangeRequest) ToInternal() (any, error) {
-	// TODO(malleability, #7707) implement with validation checks
-	return r, nil
+	return (*flow.RangeRequest)(r), nil
 }
 
 // BatchRequest is part of the synchronization protocol and represents an active

--- a/network/test/cohort1/network_test.go
+++ b/network/test/cohort1/network_test.go
@@ -841,9 +841,13 @@ func (suite *NetworkTestSuite) TestLargeMessageSize_SendDirect() {
 			require.True(suite.T(), ok)
 			require.Equal(suite.T(), suite.ids[sourceIndex].NodeID, msgOriginID) // sender id
 
-			msgPayload, ok := args[2].(*messages.ChunkDataResponse)
+			msgPayload, ok := args[2].(*flow.ChunkDataResponse)
 			require.True(suite.T(), ok)
-			require.Equal(suite.T(), event, msgPayload) // payload
+
+			internal, err := event.ToInternal()
+			require.NoError(suite.T(), err)
+
+			require.Equal(suite.T(), internal, msgPayload) // payload
 		}).Return(nil).Once()
 
 	// sends a direct message from source node to the target node
@@ -950,7 +954,7 @@ func TestChunkDataPackMaxMessageSize(t *testing.T) {
 		flow.IdentifierList{unittest.IdentifierFixture()},
 		channels.TopicFromChannel(channels.ProvideChunks, unittest.IdentifierFixture()),
 		&messages.ChunkDataResponse{
-			ChunkDataPack: *unittest.ChunkDataPackFixture(unittest.IdentifierFixture()),
+			ChunkDataPack: (flow.UntrustedChunkDataPack)(*unittest.ChunkDataPackFixture(unittest.IdentifierFixture())),
 			Nonce:         rand.Uint64(),
 		},
 		unittest.NetworkCodec().Encode,

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -1614,7 +1614,7 @@ func ChunkDataResponseMsgFixture(
 	opts ...func(*messages.ChunkDataResponse),
 ) *messages.ChunkDataResponse {
 	cdp := &messages.ChunkDataResponse{
-		ChunkDataPack: *ChunkDataPackFixture(chunkID),
+		ChunkDataPack: flow.UntrustedChunkDataPack(*ChunkDataPackFixture(chunkID)),
 		Nonce:         rand.Uint64(),
 	}
 
@@ -1632,7 +1632,7 @@ func WithApproximateSize(bytes uint64) func(*messages.ChunkDataResponse) {
 		txCount := bytes / 350
 		collection := CollectionFixture(int(txCount) + 1)
 		pack := ChunkDataPackFixture(request.ChunkDataPack.ChunkID, WithChunkDataPackCollection(&collection))
-		request.ChunkDataPack = *pack
+		request.ChunkDataPack = flow.UntrustedChunkDataPack(*pack)
 	}
 }
 


### PR DESCRIPTION
Closes #7715, #7716, #7707

## Context
- Added `flow.ChunkDataRequest`, `flow.ChunkDataResponse`, `flow.RangeRequest` internal types.
- Implemented `ToInternal()` for corresponding `messages.*` types to convert to internal model.
- Changed from `messages.ChunkDataRequest`, `messages.ChunkDataResponse` and `messages.RangeRequest `  to `flow.ChunkDataRequest`, `flow.ChunkDataResponse`, and  `flow.RangeRequest`  where they are used internally to be consistent.
- Updated test according to changes.