### PR TITLE
Bump `ethereum/go-ethereum` dependency to `v1.16.3`

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -542,7 +542,6 @@ func (proc *procedure) deployAt(
 	// run code through interpreter
 	// this would check for errors and computes the final bytes to be stored under account
 	var err error
-	inter := gethVM.NewEVMInterpreter(proc.evm)
 	contract := gethVM.NewContract(
 		callerCommon,
 		addr,
@@ -555,7 +554,7 @@ func (proc *procedure) deployAt(
 	// update access list (Berlin)
 	proc.state.AddAddressToAccessList(addr)
 
-	ret, err := inter.Run(contract, nil, false)
+	ret, err := proc.evm.Run(contract, nil, false)
 	gasCost := uint64(len(ret)) * gethParams.CreateDataGas
 	res.GasConsumed = gasCost
 

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm/evm/emulator"
+	"github.com/onflow/flow-go/fvm/evm/precompiles"
 	"github.com/onflow/flow-go/fvm/evm/testutils"
 	"github.com/onflow/flow-go/fvm/evm/testutils/contracts"
 	"github.com/onflow/flow-go/fvm/evm/types"
@@ -1252,4 +1253,8 @@ func (mp *MockedPrecompiled) Run(input []byte) ([]byte, error) {
 		panic("Run not set for the mocked precompiled contract")
 	}
 	return mp.RunFunc(input)
+}
+
+func (mp *MockedPrecompiled) Name() string {
+	return precompiles.CADENCE_ARCH_PRECOMPILE_NAME
 }

--- a/fvm/evm/emulator/tracker.go
+++ b/fvm/evm/emulator/tracker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sort"
 
+	"github.com/onflow/flow-go/fvm/evm/precompiles"
 	"github.com/onflow/flow-go/fvm/evm/types"
 )
 
@@ -117,4 +118,8 @@ func (wpc *WrappedPrecompiledContract) Run(input []byte) ([]byte, error) {
 	output, err := wpc.pc.Run(input)
 	wpc.ct.CaptureRun(wpc.pc.Address(), input, output, err)
 	return output, err
+}
+
+func (wpc *WrappedPrecompiledContract) Name() string {
+	return precompiles.CADENCE_ARCH_PRECOMPILE_NAME
 }

--- a/fvm/evm/precompiles/arch.go
+++ b/fvm/evm/precompiles/arch.go
@@ -6,6 +6,8 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/types"
 )
 
+const CADENCE_ARCH_PRECOMPILE_NAME = "CADENCE_ARCH"
+
 var (
 	FlowBlockHeightFuncSig = ComputeFunctionSelector("flowBlockHeight", nil)
 

--- a/fvm/evm/precompiles/precompile.go
+++ b/fvm/evm/precompiles/precompile.go
@@ -73,3 +73,7 @@ func (p *precompile) Run(input []byte) (output []byte, err error) {
 	}
 	return callable.Run(data)
 }
+
+func (p *precompile) Name() string {
+	return CADENCE_ARCH_PRECOMPILE_NAME
+}

--- a/fvm/evm/precompiles/replayer.go
+++ b/fvm/evm/precompiles/replayer.go
@@ -75,3 +75,7 @@ func (p *ReplayerPrecompiledContract) HasReplayedAll() bool {
 	return len(p.expectedCalls.RequiredGasCalls) == p.requiredGasIndex &&
 		len(p.expectedCalls.RunCalls) == p.runIndex
 }
+
+func (p *ReplayerPrecompiledContract) Name() string {
+	return CADENCE_ARCH_PRECOMPILE_NAME
+}

--- a/fvm/evm/testutils/handler.go
+++ b/fvm/evm/testutils/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onflow/flow-go/fvm/evm/emulator"
 	"github.com/onflow/flow-go/fvm/evm/handler"
+	"github.com/onflow/flow-go/fvm/evm/precompiles"
 	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
@@ -57,4 +58,8 @@ func (pc *TestPrecompiledContract) Address() types.Address {
 		panic("AddressFunc is not set for the test precompiled contract")
 	}
 	return pc.AddressFunc()
+}
+
+func (pc *TestPrecompiledContract) Name() string {
+	return precompiles.CADENCE_ARCH_PRECOMPILE_NAME
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/ef-ds/deque v1.0.4
-	github.com/ethereum/go-ethereum v1.16.2
+	github.com/ethereum/go-ethereum v1.16.3
 	github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829
 	github.com/gammazero/workerpool v1.1.3
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
-github.com/ethereum/go-ethereum v1.16.2 h1:VDHqj86DaQiMpnMgc7l0rwZTg0FRmlz74yupSG5SnzI=
-github.com/ethereum/go-ethereum v1.16.2/go.mod h1:X5CIOyo8SuK1Q5GnaEizQVLHT/DfsiGWuNeVdQcEMNA=
+github.com/ethereum/go-ethereum v1.16.3 h1:nDoBSrmsrPbrDIVLTkDQCy1U9KdHN+F2PzvMbDoS42Q=
+github.com/ethereum/go-ethereum v1.16.3/go.mod h1:Lrsc6bt9Gm9RyvhfFK53vboCia8kpF9nv+2Ukntnl+8=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.0 // indirect
-	github.com/ethereum/go-ethereum v1.16.2 // indirect
+	github.com/ethereum/go-ethereum v1.16.3 // indirect
 	github.com/ethereum/go-verkle v0.2.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/ferranbt/fastssz v0.1.4 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -323,8 +323,8 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
-github.com/ethereum/go-ethereum v1.16.2 h1:VDHqj86DaQiMpnMgc7l0rwZTg0FRmlz74yupSG5SnzI=
-github.com/ethereum/go-ethereum v1.16.2/go.mod h1:X5CIOyo8SuK1Q5GnaEizQVLHT/DfsiGWuNeVdQcEMNA=
+github.com/ethereum/go-ethereum v1.16.3 h1:nDoBSrmsrPbrDIVLTkDQCy1U9KdHN+F2PzvMbDoS42Q=
+github.com/ethereum/go-ethereum v1.16.3/go.mod h1:Lrsc6bt9Gm9RyvhfFK53vboCia8kpF9nv+2Ukntnl+8=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/dapperlabs/testingdock v0.4.5-0.20231020233342-a2853fe18724
 	github.com/docker/docker v24.0.6+incompatible
 	github.com/docker/go-connections v0.4.0
-	github.com/ethereum/go-ethereum v1.16.2
+	github.com/ethereum/go-ethereum v1.16.3
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/gorilla/websocket v1.5.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -289,8 +289,8 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
-github.com/ethereum/go-ethereum v1.16.2 h1:VDHqj86DaQiMpnMgc7l0rwZTg0FRmlz74yupSG5SnzI=
-github.com/ethereum/go-ethereum v1.16.2/go.mod h1:X5CIOyo8SuK1Q5GnaEizQVLHT/DfsiGWuNeVdQcEMNA=
+github.com/ethereum/go-ethereum v1.16.3 h1:nDoBSrmsrPbrDIVLTkDQCy1U9KdHN+F2PzvMbDoS42Q=
+github.com/ethereum/go-ethereum v1.16.3/go.mod h1:Lrsc6bt9Gm9RyvhfFK53vboCia8kpF9nv+2Ukntnl+8=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
 github.com/fanliao/go-promise v0.0.0-20141029170127-1890db352a72/go.mod h1:PjfxuH4FZdUyfMdtBio2lsRr1AKEaVPwelzuHuh8Lqc=


### PR DESCRIPTION
Work Towards: https://github.com/onflow/flow-go/issues/7816

Release notes: https://github.com/ethereum/go-ethereum/releases/tag/v1.16.3