### PR TITLE
[Access] Improve API request/response limit config

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -44,7 +44,6 @@ import (
 	"github.com/onflow/flow-go/engine/access/ingestion/tx_error_messages"
 	pingeng "github.com/onflow/flow-go/engine/access/ping"
 	"github.com/onflow/flow-go/engine/access/rest"
-	commonrest "github.com/onflow/flow-go/engine/access/rest/common"
 	"github.com/onflow/flow-go/engine/access/rest/router"
 	"github.com/onflow/flow-go/engine/access/rest/websockets"
 	"github.com/onflow/flow-go/engine/access/rpc"
@@ -143,8 +142,6 @@ import (
 // while for a node running as a library, the config fields are expected to be initialized by the caller.
 type AccessNodeConfig struct {
 	supportsObserver                     bool // True if this is an Access node that supports observers and consensus follower engines
-	collectionGRPCPort                   uint
-	executionGRPCPort                    uint
 	pingEnabled                          bool
 	nodeInfoFile                         string
 	apiRatelimits                        map[string]int
@@ -198,9 +195,7 @@ type PublicNetworkConfig struct {
 func DefaultAccessNodeConfig() *AccessNodeConfig {
 	homedir, _ := os.UserHomeDir()
 	return &AccessNodeConfig{
-		supportsObserver:   false,
-		collectionGRPCPort: 9000,
-		executionGRPCPort:  9000,
+		supportsObserver: false,
 		rpcConf: rpc.Config{
 			UnsecureGRPCListenAddr: "0.0.0.0:9000",
 			SecureGRPCListenAddr:   "0.0.0.0:9001",
@@ -208,8 +203,9 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 			CollectionAddr:         "",
 			HistoricalAccessAddrs:  "",
 			BackendConfig: backend.Config{
-				CollectionClientTimeout:   3 * time.Second,
-				ExecutionClientTimeout:    3 * time.Second,
+				AccessConfig:              rpcConnection.DefaultAccessConfig(),
+				CollectionConfig:          rpcConnection.DefaultCollectionConfig(),
+				ExecutionConfig:           rpcConnection.DefaultExecutionConfig(),
 				ConnectionPoolSize:        backend.DefaultConnectionPoolSize,
 				MaxHeightRange:            events.DefaultMaxHeightRange,
 				PreferredExecutionNodeIDs: nil,
@@ -225,19 +221,20 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 				TxResultQueryMode:   query_mode.IndexQueryModeExecutionNodesOnly.String(), // default to ENs only for now
 			},
 			RestConfig: rest.Config{
-				ListenAddress:  "",
-				WriteTimeout:   rest.DefaultWriteTimeout,
-				ReadTimeout:    rest.DefaultReadTimeout,
-				IdleTimeout:    rest.DefaultIdleTimeout,
-				MaxRequestSize: commonrest.DefaultMaxRequestSize,
+				ListenAddress:   "",
+				WriteTimeout:    rest.DefaultWriteTimeout,
+				ReadTimeout:     rest.DefaultReadTimeout,
+				IdleTimeout:     rest.DefaultIdleTimeout,
+				MaxRequestSize:  commonrpc.DefaultAccessMaxRequestSize,
+				MaxResponseSize: commonrpc.DefaultAccessMaxResponseSize,
 			},
-			MaxMsgSize:                grpcutils.DefaultMaxMsgSize,
+			DeprecatedMaxMsgSize:      0,
 			CompressorName:            grpcutils.NoCompressor,
 			WebSocketConfig:           websockets.NewDefaultWebsocketConfig(),
 			EnableWebSocketsStreamAPI: true,
 		},
 		stateStreamConf: statestreambackend.Config{
-			MaxExecutionDataMsgSize: grpcutils.DefaultMaxMsgSize,
+			MaxExecutionDataMsgSize: commonrpc.DefaultAccessMaxResponseSize,
 			ExecutionDataCacheSize:  subscription.DefaultCacheSize,
 			ClientSendTimeout:       subscription.DefaultSendTimeout,
 			ClientSendBufferSize:    subscription.DefaultSendBufferSize,
@@ -1162,8 +1159,14 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 	builder.ExtraFlags(func(flags *pflag.FlagSet) {
 		defaultConfig := DefaultAccessNodeConfig()
 
-		flags.UintVar(&builder.collectionGRPCPort, "collection-ingress-port", defaultConfig.collectionGRPCPort, "the grpc ingress port for all collection nodes")
-		flags.UintVar(&builder.executionGRPCPort, "execution-ingress-port", defaultConfig.executionGRPCPort, "the grpc ingress port for all execution nodes")
+		flags.UintVar(&builder.rpcConf.BackendConfig.CollectionConfig.GRPCPort,
+			"collection-ingress-port",
+			defaultConfig.rpcConf.BackendConfig.CollectionConfig.GRPCPort,
+			"the grpc ingress port for all collection nodes")
+		flags.UintVar(&builder.rpcConf.BackendConfig.ExecutionConfig.GRPCPort,
+			"execution-ingress-port",
+			defaultConfig.rpcConf.BackendConfig.ExecutionConfig.GRPCPort,
+			"the grpc ingress port for all execution nodes")
 		flags.StringVarP(&builder.rpcConf.UnsecureGRPCListenAddr,
 			"rpc-addr",
 			"r",
@@ -1195,6 +1198,10 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"rest-max-request-size",
 			defaultConfig.rpcConf.RestConfig.MaxRequestSize,
 			"the maximum request size in bytes for payload sent over REST server")
+		flags.Int64Var(&builder.rpcConf.RestConfig.MaxResponseSize,
+			"rest-max-response-size",
+			defaultConfig.rpcConf.RestConfig.MaxResponseSize,
+			"the maximum response size in bytes for payload sent from REST server")
 		flags.StringVarP(&builder.rpcConf.CollectionAddr,
 			"static-collection-ingress-addr",
 			"",
@@ -1210,22 +1217,46 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"",
 			defaultConfig.rpcConf.HistoricalAccessAddrs,
 			"comma separated rpc addresses for historical access nodes")
-		flags.DurationVar(&builder.rpcConf.BackendConfig.CollectionClientTimeout,
+		flags.DurationVar(&builder.rpcConf.BackendConfig.CollectionConfig.Timeout,
 			"collection-client-timeout",
-			defaultConfig.rpcConf.BackendConfig.CollectionClientTimeout,
+			defaultConfig.rpcConf.BackendConfig.CollectionConfig.Timeout,
 			"grpc client timeout for a collection node")
-		flags.DurationVar(&builder.rpcConf.BackendConfig.ExecutionClientTimeout,
+		flags.DurationVar(&builder.rpcConf.BackendConfig.ExecutionConfig.Timeout,
 			"execution-client-timeout",
-			defaultConfig.rpcConf.BackendConfig.ExecutionClientTimeout,
+			defaultConfig.rpcConf.BackendConfig.ExecutionConfig.Timeout,
 			"grpc client timeout for an execution node")
 		flags.UintVar(&builder.rpcConf.BackendConfig.ConnectionPoolSize,
 			"connection-pool-size",
 			defaultConfig.rpcConf.BackendConfig.ConnectionPoolSize,
 			"maximum number of connections allowed in the connection pool, size of 0 disables the connection pooling, and anything less than the default size will be overridden to use the default size")
-		flags.UintVar(&builder.rpcConf.MaxMsgSize,
+		flags.UintVar(&builder.rpcConf.DeprecatedMaxMsgSize,
 			"rpc-max-message-size",
-			grpcutils.DefaultMaxMsgSize,
-			"the maximum message size in bytes for messages sent or received over grpc")
+			defaultConfig.rpcConf.DeprecatedMaxMsgSize,
+			"[deprecated] the maximum message size in bytes for messages sent or received over grpc")
+		flags.UintVar(&builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
+			"rpc-max-request-message-size",
+			defaultConfig.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
+			"the maximum request message size in bytes for request messages received over grpc by the server")
+		flags.UintVar(&builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize,
+			"rpc-max-response-message-size",
+			defaultConfig.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize,
+			"the maximum message size in bytes for response messages sent over grpc by the server")
+		flags.UintVar(&builder.rpcConf.BackendConfig.CollectionConfig.MaxRequestMsgSize,
+			"rpc-max-collection-request-message-size",
+			defaultConfig.rpcConf.BackendConfig.CollectionConfig.MaxRequestMsgSize,
+			"the maximum request message size in bytes for request messages sent over grpc to collection nodes")
+		flags.UintVar(&builder.rpcConf.BackendConfig.CollectionConfig.MaxResponseMsgSize,
+			"rpc-max-collection-response-message-size",
+			defaultConfig.rpcConf.BackendConfig.CollectionConfig.MaxResponseMsgSize,
+			"the maximum message size in bytes for response messages received over grpc from collection nodes")
+		flags.UintVar(&builder.rpcConf.BackendConfig.ExecutionConfig.MaxRequestMsgSize,
+			"rpc-max-execution-request-message-size",
+			defaultConfig.rpcConf.BackendConfig.ExecutionConfig.MaxRequestMsgSize,
+			"the maximum request message size in bytes for request messages sent over grpc to execution nodes")
+		flags.UintVar(&builder.rpcConf.BackendConfig.ExecutionConfig.MaxResponseMsgSize,
+			"rpc-max-execution-response-message-size",
+			defaultConfig.rpcConf.BackendConfig.ExecutionConfig.MaxResponseMsgSize,
+			"the maximum message size in bytes for response messages received over grpc from execution nodes")
 		flags.UintVar(&builder.rpcConf.BackendConfig.MaxHeightRange,
 			"rpc-max-height-range",
 			defaultConfig.rpcConf.BackendConfig.MaxHeightRange,
@@ -1542,6 +1573,27 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 		if builder.rpcConf.RestConfig.MaxRequestSize <= 0 {
 			return errors.New("rest-max-request-size must be greater than 0")
 		}
+		if builder.rpcConf.RestConfig.MaxResponseSize <= 0 {
+			return errors.New("rest-max-response-size must be greater than 0")
+		}
+		if builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize <= 0 {
+			return errors.New("rpc-max-request-message-size must be greater than 0")
+		}
+		if builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize <= 0 {
+			return errors.New("rpc-max-response-message-size must be greater than 0")
+		}
+		if builder.rpcConf.BackendConfig.CollectionConfig.MaxRequestMsgSize <= 0 {
+			return errors.New("rpc-max-collection-request-message-size must be greater than 0")
+		}
+		if builder.rpcConf.BackendConfig.CollectionConfig.MaxResponseMsgSize <= 0 {
+			return errors.New("rpc-max-collection-response-message-size must be greater than 0")
+		}
+		if builder.rpcConf.BackendConfig.ExecutionConfig.MaxRequestMsgSize <= 0 {
+			return errors.New("rpc-max-execution-request-message-size must be greater than 0")
+		}
+		if builder.rpcConf.BackendConfig.ExecutionConfig.MaxResponseMsgSize <= 0 {
+			return errors.New("rpc-max-execution-response-message-size must be greater than 0")
+		}
 
 		return nil
 	})
@@ -1671,6 +1723,23 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 
 	builder.
 		BuildConsensusFollower().
+		Module("normalize rpc message limits", func(node *cmd.NodeConfig) error {
+			// This needs to be the first module run so other modules can use the normalized values
+			// TODO: remove this module once the deprecated flag is removed
+			if builder.rpcConf.DeprecatedMaxMsgSize != 0 {
+				node.Logger.Warn().Msg("A deprecated flag was specified (--rpc-max-message-size). Use --rpc-max-request-message-size and --rpc-max-response-message-size instead. This flag will be removed in a future release.")
+				builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize = builder.rpcConf.DeprecatedMaxMsgSize
+				builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize = builder.rpcConf.DeprecatedMaxMsgSize
+
+				builder.rpcConf.BackendConfig.CollectionConfig.MaxRequestMsgSize = commonrpc.DefaultMaxMsgSize // previous version used this default
+				builder.rpcConf.BackendConfig.CollectionConfig.MaxResponseMsgSize = builder.rpcConf.DeprecatedMaxMsgSize
+
+				builder.rpcConf.BackendConfig.ExecutionConfig.MaxRequestMsgSize = commonrpc.DefaultMaxMsgSize // previous version used this default
+				builder.rpcConf.BackendConfig.ExecutionConfig.MaxResponseMsgSize = builder.rpcConf.DeprecatedMaxMsgSize
+			}
+
+			return nil
+		}).
 		Module("collection node client", func(node *cmd.NodeConfig) error {
 			// collection node address is optional (if not specified, collection nodes will be chosen at random)
 			if strings.TrimSpace(builder.rpcConf.CollectionAddr) == "" {
@@ -1682,11 +1751,14 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				Str("collection_node", builder.rpcConf.CollectionAddr).
 				Msg("using the static collection node address")
 
-			collectionRPCConn, err := grpc.Dial(
+			collectionRPCConn, err := grpc.NewClient(
 				builder.rpcConf.CollectionAddr,
-				grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(int(builder.rpcConf.MaxMsgSize))),
+				grpc.WithDefaultCallOptions(
+					grpc.MaxCallSendMsgSize(int(builder.rpcConf.BackendConfig.CollectionConfig.MaxRequestMsgSize)),
+					grpc.MaxCallRecvMsgSize(int(builder.rpcConf.BackendConfig.CollectionConfig.MaxResponseMsgSize)),
+				),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				rpcConnection.WithClientTimeoutOption(builder.rpcConf.BackendConfig.CollectionClientTimeout))
+				rpcConnection.WithClientTimeoutOption(builder.rpcConf.BackendConfig.CollectionConfig.Timeout))
 			if err != nil {
 				return err
 			}
@@ -1701,9 +1773,24 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				}
 				node.Logger.Info().Str("access_nodes", addr).Msg("historical access node addresses")
 
-				historicalAccessRPCConn, err := grpc.Dial(
+				// maintain backwards compatibility with the deprecated flag
+				// TODO: remove this once the deprecated flag is removed
+				var callOpts []grpc.CallOption
+				if builder.rpcConf.DeprecatedMaxMsgSize == 0 {
+					callOpts = append(callOpts,
+						grpc.MaxCallSendMsgSize(int(builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize)),
+						grpc.MaxCallRecvMsgSize(int(builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize)),
+					)
+				} else {
+					// only receive limit was enforced in previous versions. send used default (4mb)
+					callOpts = append(callOpts,
+						grpc.MaxCallRecvMsgSize(int(builder.rpcConf.DeprecatedMaxMsgSize)),
+					)
+				}
+
+				historicalAccessRPCConn, err := grpc.NewClient(
 					addr,
-					grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(int(builder.rpcConf.MaxMsgSize))),
+					grpc.WithDefaultCallOptions(callOpts...),
 					grpc.WithTransportCredentials(insecure.NewCredentials()))
 				if err != nil {
 					return err
@@ -1789,7 +1876,8 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			builder.secureGrpcServer = grpcserver.NewGrpcServerBuilder(
 				node.Logger,
 				builder.rpcConf.SecureGRPCListenAddr,
-				builder.rpcConf.MaxMsgSize,
+				builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
+				builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize,
 				builder.rpcMetricsEnabled,
 				builder.apiRatelimits,
 				builder.apiBurstlimits,
@@ -1798,6 +1886,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			builder.stateStreamGrpcServer = grpcserver.NewGrpcServerBuilder(
 				node.Logger,
 				builder.stateStreamConf.ListenAddr,
+				builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
 				builder.stateStreamConf.MaxExecutionDataMsgSize,
 				builder.rpcMetricsEnabled,
 				builder.apiRatelimits,
@@ -1807,7 +1896,8 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			if builder.rpcConf.UnsecureGRPCListenAddr != builder.stateStreamConf.ListenAddr {
 				builder.unsecureGrpcServer = grpcserver.NewGrpcServerBuilder(node.Logger,
 					builder.rpcConf.UnsecureGRPCListenAddr,
-					builder.rpcConf.MaxMsgSize,
+					builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
+					builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize,
 					builder.rpcMetricsEnabled,
 					builder.apiRatelimits,
 					builder.apiBurstlimits).Build()
@@ -1935,17 +2025,15 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			}
 
 			connFactory := &rpcConnection.ConnectionFactoryImpl{
-				CollectionGRPCPort:        builder.collectionGRPCPort,
-				ExecutionGRPCPort:         builder.executionGRPCPort,
-				CollectionNodeGRPCTimeout: backendConfig.CollectionClientTimeout,
-				ExecutionNodeGRPCTimeout:  backendConfig.ExecutionClientTimeout,
-				AccessMetrics:             accessMetrics,
-				Log:                       node.Logger,
+				AccessConfig:     backendConfig.AccessConfig,
+				CollectionConfig: backendConfig.CollectionConfig,
+				ExecutionConfig:  backendConfig.ExecutionConfig,
+				AccessMetrics:    accessMetrics,
+				Log:              node.Logger,
 				Manager: rpcConnection.NewManager(
 					node.Logger,
 					accessMetrics,
 					connBackendCache,
-					config.MaxMsgSize,
 					backendConfig.CircuitBreakerConfig,
 					config.CompressorName,
 				),
@@ -2064,6 +2152,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				VersionControl:             notNil(builder.VersionControl),
 				ExecNodeIdentitiesProvider: notNil(builder.ExecNodeIdentitiesProvider),
 				TxErrorMessageProvider:     notNil(builder.txResultErrorMessageProvider),
+				MaxScriptAndArgumentSize:   config.BackendConfig.AccessConfig.MaxRequestMsgSize,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("could not initialize backend: %w", err)

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/onflow/flow-go/engine/collection/rpc"
 	followereng "github.com/onflow/flow-go/engine/common/follower"
 	"github.com/onflow/flow-go/engine/common/provider"
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
 	consync "github.com/onflow/flow-go/engine/common/synchronization"
 	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/bootstrap"
@@ -58,7 +59,6 @@ import (
 	"github.com/onflow/flow-go/state/protocol/blocktimer"
 	"github.com/onflow/flow-go/state/protocol/events/gadgets"
 	"github.com/onflow/flow-go/storage/badger"
-	"github.com/onflow/flow-go/utils/grpcutils"
 )
 
 func main() {
@@ -121,8 +121,12 @@ func main() {
 			"maximum number of transactions in the memory pool")
 		flags.StringVarP(&rpcConf.ListenAddr, "ingress-addr", "i", "localhost:9000",
 			"the address the ingress server listens on")
-		flags.UintVar(&rpcConf.MaxMsgSize, "rpc-max-message-size", grpcutils.DefaultMaxMsgSize,
-			"the maximum message size in bytes for messages sent or received over grpc")
+		flags.UintVar(&rpcConf.DeprecatedMaxMsgSize, "rpc-max-message-size", 0,
+			"[deprecated] the maximum message size in bytes for messages sent or received over grpc")
+		flags.UintVar(&rpcConf.MaxRequestMsgSize, "rpc-max-request-message-size", commonrpc.DefaultCollectionMaxRequestSize,
+			"the maximum request message size in bytes for request messages received over grpc by the server")
+		flags.UintVar(&rpcConf.MaxResponseMsgSize, "rpc-max-response-message-size", commonrpc.DefaultCollectionMaxResponseSize,
+			"the maximum message size in bytes for response messages sent over grpc by the server")
 		flags.BoolVar(&rpcConf.RpcMetricsEnabled, "rpc-metrics-enabled", false,
 			"whether to enable the rpc metrics")
 		flags.Uint64Var(&ingestConf.MaxGasLimit, "ingest-max-gas-limit", flow.DefaultMaxTransactionGasLimit,
@@ -479,6 +483,13 @@ func main() {
 			return ing, err
 		}).
 		Component("transaction ingress rpc server", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+			// maintain backwards compatibility with the deprecated flag
+			if rpcConf.DeprecatedMaxMsgSize != 0 {
+				node.Logger.Warn().Msg("A deprecated flag was specified (--rpc-max-message-size). Use --rpc-max-request-message-size and --rpc-max-response-message-size instead. This flag will be removed in a future release.")
+				rpcConf.MaxRequestMsgSize = rpcConf.DeprecatedMaxMsgSize
+				rpcConf.MaxResponseMsgSize = rpcConf.DeprecatedMaxMsgSize
+			}
+
 			server := rpc.New(
 				rpcConf,
 				ing,

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1357,6 +1357,12 @@ func (exeNode *ExecutionNode) LoadGrpcServer(
 	module.ReadyDoneAware,
 	error,
 ) {
+	// maintain backwards compatibility with the deprecated flag
+	if exeNode.exeConf.rpcConf.DeprecatedMaxMsgSize != 0 {
+		node.Logger.Warn().Msg("A deprecated flag was specified (--rpc-max-message-size). Use --rpc-max-request-message-size and --rpc-max-response-message-size instead. This flag will be removed in a future release.")
+		exeNode.exeConf.rpcConf.MaxRequestMsgSize = exeNode.exeConf.rpcConf.DeprecatedMaxMsgSize
+		exeNode.exeConf.rpcConf.MaxResponseMsgSize = exeNode.exeConf.rpcConf.DeprecatedMaxMsgSize
+	}
 	return rpc.New(
 		node.Logger,
 		exeNode.exeConf.rpcConf,

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -16,8 +16,8 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/module/mempool"
-	"github.com/onflow/flow-go/utils/grpcutils"
 
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/engine/execution/computation"
 	"github.com/onflow/flow-go/engine/execution/ingestion/stop"
 	"github.com/onflow/flow-go/engine/execution/rpc"
@@ -85,7 +85,12 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	datadir := "/data"
 
 	flags.StringVarP(&exeConf.rpcConf.ListenAddr, "rpc-addr", "i", "localhost:9000", "the address the gRPC server listens on")
-	flags.UintVar(&exeConf.rpcConf.MaxMsgSize, "rpc-max-message-size", grpcutils.DefaultMaxMsgSize, "the maximum message size in bytes for messages sent or received over grpc")
+	flags.UintVar(&exeConf.rpcConf.DeprecatedMaxMsgSize, "rpc-max-message-size", 0,
+		"[deprecated] the maximum message size in bytes for messages sent or received over grpc")
+	flags.UintVar(&exeConf.rpcConf.MaxRequestMsgSize, "rpc-max-request-message-size", commonrpc.DefaultExecutionMaxRequestSize,
+		"the maximum request message size in bytes for request messages received over grpc by the server")
+	flags.UintVar(&exeConf.rpcConf.MaxResponseMsgSize, "rpc-max-response-message-size", commonrpc.DefaultExecutionMaxResponseSize,
+		"the maximum message size in bytes for response messages sent over grpc by the server")
 	flags.BoolVar(&exeConf.rpcConf.RpcMetricsEnabled, "rpc-metrics-enabled", false, "whether to enable the rpc metrics")
 	flags.StringVar(&exeConf.triedir, "triedir", filepath.Join(datadir, "trie"), "directory to store the execution State")
 	flags.StringVar(&exeConf.executionDataDir, "execution-data-dir", filepath.Join(datadir, "execution_data"), "directory to use for storing Execution Data")

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -6,11 +6,11 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/onflow/flow-go/cmd"
+	"github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/engine/ghost/engine"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/validator"
-	"github.com/onflow/flow-go/utils/grpcutils"
 )
 
 func main() {
@@ -21,7 +21,7 @@ func main() {
 	nodeBuilder := cmd.FlowNode("ghost")
 	nodeBuilder.ExtraFlags(func(flags *pflag.FlagSet) {
 		flags.StringVarP(&rpcConf.ListenAddr, "rpc-addr", "r", "localhost:9000", "the address the GRPC server listens on")
-		flags.UintVar(&rpcConf.MaxMsgSize, "rpc-max-message-size", grpcutils.DefaultMaxMsgSize, "the maximum message size in bytes for messages sent or received over grpc")
+		flags.UintVar(&rpcConf.MaxMsgSize, "rpc-max-message-size", rpc.DefaultMaxResponseMsgSize, "the maximum message size in bytes for messages sent or received over grpc")
 	})
 
 	if err := nodeBuilder.Initialize(); err != nil {

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/onflow/flow-go/admin/commands"
 	"github.com/onflow/flow-go/config"
+	"github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
@@ -31,7 +32,6 @@ import (
 	"github.com/onflow/flow-go/storage"
 	bstorage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/storage/dbops"
-	"github.com/onflow/flow-go/utils/grpcutils"
 )
 
 const NotSet = "not set"
@@ -278,7 +278,7 @@ func DefaultBaseConfig() *BaseConfig {
 		AdminCert:        NotSet,
 		AdminKey:         NotSet,
 		AdminClientCAs:   NotSet,
-		AdminMaxMsgSize:  grpcutils.DefaultMaxMsgSize,
+		AdminMaxMsgSize:  rpc.DefaultMaxResponseMsgSize,
 		BindAddr:         NotSet,
 		ObserverMode:     false,
 		BootstrapDir:     "bootstrap",

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -41,7 +41,6 @@ import (
 	"github.com/onflow/flow-go/engine/access/index"
 	"github.com/onflow/flow-go/engine/access/rest"
 	restapiproxy "github.com/onflow/flow-go/engine/access/rest/apiproxy"
-	commonrest "github.com/onflow/flow-go/engine/access/rest/common"
 	"github.com/onflow/flow-go/engine/access/rest/router"
 	"github.com/onflow/flow-go/engine/access/rest/websockets"
 	"github.com/onflow/flow-go/engine/access/rpc"
@@ -145,7 +144,6 @@ type ObserverServiceConfig struct {
 	rpcMetricsEnabled                    bool
 	registersDBPath                      string
 	checkpointFile                       string
-	apiTimeout                           time.Duration
 	stateStreamConf                      statestreambackend.Config
 	stateStreamFilterConf                map[string]int
 	upstreamNodeAddresses                []string
@@ -187,8 +185,9 @@ func DefaultObserverServiceConfig() *ObserverServiceConfig {
 			CollectionAddr:         "",
 			HistoricalAccessAddrs:  "",
 			BackendConfig: backend.Config{
-				CollectionClientTimeout:   3 * time.Second,
-				ExecutionClientTimeout:    3 * time.Second,
+				AccessConfig:              rpcConnection.DefaultAccessConfig(),
+				CollectionConfig:          rpcConnection.DefaultCollectionConfig(), // unused on observers
+				ExecutionConfig:           rpcConnection.DefaultExecutionConfig(),  // unused on observers
 				ConnectionPoolSize:        backend.DefaultConnectionPoolSize,
 				MaxHeightRange:            events.DefaultMaxHeightRange,
 				PreferredExecutionNodeIDs: nil,
@@ -198,19 +197,20 @@ func DefaultObserverServiceConfig() *ObserverServiceConfig {
 				TxResultQueryMode:         query_mode.IndexQueryModeExecutionNodesOnly.String(), // default to ENs only for now
 			},
 			RestConfig: rest.Config{
-				ListenAddress:  "",
-				WriteTimeout:   rest.DefaultWriteTimeout,
-				ReadTimeout:    rest.DefaultReadTimeout,
-				IdleTimeout:    rest.DefaultIdleTimeout,
-				MaxRequestSize: commonrest.DefaultMaxRequestSize,
+				ListenAddress:   "",
+				WriteTimeout:    rest.DefaultWriteTimeout,
+				ReadTimeout:     rest.DefaultReadTimeout,
+				IdleTimeout:     rest.DefaultIdleTimeout,
+				MaxRequestSize:  commonrpc.DefaultAccessMaxRequestSize,
+				MaxResponseSize: commonrpc.DefaultAccessMaxResponseSize,
 			},
-			MaxMsgSize:                grpcutils.DefaultMaxMsgSize,
+			DeprecatedMaxMsgSize:      0,
 			CompressorName:            grpcutils.NoCompressor,
 			WebSocketConfig:           websockets.NewDefaultWebsocketConfig(),
 			EnableWebSocketsStreamAPI: true,
 		},
 		stateStreamConf: statestreambackend.Config{
-			MaxExecutionDataMsgSize: grpcutils.DefaultMaxMsgSize,
+			MaxExecutionDataMsgSize: commonrpc.DefaultAccessMaxResponseSize,
 			ExecutionDataCacheSize:  subscription.DefaultCacheSize,
 			ClientSendTimeout:       subscription.DefaultSendTimeout,
 			ClientSendBufferSize:    subscription.DefaultSendBufferSize,
@@ -225,7 +225,6 @@ func DefaultObserverServiceConfig() *ObserverServiceConfig {
 		apiRatelimits:                        nil,
 		apiBurstlimits:                       nil,
 		observerNetworkingKeyPath:            cmd.NotSet,
-		apiTimeout:                           3 * time.Second,
 		upstreamNodeAddresses:                []string{},
 		upstreamNodePublicKeys:               []string{},
 		registersDBPath:                      filepath.Join(homedir, ".flow", "execution_state"),
@@ -640,10 +639,22 @@ func (builder *ObserverServiceBuilder) extraFlags() {
 			"rest-max-request-size",
 			defaultConfig.rpcConf.RestConfig.MaxRequestSize,
 			"the maximum request size in bytes for payload sent over REST server")
-		flags.UintVar(&builder.rpcConf.MaxMsgSize,
+		flags.Int64Var(&builder.rpcConf.RestConfig.MaxResponseSize,
+			"rest-max-response-size",
+			defaultConfig.rpcConf.RestConfig.MaxResponseSize,
+			"the maximum response size in bytes for payload sent from REST server")
+		flags.UintVar(&builder.rpcConf.DeprecatedMaxMsgSize,
 			"rpc-max-message-size",
-			defaultConfig.rpcConf.MaxMsgSize,
-			"the maximum message size in bytes for messages sent or received over grpc")
+			defaultConfig.rpcConf.DeprecatedMaxMsgSize,
+			"[deprecated] the maximum message size in bytes for messages sent or received over grpc")
+		flags.UintVar(&builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
+			"rpc-max-request-message-size",
+			defaultConfig.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
+			"the maximum request message size in bytes for request messages received over grpc by the server")
+		flags.UintVar(&builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize,
+			"rpc-max-response-message-size",
+			defaultConfig.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize,
+			"the maximum message size in bytes for response messages sent over grpc by the server")
 		flags.UintVar(&builder.rpcConf.BackendConfig.ConnectionPoolSize,
 			"connection-pool-size",
 			defaultConfig.rpcConf.BackendConfig.ConnectionPoolSize,
@@ -664,7 +675,10 @@ func (builder *ObserverServiceBuilder) extraFlags() {
 			"observer-networking-key-path",
 			defaultConfig.observerNetworkingKeyPath,
 			"path to the networking key for observer")
-		flags.DurationVar(&builder.apiTimeout, "upstream-api-timeout", defaultConfig.apiTimeout, "tcp timeout for Flow API gRPC sockets to upstrem nodes")
+		flags.DurationVar(&builder.rpcConf.BackendConfig.AccessConfig.Timeout,
+			"upstream-api-timeout",
+			defaultConfig.rpcConf.BackendConfig.AccessConfig.Timeout,
+			"tcp timeout for Flow API gRPC sockets to upstrem nodes")
 		flags.StringSliceVar(&builder.upstreamNodeAddresses,
 			"upstream-node-addresses",
 			defaultConfig.upstreamNodeAddresses,
@@ -1756,9 +1770,16 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 		return nil
 	})
 	builder.Module("creating grpc servers", func(node *cmd.NodeConfig) error {
+		if builder.rpcConf.DeprecatedMaxMsgSize != 0 {
+			node.Logger.Warn().Msg("A deprecated flag was specified (--rpc-max-message-size). Use --rpc-max-request-message-size and --rpc-max-response-message-size instead. This flag will be removed in a future release.")
+			builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize = builder.rpcConf.DeprecatedMaxMsgSize
+			builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize = builder.rpcConf.DeprecatedMaxMsgSize
+		}
+
 		builder.secureGrpcServer = grpcserver.NewGrpcServerBuilder(node.Logger,
 			builder.rpcConf.SecureGRPCListenAddr,
-			builder.rpcConf.MaxMsgSize,
+			builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
+			builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize,
 			builder.rpcMetricsEnabled,
 			builder.apiRatelimits,
 			builder.apiBurstlimits,
@@ -1767,6 +1788,7 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 		builder.stateStreamGrpcServer = grpcserver.NewGrpcServerBuilder(
 			node.Logger,
 			builder.stateStreamConf.ListenAddr,
+			builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
 			builder.stateStreamConf.MaxExecutionDataMsgSize,
 			builder.rpcMetricsEnabled,
 			builder.apiRatelimits,
@@ -1776,7 +1798,8 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 		if builder.rpcConf.UnsecureGRPCListenAddr != builder.stateStreamConf.ListenAddr {
 			builder.unsecureGrpcServer = grpcserver.NewGrpcServerBuilder(node.Logger,
 				builder.rpcConf.UnsecureGRPCListenAddr,
-				builder.rpcConf.MaxMsgSize,
+				builder.rpcConf.BackendConfig.AccessConfig.MaxRequestMsgSize,
+				builder.rpcConf.BackendConfig.AccessConfig.MaxResponseMsgSize,
 				builder.rpcMetricsEnabled,
 				builder.apiRatelimits,
 				builder.apiBurstlimits).Build()
@@ -1883,17 +1906,15 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 		}
 
 		connFactory := &rpcConnection.ConnectionFactoryImpl{
-			CollectionGRPCPort:        0,
-			ExecutionGRPCPort:         0,
-			CollectionNodeGRPCTimeout: builder.apiTimeout,
-			ExecutionNodeGRPCTimeout:  builder.apiTimeout,
-			AccessMetrics:             accessMetrics,
-			Log:                       node.Logger,
+			AccessConfig:     backendConfig.AccessConfig,
+			CollectionConfig: backendConfig.CollectionConfig,
+			ExecutionConfig:  backendConfig.ExecutionConfig,
+			AccessMetrics:    accessMetrics,
+			Log:              node.Logger,
 			Manager: rpcConnection.NewManager(
 				node.Logger,
 				accessMetrics,
 				connBackendCache,
-				config.MaxMsgSize,
 				backendConfig.CircuitBreakerConfig,
 				config.CompressorName,
 			),
@@ -1987,6 +2008,7 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 			IndexReporter:              indexReporter,
 			VersionControl:             builder.VersionControl,
 			ExecNodeIdentitiesProvider: execNodeIdentitiesProvider,
+			MaxScriptAndArgumentSize:   config.BackendConfig.AccessConfig.MaxRequestMsgSize,
 		}
 
 		if builder.localServiceAPIEnabled {

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -162,23 +162,24 @@ func (suite *Suite) RunTest(
 
 		var err error
 		suite.backend, err = backend.New(backend.Params{
-			State:                suite.state,
-			CollectionRPC:        suite.collClient,
-			Blocks:               all.Blocks,
-			Headers:              all.Headers,
-			Collections:          all.Collections,
-			Transactions:         all.Transactions,
-			ExecutionResults:     en.Results,
-			ExecutionReceipts:    en.Receipts,
-			ChainID:              suite.chainID,
-			AccessMetrics:        suite.metrics,
-			MaxHeightRange:       events.DefaultMaxHeightRange,
-			Log:                  suite.log,
-			SnapshotHistoryLimit: backend.DefaultSnapshotHistoryLimit,
-			Communicator:         node_communicator.NewNodeCommunicator(false),
-			EventQueryMode:       query_mode.IndexQueryModeExecutionNodesOnly,
-			ScriptExecutionMode:  query_mode.IndexQueryModeExecutionNodesOnly,
-			TxResultQueryMode:    query_mode.IndexQueryModeExecutionNodesOnly,
+			State:                    suite.state,
+			CollectionRPC:            suite.collClient,
+			Blocks:                   all.Blocks,
+			Headers:                  all.Headers,
+			Collections:              all.Collections,
+			Transactions:             all.Transactions,
+			ExecutionResults:         en.Results,
+			ExecutionReceipts:        en.Receipts,
+			ChainID:                  suite.chainID,
+			AccessMetrics:            suite.metrics,
+			MaxHeightRange:           events.DefaultMaxHeightRange,
+			Log:                      suite.log,
+			SnapshotHistoryLimit:     backend.DefaultSnapshotHistoryLimit,
+			Communicator:             node_communicator.NewNodeCommunicator(false),
+			EventQueryMode:           query_mode.IndexQueryModeExecutionNodesOnly,
+			ScriptExecutionMode:      query_mode.IndexQueryModeExecutionNodesOnly,
+			TxResultQueryMode:        query_mode.IndexQueryModeExecutionNodesOnly,
+			MaxScriptAndArgumentSize: commonrpc.DefaultAccessMaxRequestSize,
 		})
 		require.NoError(suite.T(), err)
 
@@ -340,22 +341,23 @@ func (suite *Suite) TestSendTransactionToRandomCollectionNode() {
 
 		// create a mock connection factory
 		connFactory := connectionmock.NewConnectionFactory(suite.T())
-		connFactory.On("GetAccessAPIClient", collNode1.Address, nil).Return(col1ApiClient, &mocks.MockCloser{}, nil)
-		connFactory.On("GetAccessAPIClient", collNode2.Address, nil).Return(col2ApiClient, &mocks.MockCloser{}, nil)
+		connFactory.On("GetCollectionAPIClient", collNode1.Address, nil).Return(col1ApiClient, &mocks.MockCloser{}, nil)
+		connFactory.On("GetCollectionAPIClient", collNode2.Address, nil).Return(col2ApiClient, &mocks.MockCloser{}, nil)
 
 		bnd, err := backend.New(backend.Params{State: suite.state,
-			Collections:          collections,
-			Transactions:         transactions,
-			ChainID:              suite.chainID,
-			AccessMetrics:        metrics,
-			ConnFactory:          connFactory,
-			MaxHeightRange:       events.DefaultMaxHeightRange,
-			Log:                  suite.log,
-			SnapshotHistoryLimit: backend.DefaultSnapshotHistoryLimit,
-			Communicator:         node_communicator.NewNodeCommunicator(false),
-			EventQueryMode:       query_mode.IndexQueryModeExecutionNodesOnly,
-			ScriptExecutionMode:  query_mode.IndexQueryModeExecutionNodesOnly,
-			TxResultQueryMode:    query_mode.IndexQueryModeExecutionNodesOnly,
+			Collections:              collections,
+			Transactions:             transactions,
+			ChainID:                  suite.chainID,
+			AccessMetrics:            metrics,
+			ConnFactory:              connFactory,
+			MaxHeightRange:           events.DefaultMaxHeightRange,
+			Log:                      suite.log,
+			SnapshotHistoryLimit:     backend.DefaultSnapshotHistoryLimit,
+			Communicator:             node_communicator.NewNodeCommunicator(false),
+			EventQueryMode:           query_mode.IndexQueryModeExecutionNodesOnly,
+			ScriptExecutionMode:      query_mode.IndexQueryModeExecutionNodesOnly,
+			TxResultQueryMode:        query_mode.IndexQueryModeExecutionNodesOnly,
+			MaxScriptAndArgumentSize: commonrpc.DefaultAccessMaxRequestSize,
 		})
 		require.NoError(suite.T(), err)
 

--- a/engine/access/apiproxy/access_api_proxy_test.go
+++ b/engine/access/apiproxy/access_api_proxy_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/onflow/flow-go/engine/access/rpc/connection"
 	"github.com/onflow/flow-go/engine/common/grpc/forwarder"
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/utils/grpcutils"
@@ -149,13 +150,16 @@ func TestNewFlowCachedAccessAPIProxy(t *testing.T) {
 	// create the factory
 	connectionFactory := &connection.ConnectionFactoryImpl{
 		// set metrics reporting
-		AccessMetrics:             metrics,
-		CollectionNodeGRPCTimeout: time.Second,
+		AccessMetrics: metrics,
+		CollectionConfig: connection.Config{
+			Timeout:            time.Second,
+			MaxRequestMsgSize:  commonrpc.DefaultCollectionMaxRequestSize,
+			MaxResponseMsgSize: commonrpc.DefaultCollectionMaxResponseSize,
+		},
 		Manager: connection.NewManager(
 			unittest.Logger(),
 			metrics,
 			nil,
-			grpcutils.DefaultMaxMsgSize,
 			connection.CircuitBreakerConfig{},
 			grpcutils.NoCompressor,
 		),
@@ -264,9 +268,9 @@ func newFlowLite(network string, address string, done chan int) (*grpc.Server, *
 }
 
 func openFlowLite(address string) error {
-	c, err := grpc.Dial(
+	c, err := grpc.NewClient(
 		"unix://"+address,
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcutils.DefaultMaxMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(commonrpc.DefaultAccessMaxResponseSize)),
 		grpc.WithTransportCredentials(grpcinsecure.NewCredentials()))
 	if err != nil {
 		return err

--- a/engine/access/handle_irrecoverable_state_test.go
+++ b/engine/access/handle_irrecoverable_state_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/flow-go/engine/access/rpc/backend/node_communicator"
 	"github.com/onflow/flow-go/engine/access/rpc/backend/query_mode"
 	statestreambackend "github.com/onflow/flow-go/engine/access/state_stream/backend"
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/grpcserver"
 	"github.com/onflow/flow-go/module/irrecoverable"
@@ -127,7 +128,8 @@ func (suite *IrrecoverableStateTestSuite) SetupTest() {
 
 	suite.secureGrpcServer = grpcserver.NewGrpcServerBuilder(suite.log,
 		config.SecureGRPCListenAddr,
-		grpcutils.DefaultMaxMsgSize,
+		commonrpc.DefaultAccessMaxRequestSize,
+		commonrpc.DefaultAccessMaxResponseSize,
 		false,
 		nil,
 		nil,
@@ -135,7 +137,8 @@ func (suite *IrrecoverableStateTestSuite) SetupTest() {
 
 	suite.unsecureGrpcServer = grpcserver.NewGrpcServerBuilder(suite.log,
 		config.UnsecureGRPCListenAddr,
-		grpcutils.DefaultMaxMsgSize,
+		commonrpc.DefaultAccessMaxRequestSize,
+		commonrpc.DefaultAccessMaxResponseSize,
 		false,
 		nil,
 		nil).Build()

--- a/engine/access/integration_unsecure_grpc_server_test.go
+++ b/engine/access/integration_unsecure_grpc_server_test.go
@@ -30,6 +30,7 @@ import (
 	statestreambackend "github.com/onflow/flow-go/engine/access/state_stream/backend"
 	"github.com/onflow/flow-go/engine/access/subscription"
 	"github.com/onflow/flow-go/engine/access/subscription/tracker"
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/blobs"
 	"github.com/onflow/flow-go/module/execution"
@@ -170,7 +171,8 @@ func (suite *SameGRPCPortTestSuite) SetupTest() {
 
 	suite.secureGrpcServer = grpcserver.NewGrpcServerBuilder(suite.log,
 		config.SecureGRPCListenAddr,
-		grpcutils.DefaultMaxMsgSize,
+		commonrpc.DefaultAccessMaxRequestSize,
+		commonrpc.DefaultAccessMaxResponseSize,
 		false,
 		nil,
 		nil,
@@ -178,7 +180,8 @@ func (suite *SameGRPCPortTestSuite) SetupTest() {
 
 	suite.unsecureGrpcServer = grpcserver.NewGrpcServerBuilder(suite.log,
 		config.UnsecureGRPCListenAddr,
-		grpcutils.DefaultMaxMsgSize,
+		commonrpc.DefaultAccessMaxRequestSize,
+		commonrpc.DefaultAccessMaxResponseSize,
 		false,
 		nil,
 		nil).Build()

--- a/engine/access/rest/common/http_request_handler.go
+++ b/engine/access/rest/common/http_request_handler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-const DefaultMaxRequestSize = 2 << 20 // 2MB
 
 // HttpHandler is custom http handler implementing custom handler function.
 // HttpHandler function allows easier handling of errors and responses as it
@@ -25,18 +24,21 @@ type HttpHandler struct {
 	Logger zerolog.Logger
 	Chain  flow.Chain
 
-	MaxRequestSize int64
+	MaxRequestSize  int64
+	MaxResponseSize int64
 }
 
 func NewHttpHandler(
 	logger zerolog.Logger,
 	chain flow.Chain,
 	maxRequestSize int64,
+	maxResponseSize int64,
 ) *HttpHandler {
 	return &HttpHandler{
-		Logger:         logger,
-		Chain:          chain,
-		MaxRequestSize: maxRequestSize,
+		Logger:          logger,
+		Chain:           chain,
+		MaxRequestSize:  maxRequestSize,
+		MaxResponseSize: maxResponseSize,
 	}
 }
 
@@ -69,6 +71,12 @@ func (h *HttpHandler) ErrorHandler(w http.ResponseWriter, err error, errorLogger
 	if cadenceError != nil {
 		msg := fmt.Sprintf("Cadence error: %s", cadenceError.Error())
 		h.errorResponse(w, http.StatusBadRequest, msg, errorLogger)
+		return
+	}
+
+	var sizeErr *http.MaxBytesError
+	if errors.As(err, &sizeErr) {
+		h.errorResponse(w, http.StatusRequestEntityTooLarge, "request size exceeds maximum allowed", errorLogger)
 		return
 	}
 
@@ -111,6 +119,12 @@ func (h *HttpHandler) JsonResponse(w http.ResponseWriter, code int, response int
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		errLogger.Error().Err(err).Str("response", string(encodedResponse)).Msg("failed to indent response")
+		return
+	}
+
+	if len(encodedResponse) > int(h.MaxResponseSize) {
+		w.WriteHeader(http.StatusInternalServerError)
+		errLogger.Error().Int("response_size", len(encodedResponse)).Msg("response size exceeds maximum allowed")
 		return
 	}
 

--- a/engine/access/rest/http/handler.go
+++ b/engine/access/rest/http/handler.go
@@ -37,12 +37,13 @@ func NewHandler(
 	generator models.LinkGenerator,
 	chain flow.Chain,
 	maxRequestSize int64,
+	maxResponseSize int64,
 ) *Handler {
 	handler := &Handler{
 		backend:        backend,
 		apiHandlerFunc: handlerFunc,
 		linkGenerator:  generator,
-		HttpHandler:    common.NewHttpHandler(logger, chain, maxRequestSize),
+		HttpHandler:    common.NewHttpHandler(logger, chain, maxRequestSize, maxResponseSize),
 	}
 
 	return handler

--- a/engine/access/rest/server.go
+++ b/engine/access/rest/server.go
@@ -30,11 +30,12 @@ const (
 )
 
 type Config struct {
-	ListenAddress  string
-	WriteTimeout   time.Duration
-	ReadTimeout    time.Duration
-	IdleTimeout    time.Duration
-	MaxRequestSize int64
+	ListenAddress   string
+	WriteTimeout    time.Duration
+	ReadTimeout     time.Duration
+	IdleTimeout     time.Duration
+	MaxRequestSize  int64
+	MaxResponseSize int64
 }
 
 // NewServer returns an HTTP server initialized with the REST API handler
@@ -50,9 +51,9 @@ func NewServer(
 	enableNewWebsocketsStreamAPI bool,
 	wsConfig websockets.Config,
 ) (*http.Server, error) {
-	builder := router.NewRouterBuilder(logger, restCollector).AddRestRoutes(serverAPI, chain, config.MaxRequestSize)
+	builder := router.NewRouterBuilder(logger, restCollector).AddRestRoutes(serverAPI, chain, config.MaxRequestSize, config.MaxResponseSize)
 	if stateStreamApi != nil {
-		builder.AddLegacyWebsocketsRoutes(stateStreamApi, chain, stateStreamConfig, config.MaxRequestSize)
+		builder.AddLegacyWebsocketsRoutes(stateStreamApi, chain, stateStreamConfig, config.MaxRequestSize, config.MaxResponseSize)
 	}
 
 	dataProviderFactory := dp.NewDataProviderFactory(
@@ -66,7 +67,7 @@ func NewServer(
 	)
 
 	if enableNewWebsocketsStreamAPI {
-		builder.AddWebsocketsRoute(ctx, chain, wsConfig, config.MaxRequestSize, dataProviderFactory)
+		builder.AddWebsocketsRoute(ctx, chain, wsConfig, config.MaxRequestSize, config.MaxResponseSize, dataProviderFactory)
 	}
 
 	c := cors.New(cors.Options{

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -109,6 +109,7 @@ type Params struct {
 	EventQueryMode        query_mode.IndexQueryMode
 	BlockTracker          tracker.BlockTracker
 	SubscriptionHandler   *subscription.SubscriptionHandler
+	MaxScriptAndArgumentSize uint
 
 	EventsIndex                *index.EventsIndex
 	TxResultQueryMode          query_mode.IndexQueryMode
@@ -185,6 +186,7 @@ func New(params Params) (*Backend, error) {
 		params.ScriptExecutionMode,
 		params.ExecNodeIdentitiesProvider,
 		loggedScripts,
+		params.MaxScriptAndArgumentSize,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create scripts: %w", err)

--- a/engine/access/rpc/backend/config.go
+++ b/engine/access/rpc/backend/config.go
@@ -1,15 +1,14 @@
 package backend
 
 import (
-	"time"
-
 	"github.com/onflow/flow-go/engine/access/rpc/connection"
 )
 
 // Config defines the configurable options for creating Backend
 type Config struct {
-	ExecutionClientTimeout    time.Duration                   // execution API GRPC client timeout
-	CollectionClientTimeout   time.Duration                   // collection API GRPC client timeout
+	AccessConfig              connection.Config               // access API GRPC client config
+	ExecutionConfig           connection.Config               // execution API GRPC client config
+	CollectionConfig          connection.Config               // collection API GRPC client config
 	ConnectionPoolSize        uint                            // size of the cache for storing collection and execution connections
 	MaxHeightRange            uint                            // max size of height range requests
 	PreferredExecutionNodeIDs []string                        // preferred list of upstream execution node IDs

--- a/engine/access/rpc/engine.go
+++ b/engine/access/rpc/engine.go
@@ -41,10 +41,13 @@ type Config struct {
 
 	BackendConfig             backend.Config // configurable options for creating Backend
 	RestConfig                rest.Config    // the REST server configuration
-	MaxMsgSize                uint           // GRPC max message size
 	CompressorName            string         // GRPC compressor name
 	WebSocketConfig           websockets.Config
 	EnableWebSocketsStreamAPI bool
+
+	// holds value of deprecated MaxMsgSize flag for use during bootstrapping.
+	// will be removed in a future release.
+	DeprecatedMaxMsgSize uint // in bytes
 }
 
 // Engine exposes the server with a simplified version of the Access API.

--- a/engine/collection/rpc/engine.go
+++ b/engine/collection/rpc/engine.go
@@ -33,9 +33,14 @@ type Backend interface {
 
 // Config defines the configurable options for the ingress server.
 type Config struct {
-	ListenAddr        string
-	MaxMsgSize        uint // in bytes
-	RpcMetricsEnabled bool // enable GRPC metrics
+	ListenAddr         string
+	MaxRequestMsgSize  uint // in bytes
+	MaxResponseMsgSize uint // in bytes
+	RpcMetricsEnabled  bool // enable GRPC metrics
+
+	// holds value of deprecated MaxMsgSize flag for use during bootstrapping.
+	// will be removed in a future release.
+	DeprecatedMaxMsgSize uint // in bytes
 }
 
 // Engine implements a gRPC server with a simplified version of the Observation
@@ -59,8 +64,8 @@ func New(
 ) *Engine {
 	// create a GRPC server to serve GRPC clients
 	grpcOpts := []grpc.ServerOption{
-		grpc.MaxRecvMsgSize(int(config.MaxMsgSize)),
-		grpc.MaxSendMsgSize(int(config.MaxMsgSize)),
+		grpc.MaxRecvMsgSize(int(config.MaxRequestMsgSize)),
+		grpc.MaxSendMsgSize(int(config.MaxResponseMsgSize)),
 	}
 
 	var interceptors []grpc.UnaryServerInterceptor // ordered list of interceptors

--- a/engine/common/rpc/errors.go
+++ b/engine/common/rpc/errors.go
@@ -12,6 +12,9 @@ import (
 	"github.com/onflow/flow-go/storage"
 )
 
+// ErrScriptTooLarge is returned when a script and/or arguments exceed the max size allowed by the server
+var ErrScriptTooLarge = errors.New("script and/or arguments are too large")
+
 // ConvertError converts a generic error into a grpc status error. The input may either
 // be a status.Error already, or standard error type. Any error that matches on of the
 // common status code mappings will be converted, all unmatched errors will be converted

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/engine"
+	"github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
 	exeEng "github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/engine/execution/computation/metrics"
@@ -40,9 +41,14 @@ const DefaultMaxBlockRange = 300
 
 // Config defines the configurable options for the gRPC server.
 type Config struct {
-	ListenAddr        string
-	MaxMsgSize        uint // In bytes
-	RpcMetricsEnabled bool // enable GRPC metrics reporting
+	ListenAddr         string
+	MaxRequestMsgSize  uint // in bytes
+	MaxResponseMsgSize uint // in bytes
+	RpcMetricsEnabled  bool // enable GRPC metrics reporting
+
+	// holds value of deprecated MaxMsgSize flag for use during bootstrapping.
+	// will be removed in a future release.
+	DeprecatedMaxMsgSize uint // in bytes
 }
 
 // Engine implements a gRPC server with a simplified version of the Observation API.
@@ -73,8 +79,8 @@ func New(
 ) *Engine {
 	log = log.With().Str("engine", "rpc").Logger()
 	serverOptions := []grpc.ServerOption{
-		grpc.MaxRecvMsgSize(int(config.MaxMsgSize)),
-		grpc.MaxSendMsgSize(int(config.MaxMsgSize)),
+		grpc.MaxRecvMsgSize(int(config.MaxRequestMsgSize)),
+		grpc.MaxSendMsgSize(int(config.MaxResponseMsgSize)),
 	}
 
 	var interceptors []grpc.UnaryServerInterceptor // ordered list of interceptors
@@ -112,6 +118,7 @@ func New(
 			transactionMetrics:   transactionMetrics,
 			log:                  log,
 			maxBlockRange:        DefaultMaxBlockRange,
+			maxScriptSize:        config.MaxRequestMsgSize,
 		},
 		server: server,
 		config: config,
@@ -173,6 +180,7 @@ type handler struct {
 	commits              storage.CommitsReader
 	transactionMetrics   metrics.TransactionExecutionMetricsProvider
 	maxBlockRange        int
+	maxScriptSize        uint
 }
 
 var _ execution.ExecutionAPIServer = (*handler)(nil)
@@ -189,6 +197,12 @@ func (h *handler) ExecuteScriptAtBlockID(
 	ctx context.Context,
 	req *execution.ExecuteScriptAtBlockIDRequest,
 ) (*execution.ExecuteScriptAtBlockIDResponse, error) {
+	script := req.GetScript()
+	arguments := req.GetArguments()
+
+	if !rpc.CheckScriptSize(script, arguments, h.maxScriptSize) {
+		return nil, status.Errorf(codes.InvalidArgument, rpc.ErrScriptTooLarge.Error())
+	}
 
 	blockID, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
@@ -203,7 +217,7 @@ func (h *handler) ExecuteScriptAtBlockID(
 		return nil, status.Errorf(codes.Internal, "state commitment for block ID %s could not be retrieved", blockID)
 	}
 
-	value, compUsage, err := h.engine.ExecuteScriptAtBlockID(ctx, req.GetScript(), req.GetArguments(), blockID)
+	value, compUsage, err := h.engine.ExecuteScriptAtBlockID(ctx, script, arguments, blockID)
 	if err != nil {
 		// todo check the error code instead
 		// return code 3 as this passes the litmus test in our context

--- a/integration/tests/admin/command_runner_test.go
+++ b/integration/tests/admin/command_runner_test.go
@@ -31,9 +31,9 @@ import (
 
 	"github.com/onflow/flow-go/admin"
 	pb "github.com/onflow/flow-go/admin/admin"
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/integration/client"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/onflow/flow-go/utils/grpcutils"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -80,7 +80,7 @@ func (suite *CommandRunnerSuite) SetupCommandRunner(opts ...admin.CommandRunnerO
 	signalerCtx := irrecoverable.NewMockSignalerContext(suite.T(), ctx)
 
 	suite.grpcAddressSock = fmt.Sprintf("%s/%s-flow-node-admin.sock", os.TempDir(), unittest.GenerateRandomStringWithLen(16))
-	opts = append(opts, admin.WithGRPCAddress(suite.grpcAddressSock), admin.WithMaxMsgSize(grpcutils.DefaultMaxMsgSize))
+	opts = append(opts, admin.WithGRPCAddress(suite.grpcAddressSock), admin.WithMaxMsgSize(commonrpc.DefaultMaxResponseMsgSize))
 
 	logger := zerolog.New(zerolog.NewConsoleWriter())
 	suite.runner = suite.bootstrapper.Bootstrap(logger, suite.httpAddress, opts...)

--- a/module/grpcclient/flow_client.go
+++ b/module/grpcclient/flow_client.go
@@ -9,6 +9,7 @@ import (
 
 	client "github.com/onflow/flow-go-sdk/access/grpc"
 
+	commonrpc "github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/state/protocol"
@@ -67,7 +68,7 @@ func secureFlowClient(accessAddress, accessApiNodePubKey string) (*client.Client
 		accessAddress,
 		client.WithGRPCDialOptions(
 			dialOpts,
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcutils.DefaultMaxMsgSize)),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(commonrpc.DefaultAccessMaxResponseSize)),
 		),
 	)
 	if err != nil {
@@ -84,7 +85,7 @@ func insecureFlowClient(accessAddress string) (*client.Client, error) {
 		accessAddress,
 		client.WithGRPCDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcutils.DefaultMaxMsgSize)),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(commonrpc.DefaultAccessMaxResponseSize)),
 		),
 	)
 	if err != nil {

--- a/module/grpcserver/server_builder.go
+++ b/module/grpcserver/server_builder.go
@@ -52,9 +52,11 @@ type GrpcServerBuilder struct {
 // If transport credentials are provided, a secure gRPC server is created; otherwise, an unsecured server is initialized.
 //
 // Note: The gRPC server is created with the specified options and is ready for further configuration or starting.
-func NewGrpcServerBuilder(log zerolog.Logger,
+func NewGrpcServerBuilder(
+	log zerolog.Logger,
 	gRPCListenAddr string,
-	maxMsgSize uint,
+	maxRequestMsgSize uint,
+	maxResponseMsgSize uint,
 	rpcMetricsEnabled bool,
 	apiRateLimits map[string]int, // the api rate limit (max calls per second) for each of the Access API e.g. Ping->100, GetTransaction->300
 	apiBurstLimits map[string]int, // the api burst limit (max calls at the same time) for each of the Access API e.g. Ping->50, GetTransaction->10
@@ -78,8 +80,8 @@ func NewGrpcServerBuilder(log zerolog.Logger,
 
 	// create a GRPC server to serve GRPC clients
 	grpcOpts := []grpc.ServerOption{
-		grpc.MaxRecvMsgSize(int(maxMsgSize)),
-		grpc.MaxSendMsgSize(int(maxMsgSize)),
+		grpc.MaxRecvMsgSize(int(maxRequestMsgSize)),
+		grpc.MaxSendMsgSize(int(maxResponseMsgSize)),
 	}
 
 	var unaryInterceptors []grpc.UnaryServerInterceptor

--- a/utils/grpcutils/grpc.go
+++ b/utils/grpcutils/grpc.go
@@ -16,11 +16,6 @@ import (
 // NoCompressor use when no specific compressor name provided, which effectively means no compression.
 const NoCompressor = ""
 
-// DefaultMaxMsgSize use 1 GiB as the default message size limit.
-// This enforces a sane max message size, while still allowing for reasonably large messages.
-// grpc library default is 4 MiB.
-const DefaultMaxMsgSize = 1 << (10 * 3) // 1 GiB
-
 // CertificateConfig is used to configure an Certificate
 type CertificateConfig struct {
 	opts []libp2ptls.IdentityOption


### PR DESCRIPTION
Improve the request and response size limit configs for all nodes with APIs. This makes the following changes:
* Separate config for max request and response size so they can be configured independantly
* Separate config for Access API server, collection and execution clients.
* Backwards compatible with existing `--rpc-max-message-size` flag, which is now deprecated.