### PR TITLE
Revert "Remove EFM backward compatibility logic for `DGKIndexMap`"

### DIFF
--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -202,12 +202,46 @@ func convertServiceEventEpochSetup(event flow.Event) (*flow.ServiceEvent, error)
 	return serviceEvent, nil
 }
 
+// convertServiceEventEpochCommit is a wrapper function to support backward-compatible event parsing for [flow.EpochCommit] events.
+// It delegates to the version-specific conversion function based on the number of fields in the event.
+// TODO(EFM, #6794): Replace this function with the body of `convertServiceEventEpochCommitV1` once the network upgrade is complete.
+func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error) {
+	// decode bytes using ccf
+	payload, err := ccf.Decode(nil, event.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal event payload: %w", err)
+	}
+
+	cdcEvent, ok := payload.(cadence.Event)
+	if !ok {
+		return nil, invalidCadenceTypeError("payload", payload, cadence.Event{})
+	}
+
+	if cdcEvent.Type() == nil {
+		return nil, fmt.Errorf("EpochCommit event doesn't have type")
+	}
+
+	fields := cadence.FieldsMappedByName(cdcEvent)
+
+	switch len(fields) {
+	case 3:
+		return convertServiceEventEpochCommitV0(event)
+	case 5:
+		return convertServiceEventEpochCommitV1(event)
+	default:
+		return nil, fmt.Errorf(
+			"invalid number of fields in EpochCommit event, expect 3 or 5, got: %d",
+			len(fields),
+		)
+	}
+}
+
 // convertServiceEventEpochCommit converts a service event encoded as the generic
 // flow.Event type to a ServiceEvent type for an EpochCommit event.
 // CAUTION: This function must only be used for input events computed locally, by an
 // Execution or Verification Node; it is not resilient to malicious inputs.
 // No errors are expected during normal operation.
-func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error) {
+func convertServiceEventEpochCommitV1(event flow.Event) (*flow.ServiceEvent, error) {
 	// decode bytes using ccf
 	payload, err := ccf.Decode(nil, event.Payload)
 	if err != nil {
@@ -318,6 +352,96 @@ func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error
 			DKGGroupKey:        dKGGroupKey,
 			DKGParticipantKeys: dKGParticipantKeys,
 			DKGIndexMap:        dKGIndexMap,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not construct epoch commit: %w", err)
+	}
+
+	// create the service event
+	serviceEvent := &flow.ServiceEvent{
+		Type:  flow.ServiceEventCommit,
+		Event: commit,
+	}
+
+	return serviceEvent, nil
+}
+
+// convertServiceEventEpochCommit converts a service event encoded as the generic
+// flow.Event type to a ServiceEvent type for an EpochCommit event.
+// CAUTION: This function must only be used for input events computed locally, by an
+// Execution or Verification Node; it is not resilient to malicious inputs.
+// No errors are expected during normal operation.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func convertServiceEventEpochCommitV0(event flow.Event) (*flow.ServiceEvent, error) {
+	// decode bytes using ccf
+	payload, err := ccf.Decode(nil, event.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal event payload: %w", err)
+	}
+
+	cdcEvent, ok := payload.(cadence.Event)
+	if !ok {
+		return nil, invalidCadenceTypeError("payload", payload, cadence.Event{})
+	}
+
+	if cdcEvent.Type() == nil {
+		return nil, fmt.Errorf("EpochCommit event doesn't have type")
+	}
+
+	fields := cadence.FieldsMappedByName(cdcEvent)
+
+	const expectedFieldCount = 3
+	if len(fields) < expectedFieldCount {
+		return nil, fmt.Errorf(
+			"insufficient fields in EpochCommit event (%d < %d)",
+			len(fields),
+			expectedFieldCount,
+		)
+	}
+
+	// Extract EpochCommit event fields
+
+	counter, err := getField[cadence.UInt64](fields, "counter")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochCommit event: %w", err)
+	}
+
+	cdcClusterQCVotes, err := getField[cadence.Array](fields, "clusterQCs")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochCommit event: %w", err)
+	}
+
+	cdcDKGKeys, err := getField[cadence.Array](fields, "dkgPubKeys")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochCommit event: %w", err)
+	}
+
+	// parse cluster qc votes
+	clusterQCs, err := convertClusterQCVotes(cdcClusterQCVotes.Values)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert cluster qc votes: %w", err)
+	}
+
+	// parse DKG group key and participants
+	// Note: this is read in the same order as `DKGClient.SubmitResult` ie. with the group public key first followed by individual keys
+	// https://github.com/onflow/flow-go/blob/feature/dkg/module/dkg/client.go#L182-L183
+	dKGGroupKey, err := convertDKGKey(cdcDKGKeys.Values[0])
+	if err != nil {
+		return nil, fmt.Errorf("could not convert DKG group key: %w", err)
+	}
+	dKGParticipantKeys, err := convertDKGKeys(cdcDKGKeys.Values[1:])
+	if err != nil {
+		return nil, fmt.Errorf("could not convert DKG keys: %w", err)
+	}
+
+	commit, err := flow.NewEpochCommit(
+		flow.UntrustedEpochCommit{
+			Counter:            uint64(counter),
+			ClusterQCs:         clusterQCs,
+			DKGGroupKey:        dKGGroupKey,
+			DKGParticipantKeys: dKGParticipantKeys,
+			DKGIndexMap:        nil,
 		},
 	)
 	if err != nil {

--- a/model/convert/service_event_test.go
+++ b/model/convert/service_event_test.go
@@ -100,6 +100,25 @@ func TestEventConversion(t *testing.T) {
 	},
 	)
 
+	// TODO(EFM, #6794): Remove this once we complete the network upgrade, this is only to test
+	//  backward compatibility of EpochCommit service event
+	t.Run("epoch commit, backward compatibility", func(t *testing.T) {
+
+		fixture, expected := unittest.EpochCommitV0FixtureByChainID(chainID)
+
+		// convert Cadence types to Go types
+		event, err := convert.ServiceEvent(chainID, fixture)
+		require.NoError(t, err)
+		require.NotNil(t, event)
+
+		// cast event type to epoch commit
+		actual, ok := event.Event.(*flow.EpochCommit)
+		require.True(t, ok)
+
+		assert.Equal(t, expected, actual)
+	},
+	)
+
 	t.Run("epoch recover", func(t *testing.T) {
 		fixture, expected := unittest.EpochRecoverFixtureByChainID(chainID)
 

--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -576,29 +576,50 @@ func (commit *EpochCommit) UnmarshalMsgpack(b []byte) error {
 // differently from JSON/msgpack, because it does not handle custom encoders
 // within map types.
 // NOTE: DecodeRLP is not needed, as this is only used for hashing.
+// TODO(EFM, #6794): Currently we implement RLP encoding based on availability of DKGIndexMap
+// this is needed to support backward compatibility, to guarantee that we will produce same hash
+// for the same event. This should be removed once we complete the network upgrade.
 func (commit *EpochCommit) EncodeRLP(w io.Writer) error {
-	rlpEncodable := struct {
-		Counter            uint64
-		ClusterQCs         []ClusterQCVoteData
-		DKGGroupKey        []byte
-		DKGParticipantKeys [][]byte
-		DKGIndexMap        IdentifierList
-	}{
-		Counter:            commit.Counter,
-		ClusterQCs:         commit.ClusterQCs,
-		DKGGroupKey:        commit.DKGGroupKey.Encode(),
-		DKGParticipantKeys: make([][]byte, 0, len(commit.DKGParticipantKeys)),
-		DKGIndexMap:        make(IdentifierList, len(commit.DKGIndexMap)),
-	}
-	for _, key := range commit.DKGParticipantKeys {
-		rlpEncodable.DKGParticipantKeys = append(rlpEncodable.DKGParticipantKeys, key.Encode())
-	}
-	// ensure index map is serialized in a consistent ordered manner
-	for id, index := range commit.DKGIndexMap {
-		rlpEncodable.DKGIndexMap[index] = id
-	}
+	if commit.DKGIndexMap == nil {
+		rlpEncodable := struct {
+			Counter            uint64
+			ClusterQCs         []ClusterQCVoteData
+			DKGGroupKey        []byte
+			DKGParticipantKeys [][]byte
+		}{
+			Counter:            commit.Counter,
+			ClusterQCs:         commit.ClusterQCs,
+			DKGGroupKey:        commit.DKGGroupKey.Encode(),
+			DKGParticipantKeys: make([][]byte, 0, len(commit.DKGParticipantKeys)),
+		}
+		for _, key := range commit.DKGParticipantKeys {
+			rlpEncodable.DKGParticipantKeys = append(rlpEncodable.DKGParticipantKeys, key.Encode())
+		}
 
-	return rlp.Encode(w, rlpEncodable)
+		return rlp.Encode(w, rlpEncodable)
+	} else {
+		rlpEncodable := struct {
+			Counter            uint64
+			ClusterQCs         []ClusterQCVoteData
+			DKGGroupKey        []byte
+			DKGParticipantKeys [][]byte
+			DKGIndexMap        IdentifierList
+		}{
+			Counter:            commit.Counter,
+			ClusterQCs:         commit.ClusterQCs,
+			DKGGroupKey:        commit.DKGGroupKey.Encode(),
+			DKGParticipantKeys: make([][]byte, 0, len(commit.DKGParticipantKeys)),
+			DKGIndexMap:        make(IdentifierList, len(commit.DKGIndexMap)),
+		}
+		for _, key := range commit.DKGParticipantKeys {
+			rlpEncodable.DKGParticipantKeys = append(rlpEncodable.DKGParticipantKeys, key.Encode())
+		}
+		for id, index := range commit.DKGIndexMap {
+			rlpEncodable.DKGIndexMap[index] = id
+		}
+
+		return rlp.Encode(w, rlpEncodable)
+	}
 }
 
 // ID returns the hash of the event contents.

--- a/state/protocol/inmem/dkg.go
+++ b/state/protocol/inmem/dkg.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onflow/crypto"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/state/protocol"
 )
 
@@ -15,8 +16,13 @@ type DKG flow.EpochCommit
 var _ protocol.DKG = (*DKG)(nil)
 
 // NewDKG creates a new DKG instance from the given setup and commit events.
+// TODO(EFM, #6794): Remove branch `commit.DKGIndexMap == nil` once we complete the network upgrade.
 func NewDKG(setup *flow.EpochSetup, commit *flow.EpochCommit) protocol.DKG {
-	return (*DKG)(commit)
+	if commit.DKGIndexMap == nil {
+		return NewDKGv0(setup, commit)
+	} else {
+		return (*DKG)(commit)
+	}
 }
 
 func (d *DKG) Size() uint                 { return uint(len(d.DKGParticipantKeys)) }
@@ -64,4 +70,67 @@ func (d *DKG) NodeID(index uint) (flow.Identifier, error) {
 		}
 	}
 	return flow.ZeroID, fmt.Errorf("inconsistent DKG state: missing index %d", index)
+}
+
+// DKGv0 implements the protocol.DKG interface for the EpochCommit model used before Protocol State Version 2.
+// This model is used for [flow.EpochCommit] events without the DKGIndexMap field.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+type DKGv0 struct {
+	Participants flow.IdentitySkeletonList
+	Commit       *flow.EpochCommit
+}
+
+var _ protocol.DKG = (*DKGv0)(nil)
+
+func NewDKGv0(setup *flow.EpochSetup, commit *flow.EpochCommit) *DKGv0 {
+	return &DKGv0{
+		Participants: setup.Participants.Filter(filter.IsConsensusCommitteeMember),
+		Commit:       commit,
+	}
+}
+
+func (d DKGv0) Size() uint {
+	return uint(len(d.Participants))
+}
+
+func (d DKGv0) GroupKey() crypto.PublicKey {
+	return d.Commit.DKGGroupKey
+}
+
+func (d DKGv0) KeyShares() []crypto.PublicKey {
+	return d.Commit.DKGParticipantKeys
+}
+
+// Index returns the DKG index for the given node.
+// Expected error during normal operations:
+//   - protocol.IdentityNotFoundError if nodeID is not a known DKG participant
+func (d DKGv0) Index(nodeID flow.Identifier) (uint, error) {
+	index, exists := d.Participants.GetIndex(nodeID)
+	if !exists {
+		return 0, protocol.IdentityNotFoundError{NodeID: nodeID}
+	}
+	return index, nil
+}
+
+// KeyShare returns the public key share for the given node.
+// Expected error during normal operations:
+//   - protocol.IdentityNotFoundError if nodeID is not a known DKG participant
+func (d DKGv0) KeyShare(nodeID flow.Identifier) (crypto.PublicKey, error) {
+	index, err := d.Index(nodeID)
+	if err != nil {
+		return nil, err
+	}
+	return d.Commit.DKGParticipantKeys[index], nil
+}
+
+// NodeID returns the node identifier for the given index.
+// An exception is returned if the index is ≥ Size().
+// Intended for use outside the hotpath, with runtime
+// scaling linearly in the number of DKG participants (ie. Size())
+func (d DKGv0) NodeID(index uint) (flow.Identifier, error) {
+	identity, exists := d.Participants.ByIndex(index)
+	if !exists {
+		return flow.ZeroID, fmt.Errorf("inconsistent DKG state: missing index %d", index)
+	}
+	return identity.NodeID, nil
 }

--- a/state/protocol/inmem/dkg_test.go
+++ b/state/protocol/inmem/dkg_test.go
@@ -11,13 +11,16 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-// TestDKG tests the [inmem.DKG] implementation.
+// TestDKGv0 tests that the [inmem.DKG] is backward compatible with the v0 DKG protocol model.
+// We test this by creating a [inmem.DKG] instance from a v0 [flow.EpochSetup] and [flow.EpochCommit]
+// and verifying that the DKG methods return the expected values.
+// TODO(EFM, #6794): Update this test to use the new DKG model.
 func TestDKG(t *testing.T) {
 	consensusParticipants := unittest.IdentityListFixture(5, unittest.WithRole(flow.RoleConsensus)).Sort(flow.Canonical[flow.Identity])
 	otherParticipants := unittest.IdentityListFixture(10, unittest.WithAllRolesExcept(flow.RoleConsensus))
 	setup := unittest.EpochSetupFixture(unittest.WithParticipants(append(consensusParticipants, otherParticipants...).ToSkeleton()))
 	commit := unittest.EpochCommitFixture(unittest.WithDKGFromParticipants(setup.Participants))
-	dkg := inmem.NewDKG(setup, commit)
+	dkg := inmem.NewDKGv0(setup, commit)
 	t.Run("Index", func(t *testing.T) {
 		for i, participant := range consensusParticipants {
 			index, err := dkg.Index(participant.NodeID)

--- a/state/protocol/validity.go
+++ b/state/protocol/validity.go
@@ -149,12 +149,24 @@ func IsValidExtendingEpochCommit(extendingCommit *flow.EpochCommit, epochState *
 	return nil
 }
 
+// IsValidEpochCommit implements a wrapper around the actual validation function to allow for backward-compatible validation
+// depending on the version of the [flow.EpochCommit] event. The version of the [flow.EpochCommit] is determined by the presence
+// of the [flow.DKGIndexMap] field.
+// TODO(EFM, #6794): Replace this with the body of `isValidEpochCommit` once we complete the network upgrade.
+func IsValidEpochCommit(commit *flow.EpochCommit, setup *flow.EpochSetup) error {
+	if commit.DKGIndexMap == nil {
+		return isValidEpochCommitV0(commit, setup)
+	} else {
+		return isValidEpochCommit(commit, setup)
+	}
+}
+
 // IsValidEpochCommit checks whether an epoch commit service event is intrinsically valid.
 // Assumes the input flow.EpochSetup event has already been validated.
 // Expected errors during normal operations:
 // * protocol.InvalidServiceEventError if the EpochCommit is invalid.
 // This is a side-effect-free function. This function only returns protocol.InvalidServiceEventError as errors.
-func IsValidEpochCommit(commit *flow.EpochCommit, setup *flow.EpochSetup) error {
+func isValidEpochCommit(commit *flow.EpochCommit, setup *flow.EpochSetup) error {
 	if len(setup.Assignments) != len(commit.ClusterQCs) {
 		return NewInvalidServiceEventErrorf("number of clusters (%d) does not number of QCs (%d)", len(setup.Assignments), len(commit.ClusterQCs))
 	}
@@ -216,5 +228,33 @@ func IsValidEpochCommit(commit *flow.EpochCommit, setup *flow.EpochSetup) error 
 			signature.RandomBeaconThreshold(n), numberOfRandomBeaconParticipants)
 	}
 
+	return nil
+}
+
+// isValidEpochCommitV0 checks whether an epoch commit service event is intrinsically valid.
+// Assumes the input flow.EpochSetup event has already been validated.
+// Expected errors during normal operations:
+// * protocol.InvalidServiceEventError if the EpochCommit is invalid.
+// This is a side-effect-free function. This function only returns protocol.InvalidServiceEventError as errors.
+// TODO(EFM, #6794): This function is introduced to implement a backward-compatible validation of [flow.EpochCommit].
+// Remove this once we complete the network upgrade.
+func isValidEpochCommitV0(commit *flow.EpochCommit, setup *flow.EpochSetup) error {
+	if len(setup.Assignments) != len(commit.ClusterQCs) {
+		return NewInvalidServiceEventErrorf("number of clusters (%d) does not number of QCs (%d)", len(setup.Assignments), len(commit.ClusterQCs))
+	}
+
+	if commit.Counter != setup.Counter {
+		return NewInvalidServiceEventErrorf("inconsistent epoch counter between commit (%d) and setup (%d) events in same epoch", commit.Counter, setup.Counter)
+	}
+
+	// make sure we have a valid DKG public key
+	if commit.DKGGroupKey == nil {
+		return NewInvalidServiceEventErrorf("missing DKG public group key")
+	}
+
+	participants := setup.Participants.Filter(filter.IsConsensusCommitteeMember)
+	if len(participants) != len(commit.DKGParticipantKeys) {
+		return NewInvalidServiceEventErrorf("participant list (len=%d) does not match dkg key list (len=%d)", len(participants), len(commit.DKGParticipantKeys))
+	}
 	return nil
 }

--- a/state/protocol/validity_test.go
+++ b/state/protocol/validity_test.go
@@ -201,6 +201,50 @@ func TestBootstrapInvalidEpochCommit(t *testing.T) {
 	})
 }
 
+// TestIsValidEpochCommitBackwardCompatible tests that the implementation is backward compatible with the previous version of EpochCommit.
+// The main difference in validation logic is that the old version requires that number of consensus participants is
+// equal to the number of keys(random beacon participants) for new version of the [flow.EpochCommit] this is not required rather
+// we rely on a threshold for random beacon participants.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func TestIsValidEpochCommitBackwardCompatible(t *testing.T) {
+	_, result, _ := unittest.BootstrapFixture(participants)
+	setup := result.ServiceEvents[0].Event.(*flow.EpochSetup)
+	commit := result.ServiceEvents[1].Event.(*flow.EpochCommit)
+	requiredThreshold := protocol.RandomBeaconSafetyThreshold(uint(len(commit.DKGIndexMap)))
+	require.Less(t, int(requiredThreshold), len(commit.DKGParticipantKeys),
+		"threshold has to be at lower than the number of keys, otherwise the test is invalid")
+	// preserve the DKGIndexMap since we will be removing it later
+	dkgIndexMap := commit.DKGIndexMap
+
+	// since we are passing the new version validation result should be successful
+	err := protocol.IsValidEpochCommit(commit, setup)
+	require.NoError(t, err)
+
+	commit.DKGIndexMap = nil
+
+	// since we are passing the v0 version(because we have removed DKGIndexMap) validation result should be successful
+	// because number of participant keys is equal to the number of consensus participants.
+	err = protocol.IsValidEpochCommit(commit, setup)
+	require.NoError(t, err)
+
+	// now we are going to sample participants so the number of keys is not equal to the number of consensus participants
+	// but the threshold for random beacon participants is still met. This is valid for the new version of the [flow.EpochCommit]
+	// since it requires the [flow.DKGIndexMap] to be present, but it's invalid for the v0 version.
+	sampled, err := setup.Participants.Filter(filter.IsConsensusCommitteeMember).Sample(requiredThreshold)
+	require.NoError(t, err)
+	setup.Participants = sampled
+	commit.DKGIndexMap = dkgIndexMap
+	err = protocol.IsValidEpochCommit(commit, setup)
+	require.NoError(t, err)
+
+	commit.DKGIndexMap = nil
+
+	// since we are passing the v0 version(because we have removed DKGIndexMap) validation result should be an error
+	// because number of participant keys is not equal to the number of consensus participants and this is not valid for the v0 version.
+	err = protocol.IsValidEpochCommit(commit, setup)
+	require.Error(t, err)
+}
+
 // TestIsValidExtendingEpochSetup tests that implementation enforces the following protocol rules in case they are violated:
 // (a) We should only have a single epoch setup event per epoch.
 // (b) The setup event should have the counter increased by one

--- a/storage/badger/dkg_state.go
+++ b/storage/badger/dkg_state.go
@@ -317,16 +317,25 @@ func (ds *RecoverablePrivateBeaconKeyStateMachine) ensureKeyIncludedInEpoch(epoc
 		return fmt.Errorf("commit counter does not match epoch counter: %d != %d", epochCounter, commit.Counter)
 	}
 	publicKey := key.PublicKey()
-	myDKGIndex, found := commit.DKGIndexMap[ds.myNodeID]
-	if !found {
-		return fmt.Errorf("my node ID %v is not in the DKG committee for epoch %d", ds.myNodeID, epochCounter)
+	// TODO(EFM, #6794): allowing a nil DKGIndexMap is a temporary shortcut for backwards compatibility. This should be removed once we complete the network upgrade:
+	if commit.DKGIndexMap == nil {
+		// If commit.DKGIndexMap is nil, we verify that there exists *some* public key in the EpochCommit that matches our private key. This is a much weaker sanity
+		// check than enforcing that the public Beacon key in the EpochCommit corresponding to *my* NodeID matches the locally stored private key. However,
+		// the check still catches the case where the DKG smart contract determined a different public key for this node compared to the node local DKG result.
+		// Nevertheless, we remain vulnerable to misconfigurations, where the node operator mixed up keys.
+		isMatchingKey := func(lhs crypto.PublicKey) bool { return lhs.Equals(publicKey) }
+		if slices.IndexFunc(commit.DKGParticipantKeys, isMatchingKey) < 0 {
+			return fmt.Errorf("key not included in epoch commit: %s", publicKey)
+		}
+		return nil
+	} // the following code will be reached if and only if `commit` follows the new protocol convention, where `EpochCommit.DKGIndexMap` is not nil
+
+	keyIndex, exists := commit.DKGIndexMap[ds.myNodeID]
+	if !exists {
+		return fmt.Errorf("this node is not part of the random beacon committee as specified by the EpochCommit event")
 	}
-	if myDKGIndex < 0 || myDKGIndex >= len(commit.DKGParticipantKeys) {
-		return fmt.Errorf("my DKG index %d is out of range for epoch %d", myDKGIndex, epochCounter)
-	}
-	expectedPublicKey := commit.DKGParticipantKeys[myDKGIndex]
-	if !publicKey.Equals(expectedPublicKey) {
-		return fmt.Errorf("stored private key does not match public key in epoch commit for epoch %d", epochCounter)
+	if !commit.DKGParticipantKeys[keyIndex].Equals(publicKey) {
+		return fmt.Errorf("provided private key does not match random beacon public key in the EpochCommit event")
 	}
 	return nil
 }

--- a/storage/badger/dkg_state_test.go
+++ b/storage/badger/dkg_state_test.go
@@ -89,8 +89,7 @@ func TestDKGState_UninitializedState(t *testing.T) {
 			expectedKey := unittest.StakingPrivKeyFixture()
 			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 				commit.Counter = epochCounter
-				commit.DKGParticipantKeys = []crypto.PublicKey{expectedKey.PublicKey()}
-				commit.DKGIndexMap = flow.DKGIndexMap{myNodeID: 0}
+				commit.DKGParticipantKeys[0] = expectedKey.PublicKey()
 			})
 			err = store.UpsertMyBeaconPrivateKey(epochCounter, expectedKey, evidence)
 			require.NoError(t, err)
@@ -193,8 +192,7 @@ func TestDKGState_StartedState(t *testing.T) {
 			expectedKey := unittest.StakingPrivKeyFixture()
 			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 				commit.Counter = epochCounter
-				commit.DKGParticipantKeys = []crypto.PublicKey{expectedKey.PublicKey()}
-				commit.DKGIndexMap = flow.DKGIndexMap{myNodeID: 0}
+				commit.DKGParticipantKeys[0] = expectedKey.PublicKey()
 			})
 			err = store.UpsertMyBeaconPrivateKey(epochCounter, expectedKey, evidence)
 			require.NoError(t, err)
@@ -230,8 +228,7 @@ func TestDKGState_CompletedState(t *testing.T) {
 			expectedKey = unittest.StakingPrivKeyFixture()
 			evidence = unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 				commit.Counter = epochCounter
-				commit.DKGParticipantKeys = []crypto.PublicKey{expectedKey.PublicKey()}
-				commit.DKGIndexMap = flow.DKGIndexMap{myNodeID: 0}
+				commit.DKGParticipantKeys[0] = expectedKey.PublicKey()
 			})
 			err = store.InsertMyBeaconPrivateKey(epochCounter, expectedKey)
 			require.NoError(t, err)
@@ -311,8 +308,7 @@ func TestDKGState_CompletedState(t *testing.T) {
 			expectedKey := unittest.StakingPrivKeyFixture()
 			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 				commit.Counter = epochCounter
-				commit.DKGParticipantKeys = []crypto.PublicKey{expectedKey.PublicKey()}
-				commit.DKGIndexMap = flow.DKGIndexMap{myNodeID: 0}
+				commit.DKGParticipantKeys[0] = expectedKey.PublicKey()
 			})
 			err = store.UpsertMyBeaconPrivateKey(epochCounter, expectedKey, evidence)
 			require.NoError(t, err)
@@ -407,8 +403,7 @@ func TestDKGState_FailureState(t *testing.T) {
 			expectedKey := unittest.StakingPrivKeyFixture()
 			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 				commit.Counter = epochCounter
-				commit.DKGParticipantKeys = []crypto.PublicKey{expectedKey.PublicKey()}
-				commit.DKGIndexMap = flow.DKGIndexMap{myNodeID: 0}
+				commit.DKGParticipantKeys[0] = expectedKey.PublicKey()
 			})
 			err = store.UpsertMyBeaconPrivateKey(epochCounter, expectedKey, evidence)
 			require.NoError(t, err)
@@ -510,8 +505,7 @@ func TestDKGState_FailureStateAfterCompleted(t *testing.T) {
 			expectedKey := unittest.StakingPrivKeyFixture()
 			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 				commit.Counter = epochCounter
-				commit.DKGParticipantKeys = []crypto.PublicKey{expectedKey.PublicKey()}
-				commit.DKGIndexMap = flow.DKGIndexMap{myNodeID: 0}
+				commit.DKGParticipantKeys[0] = expectedKey.PublicKey()
 			})
 			err = store.UpsertMyBeaconPrivateKey(epochCounter, expectedKey, evidence)
 			require.NoError(t, err)
@@ -545,8 +539,7 @@ func TestDKGState_RandomBeaconKeyCommittedState(t *testing.T) {
 			privateKey = unittest.StakingPrivKeyFixture()
 			evidence = unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 				commit.Counter = epochCounter
-				commit.DKGParticipantKeys = []crypto.PublicKey{privateKey.PublicKey()}
-				commit.DKGIndexMap = flow.DKGIndexMap{myNodeID: 0}
+				commit.DKGParticipantKeys[0] = privateKey.PublicKey()
 			})
 			err = store.UpsertMyBeaconPrivateKey(epochCounter, privateKey, evidence)
 			require.NoError(t, err)
@@ -637,8 +630,7 @@ func TestDKGState_RandomBeaconKeyCommittedState(t *testing.T) {
 			otherKey := unittest.StakingPrivKeyFixture()
 			otherEvidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 				commit.Counter = epochCounter
-				commit.DKGParticipantKeys = []crypto.PublicKey{otherKey.PublicKey()}
-				commit.DKGIndexMap = flow.DKGIndexMap{myNodeID: 0}
+				commit.DKGParticipantKeys[0] = otherKey.PublicKey()
 			})
 			err = store.UpsertMyBeaconPrivateKey(epochCounter, otherKey, otherEvidence)
 			require.Error(t, err, "cannot overwrite previously committed key")
@@ -681,6 +673,34 @@ func TestDKGState_InsertedKeyIsIncludedInTheEpoch(t *testing.T) {
 			})
 			err = store.CommitMyBeaconPrivateKey(epochCounter, evidence)
 			require.NoError(t, err)
+		})
+
+		// TODO(EFM, #6794): allowing a nil DKGIndexMap is a temporary shortcut for backwards compatibility. This should be removed once we complete the network upgrade:
+		t.Run("inserted key is included in the epoch, evidence without DKGIndexMap", func(t *testing.T) {
+			epochCounter := setupState()
+			expectedKey := unittest.StakingPrivKeyFixture()
+			err = store.InsertMyBeaconPrivateKey(epochCounter, expectedKey)
+			require.NoError(t, err)
+			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
+				commit.Counter = epochCounter
+				commit.DKGParticipantKeys[0] = expectedKey.PublicKey()
+			})
+			err = store.CommitMyBeaconPrivateKey(epochCounter, evidence)
+			require.NoError(t, err)
+		})
+
+		// TODO(EFM, #6794): allowing a nil DKGIndexMap is a temporary shortcut for backwards compatibility. This should be removed once we complete the network upgrade:
+		t.Run("inserted key is not included in the epoch, evidence without DKGIndexMap", func(t *testing.T) {
+			epochCounter := setupState()
+			expectedKey := unittest.StakingPrivKeyFixture()
+			err = store.InsertMyBeaconPrivateKey(epochCounter, expectedKey)
+			require.NoError(t, err)
+			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
+				commit.Counter = epochCounter
+			})
+			err = store.CommitMyBeaconPrivateKey(epochCounter, evidence)
+			require.Error(t, err)
+			require.True(t, storage.IsInvalidDKGStateTransitionError(err))
 		})
 
 		t.Run("inserted key is included in the epoch but current node is not part of the random beacon committee", func(t *testing.T) {
@@ -749,6 +769,30 @@ func TestDKGState_UpsertedKeyIsIncludedInTheEpoch(t *testing.T) {
 			})
 			err = store.UpsertMyBeaconPrivateKey(epochCounter, expectedKey, evidence)
 			require.NoError(t, err)
+		})
+
+		// TODO(EFM, #6794): allowing a nil DKGIndexMap is a temporary shortcut for backwards compatibility. This should be removed once we complete the network upgrade:
+		t.Run("upserted key is included in the epoch, evidence without DKGIndexMap", func(t *testing.T) {
+			epochCounter := setupState()
+			expectedKey := unittest.StakingPrivKeyFixture()
+			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
+				commit.Counter = epochCounter
+				commit.DKGParticipantKeys[0] = expectedKey.PublicKey()
+			})
+			err = store.UpsertMyBeaconPrivateKey(epochCounter, expectedKey, evidence)
+			require.NoError(t, err)
+		})
+
+		// TODO(EFM, #6794): allowing a nil DKGIndexMap is a temporary shortcut for backwards compatibility. This should be removed once we complete the network upgrade:
+		t.Run("upserted key is not included in the epoch, evidence without DKGIndexMap", func(t *testing.T) {
+			epochCounter := setupState()
+			expectedKey := unittest.StakingPrivKeyFixture()
+			evidence := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
+				commit.Counter = epochCounter
+			})
+			err = store.UpsertMyBeaconPrivateKey(epochCounter, expectedKey, evidence)
+			require.Error(t, err)
+			require.True(t, storage.IsInvalidDKGStateTransitionError(err))
 		})
 
 		t.Run("upserted key is included in the epoch but current node is not part of the random beacon committee", func(t *testing.T) {

--- a/storage/badger/epoch_commits_test.go
+++ b/storage/badger/epoch_commits_test.go
@@ -1,15 +1,22 @@
 package badger_test
 
 import (
+	"io"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/crypto"
+	"github.com/onflow/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v4"
 
+	"github.com/onflow/flow-go/model/encodable"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/storage"
 	badgerstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/storage/badger/operation"
 	"github.com/onflow/flow-go/storage/badger/transaction"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -42,4 +49,130 @@ func TestEpochCommitStoreAndRetrieve(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+}
+
+// epochCommitV0 is a version of [flow.EpochCommit] without the [flow.DKGIndexMap] field.
+// This exact structure was used prior to Protocol State Version 2, and we would like to ensure that new version of [flow.EpochCommit]
+// is backward compatible with this structure.
+// It is used only in tests.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+type epochCommitV0 struct {
+	// Counter is the epoch counter of the epoch being committed
+	Counter uint64
+	// ClusterQCs is an ordered list of root quorum certificates, one per cluster.
+	// EpochCommit.ClustersQCs[i] is the QC for EpochSetup.Assignments[i]
+	ClusterQCs []flow.ClusterQCVoteData
+	// DKGGroupKey is the group public key produced by the DKG associated with this epoch.
+	// It is used to verify Random Beacon signatures for the epoch with counter, Counter.
+	DKGGroupKey crypto.PublicKey
+	// DKGParticipantKeys is a list of public keys, one per DKG participant, ordered by Random Beacon index.
+	// This list is the output of the DKG associated with this epoch.
+	// It is used to verify Random Beacon signatures for the epoch with counter, Counter.
+	// CAUTION: This list may include keys for nodes which do not exist in the consensus committee
+	//          and may NOT include keys for all nodes in the consensus committee.
+	DKGParticipantKeys []crypto.PublicKey
+}
+
+func (commit *epochCommitV0) ID() flow.Identifier {
+	return flow.MakeID(commit)
+}
+
+func (commit *epochCommitV0) EncodeRLP(w io.Writer) error {
+	rlpEncodable := struct {
+		Counter            uint64
+		ClusterQCs         []flow.ClusterQCVoteData
+		DKGGroupKey        []byte
+		DKGParticipantKeys [][]byte
+	}{
+		Counter:            commit.Counter,
+		ClusterQCs:         commit.ClusterQCs,
+		DKGGroupKey:        commit.DKGGroupKey.Encode(),
+		DKGParticipantKeys: make([][]byte, 0, len(commit.DKGParticipantKeys)),
+	}
+	for _, key := range commit.DKGParticipantKeys {
+		rlpEncodable.DKGParticipantKeys = append(rlpEncodable.DKGParticipantKeys, key.Encode())
+	}
+
+	return rlp.Encode(w, rlpEncodable)
+}
+
+// encodableCommit represents encoding of epochCommitV0, it is used for serialization purposes and is used only in tests.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+type encodableCommit struct {
+	Counter            uint64
+	ClusterQCs         []flow.ClusterQCVoteData
+	DKGGroupKey        encodable.RandomBeaconPubKey
+	DKGParticipantKeys []encodable.RandomBeaconPubKey
+}
+
+func encodableFromCommit(commit *epochCommitV0) encodableCommit {
+	encKeys := make([]encodable.RandomBeaconPubKey, 0, len(commit.DKGParticipantKeys))
+	for _, key := range commit.DKGParticipantKeys {
+		encKeys = append(encKeys, encodable.RandomBeaconPubKey{PublicKey: key})
+	}
+	return encodableCommit{
+		Counter:            commit.Counter,
+		ClusterQCs:         commit.ClusterQCs,
+		DKGGroupKey:        encodable.RandomBeaconPubKey{PublicKey: commit.DKGGroupKey},
+		DKGParticipantKeys: encKeys,
+	}
+}
+
+func commitFromEncodable(enc encodableCommit) epochCommitV0 {
+	dkgKeys := make([]crypto.PublicKey, 0, len(enc.DKGParticipantKeys))
+	for _, key := range enc.DKGParticipantKeys {
+		dkgKeys = append(dkgKeys, key.PublicKey)
+	}
+	return epochCommitV0{
+		Counter:            enc.Counter,
+		ClusterQCs:         enc.ClusterQCs,
+		DKGGroupKey:        enc.DKGGroupKey.PublicKey,
+		DKGParticipantKeys: dkgKeys,
+	}
+}
+
+func (commit *epochCommitV0) MarshalMsgpack() ([]byte, error) {
+	return msgpack.Marshal(encodableFromCommit(commit))
+}
+
+func (commit *epochCommitV0) UnmarshalMsgpack(b []byte) error {
+	var enc encodableCommit
+	err := msgpack.Unmarshal(b, &enc)
+	if err != nil {
+		return err
+	}
+	*commit = commitFromEncodable(enc)
+	return nil
+}
+
+// TestStoreV0AndDecodeV1 tests that an [flow.EpochCommit] without [flow.DKGIndexMap](v0) field can be stored and
+// later retrieved as a [flow.EpochCommit](v1) without any errors or data loss.
+// This test verifies that the [flow.EpochCommit] is backward compatible with respect to the [flow.DKGIndexMap] field.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func TestStoreV0AndDecodeV1(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		v1 := unittest.EpochCommitFixture()
+		v0 := &epochCommitV0{
+			Counter:            v1.Counter,
+			ClusterQCs:         v1.ClusterQCs,
+			DKGGroupKey:        v1.DKGGroupKey,
+			DKGParticipantKeys: v1.DKGParticipantKeys,
+		}
+		require.Equal(t, v0.ID(), v1.ID())
+
+		err := transaction.Update(db, func(tx *transaction.Tx) error {
+			return operation.InsertEpochCommitV0(v0.ID(), v0)(tx.DBTxn)
+		})
+		require.NoError(t, err)
+
+		var actual flow.EpochCommit
+		err = transaction.View(db, func(tx *transaction.Tx) error {
+			return operation.RetrieveEpochCommit(v0.ID(), &actual)(tx.DBTxn)
+		})
+		require.NoError(t, err)
+		require.Equal(t, v1, &actual)
+		require.Equal(t, v0.ID(), actual.ID())
+		require.Equal(t, v1, &actual)
+	})
+
 }

--- a/storage/badger/operation/dkg.go
+++ b/storage/badger/operation/dkg.go
@@ -1,9 +1,12 @@
 package operation
 
 import (
+	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
@@ -73,4 +76,59 @@ func UpsertDKGStateForEpoch(epochCounter uint64, newState flow.DKGState) func(*b
 // Error returns: [storage.ErrNotFound]
 func RetrieveDKGStateForEpoch(epochCounter uint64, currentState *flow.DKGState) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeDKGState, epochCounter), currentState)
+}
+
+// MigrateDKGEndStateFromV1 migrates the database that was used in protocol version v1 to the v2.
+// It reads already stored data by deprecated prefix and writes it to the new prefix with values converted to the new representation.
+// TODO(EFM, #6794): This function is introduced to implement a backward-compatible upgrade from v1 to v2.
+// Remove this once we complete the network upgrade.
+func MigrateDKGEndStateFromV1(log zerolog.Logger) func(txn *badger.Txn) error {
+	return func(txn *badger.Txn) error {
+		var ops []func(*badger.Txn) error
+		err := traverse(makePrefix(codeDKGEndState), func() (checkFunc, createFunc, handleFunc) {
+			var epochCounter uint64
+			check := func(key []byte) bool {
+				epochCounter = binary.BigEndian.Uint64(key[1:]) // omit code
+				return true
+			}
+			var oldState uint32
+			create := func() interface{} {
+				return &oldState
+			}
+			handle := func() error {
+				newState := flow.DKGStateUninitialized
+				switch oldState {
+				case 0: // DKGEndStateUnknown
+					newState = flow.DKGStateUninitialized
+				case 1: // DKGEndStateSuccess
+					newState = flow.RandomBeaconKeyCommitted
+				case 2, 3, 4: // DKGEndStateInconsistentKey, DKGEndStateNoKey, DKGEndStateDKGFailure
+					newState = flow.DKGStateFailure
+				}
+
+				// schedule upsert of the new state and removal of the old state
+				// this will be executed after to split collecting and modifying of data.
+				ops = append(ops,
+					UpsertDKGStateForEpoch(epochCounter, newState),
+					remove(makePrefix(codeDKGEndState, epochCounter)))
+				log.Info().Msgf("removing %d->%d, writing %d->%d", epochCounter, oldState, epochCounter, newState)
+
+				return nil
+			}
+			return check, create, handle
+		})(txn)
+		if err != nil {
+			return fmt.Errorf("could not collect deprecated DKG end states: %w", err)
+		}
+
+		for _, op := range ops {
+			if err := op(txn); err != nil {
+				return fmt.Errorf("aborting conversion from DKG end states: %w", err)
+			}
+		}
+		if len(ops) > 0 {
+			log.Info().Msgf("finished migrating %d DKG end states", len(ops))
+		}
+		return nil
+	}
 }

--- a/storage/badger/operation/dkg_test.go
+++ b/storage/badger/operation/dkg_test.go
@@ -1,6 +1,7 @@
 package operation
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"testing"
 
@@ -96,5 +97,78 @@ func TestDKGSetStateForEpoch(t *testing.T) {
 		// attempting to overwrite should succeed
 		err = db.Update(UpsertDKGStateForEpoch(epochCounter, flow.DKGStateFailure))
 		assert.NoError(t, err)
+	})
+}
+
+// TestMigrateDKGEndStateFromV1 tests the migration of DKG end states from v1 to v2.
+// All possible states in v1 are generated and then checked against the expected states in v2.
+// Afterward the states are then migrated we check that old key was indeed removed and new key was added.
+// This test also checks that the migration is idempotent after the first run.
+func TestMigrateDKGEndStateFromV1(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		epochCounter := rand.Uint64() % 100
+
+		preMigrationStates := make(map[uint64]uint32)
+		for i := epochCounter; i < epochCounter+100; i++ {
+			state := rand.Uint32() % 5 // [0,4] were supported in v1
+			err := db.Update(insert(makePrefix(codeDKGEndState, i), state))
+			assert.NoError(t, err)
+			preMigrationStates[i] = state
+		}
+
+		assertExpectedState := func(oldState uint32, newState flow.DKGState) {
+			switch oldState {
+			case 0: // DKGEndStateUnknown
+				assert.Equal(t, flow.DKGStateUninitialized, newState)
+			case 1: // DKGEndStateSuccess
+				assert.Equal(t, flow.RandomBeaconKeyCommitted, newState)
+			case 2, 3, 4: // DKGEndStateInconsistentKey, DKGEndStateNoKey, DKGEndStateDKGFailure
+				assert.Equal(t, flow.DKGStateFailure, newState)
+			default:
+				assert.Fail(t, "unexpected state")
+			}
+		}
+
+		// migrate the state
+		err := db.Update(MigrateDKGEndStateFromV1(unittest.Logger()))
+		assert.NoError(t, err)
+
+		assertMigrationSuccessful := func() {
+			// ensure previous keys were removed
+			err = db.View(traverse(makePrefix(codeDKGEndState), func() (checkFunc, createFunc, handleFunc) {
+				assert.Fail(t, "no keys should have been found")
+				return nil, nil, nil
+			}))
+			assert.NoError(t, err)
+
+			migratedStates := make(map[uint64]flow.DKGState)
+			err = db.View(traverse(makePrefix(codeDKGState), func() (checkFunc, createFunc, handleFunc) {
+				var epochCounter uint64
+				check := func(key []byte) bool {
+					epochCounter = binary.BigEndian.Uint64(key[1:]) // omit code
+					return true
+				}
+				var newState flow.DKGState
+				create := func() interface{} {
+					return &newState
+				}
+				handle := func() error {
+					migratedStates[epochCounter] = newState
+					return nil
+				}
+				return check, create, handle
+			}))
+			assert.NoError(t, err)
+			assert.Equal(t, len(preMigrationStates), len(migratedStates))
+			for epochCounter, newState := range migratedStates {
+				assertExpectedState(preMigrationStates[epochCounter], newState)
+			}
+		}
+		assertMigrationSuccessful()
+
+		// migrating again should be no-op
+		err = db.Update(MigrateDKGEndStateFromV1(unittest.Logger()))
+		assert.NoError(t, err)
+		assertMigrationSuccessful()
 	})
 }

--- a/storage/badger/operation/epoch.go
+++ b/storage/badger/operation/epoch.go
@@ -18,6 +18,13 @@ func InsertEpochCommit(eventID flow.Identifier, event *flow.EpochCommit) func(*b
 	return insert(makePrefix(codeEpochCommit, eventID), event)
 }
 
+// InsertEpochCommitV0 inserts an epoch commit event. This is used only in testing to verify that we have backward compatibility
+// at storage layer.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func InsertEpochCommitV0(eventID flow.Identifier, event any) func(*badger.Txn) error {
+	return insert(makePrefix(codeEpochCommit, eventID), event)
+}
+
 func RetrieveEpochCommit(eventID flow.Identifier, event *flow.EpochCommit) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeEpochCommit, eventID), event)
 }

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -161,6 +161,43 @@ func EpochCommitFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCom
 	return event, expected
 }
 
+// EpochCommitV0FixtureByChainID returns an EpochCommit service event for old data model as a Cadence event
+// representation and as a protocol model representation. This is used for testing backwards compatibility.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func EpochCommitV0FixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCommit) {
+	events := systemcontracts.ServiceEventsForChain(chain)
+
+	event := EventFixture(events.EpochCommit.EventType(), 1, 1, IdentifierFixture(), 0)
+	event.Payload = EpochCommitV0FixtureCCF
+
+	expected := &flow.EpochCommit{
+		Counter: 1,
+		ClusterQCs: []flow.ClusterQCVoteData{
+			{
+				VoterIDs: []flow.Identifier{
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000001"),
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000002"),
+				},
+				SigData: MustDecodeSignatureHex("b072ed22ed305acd44818a6c836e09b4e844eebde6a4fdbf5cec983e2872b86c8b0f6c34c0777bf52e385ab7c45dc55d"),
+			},
+			{
+				VoterIDs: []flow.Identifier{
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000003"),
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000004"),
+				},
+				SigData: MustDecodeSignatureHex("899e266a543e1b3a564f68b22f7be571f2e944ec30fadc4b39e2d5f526ba044c0f3cb2648f8334fc216fa3360a0418b2"),
+			},
+		},
+		DKGGroupKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+		DKGParticipantKeys: []crypto.PublicKey{
+			MustDecodePublicKeyHex(crypto.BLSBLS12381, "87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+		},
+		DKGIndexMap: nil,
+	}
+
+	return event, expected
+}
+
 // EpochRecoverFixtureByChainID returns an EpochRecover service event as a Cadence event
 // representation and as a protocol model representation.
 func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochRecover) {
@@ -815,6 +852,71 @@ func createEpochCommitEvent() cadence.Event {
 	}).WithType(newFlowEpochEpochCommitEventType())
 }
 
+// createEpochCommitEventV0 creates an EpochCommit event with the old data model, it is used to ensure that new version
+// is backward compatible with the old version.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func createEpochCommitEventV0() cadence.Event {
+
+	clusterQCType := newFlowClusterQCClusterQCStructType()
+
+	cluster1 := cadence.NewStruct([]cadence.Value{
+		// index
+		cadence.UInt16(0),
+
+		// voteSignatures
+		cadence.NewArray([]cadence.Value{
+			cadence.String("a39cd1e1bf7e2fb0609b7388ce5215a6a4c01eef2aee86e1a007faa28a6b2a3dc876e11bb97cdb26c3846231d2d01e4d"),
+			cadence.String("91673ad9c717d396c9a0953617733c128049ac1a639653d4002ab245b121df1939430e313bcbfd06948f6a281f6bf853"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+
+		// voteMessage
+		cadence.String("irrelevant_for_these_purposes"),
+
+		// voterIDs
+		cadence.NewArray([]cadence.Value{
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000001"),
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000002"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(clusterQCType)
+
+	cluster2 := cadence.NewStruct([]cadence.Value{
+		// index
+		cadence.UInt16(1),
+
+		// voteSignatures
+		cadence.NewArray([]cadence.Value{
+			cadence.String("b2bff159971852ed63e72c37991e62c94822e52d4fdcd7bf29aaf9fb178b1c5b4ce20dd9594e029f3574cb29533b857a"),
+			cadence.String("9931562f0248c9195758da3de4fb92f24fa734cbc20c0cb80280163560e0e0348f843ac89ecbd3732e335940c1e8dccb"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+
+		// voteMessage
+		cadence.String("irrelevant_for_these_purposes"),
+
+		// voterIDs
+		cadence.NewArray([]cadence.Value{
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000003"),
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000004"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(clusterQCType)
+
+	return cadence.NewEvent([]cadence.Value{
+		// counter
+		cadence.NewUInt64(1),
+
+		// clusterQCs
+		cadence.NewArray([]cadence.Value{
+			cluster1,
+			cluster2,
+		}).WithType(cadence.NewVariableSizedArrayType(clusterQCType)),
+
+		// dkgPubKeys
+		cadence.NewArray([]cadence.Value{
+			cadence.String("8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+			cadence.String("87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(newFlowEpochEpochCommitEventTypeV0())
+}
+
 func createEpochRecoverEvent(randomSourceHex string) cadence.Event {
 
 	clusterQCVoteDataType := newFlowClusterQCClusterQCVoteDataStructType()
@@ -1162,6 +1264,37 @@ func newFlowEpochEpochCommitEventType() *cadence.EventType {
 	)
 }
 
+// newFlowEpochEpochCommitEventTypeV0 creates an EpochCommit event with the old data model, it is used to ensure that new version
+// is backward compatible with the old version.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func newFlowEpochEpochCommitEventTypeV0() *cadence.EventType {
+
+	// A.01cf0e2f2f715450.FlowEpoch.EpochCommitted
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowEpoch")
+
+	return cadence.NewEventType(
+		location,
+		"FlowEpoch.EpochCommitted",
+		[]cadence.Field{
+			{
+				Identifier: "counter",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "clusterQCs",
+				Type:       cadence.NewVariableSizedArrayType(newFlowClusterQCClusterQCStructType()),
+			},
+			{
+				Identifier: "dkgPubKeys",
+				Type:       cadence.NewVariableSizedArrayType(cadence.StringType),
+			},
+		},
+		nil,
+	)
+}
+
 func newFlowEpochEpochRecoverEventType() *cadence.EventType {
 
 	// A.01cf0e2f2f715450.FlowEpoch.EpochRecover
@@ -1441,6 +1574,19 @@ func EpochSetupCCFWithNonHexRandomSource() []byte {
 
 var EpochCommitFixtureCCF = func() []byte {
 	b, err := ccf.Encode(createEpochCommitEvent())
+	if err != nil {
+		panic(err)
+	}
+	_, err = ccf.Decode(nil, b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}()
+
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+var EpochCommitV0FixtureCCF = func() []byte {
+	b, err := ccf.Encode(createEpochCommitEventV0())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
`v0.42.4` is the last commit before `feature/malleability` was merged into master. We throught `v0.42.4` is backward compatible with mainnet, but actually, we merged https://github.com/onflow/flow-go/pull/7631 which breaks the backward compatiblity. 

This PR reverts that. 