### PR TITLE
[Immutable Models M2] messages.TimeoutObject and messages.ClusterTimeoutObject: message/internal split + validation

### DIFF
--- a/engine/consensus/message_hub/message_hub.go
+++ b/engine/consensus/message_hub/message_hub.go
@@ -246,13 +246,7 @@ func (h *MessageHub) sendOwnTimeout(timeout *model.TimeoutObject) error {
 	}
 
 	// create the timeout message
-	msg := &messages.TimeoutObject{
-		View:        timeout.View,
-		NewestQC:    timeout.NewestQC,
-		LastViewTC:  timeout.LastViewTC,
-		SigData:     timeout.SigData,
-		TimeoutTick: timeout.TimeoutTick,
-	}
+	msg := (*messages.TimeoutObject)(timeout)
 	err = h.con.Publish(msg, recipients.NodeIDs()...)
 	if err != nil {
 		if !errors.Is(err, network.EmptyTargetList) {
@@ -501,32 +495,8 @@ func (h *MessageHub) Process(channel channels.Channel, originID flow.Identifier,
 		}
 
 		h.forwardToOwnVoteAggregator(vote)
-	case *messages.TimeoutObject:
-		t, err := model.NewTimeoutObject(
-			model.UntrustedTimeoutObject{
-				View:        msg.View,
-				NewestQC:    msg.NewestQC,
-				LastViewTC:  msg.LastViewTC,
-				SignerID:    originID,
-				SigData:     msg.SigData,
-				TimeoutTick: msg.TimeoutTick,
-			},
-		)
-		if err != nil {
-			// TODO(BFT, #7620): Replace this log statement with a call to the protocol violation consumer.
-			h.log.Warn().
-				Hex("origin_id", originID[:]).
-				Uint64("view", msg.View).
-				Uint64("newest_qc_view", msg.NewestQC.View).
-				Hex("newest_qc_block_id", logging.ID(msg.NewestQC.BlockID)).
-				Uint64("last_view_tc_view", msg.LastViewTC.View).
-				Uint64("last_view_tc_newest_qc_view", msg.LastViewTC.NewestQC.View).
-				Hex("last_view_tc_newest_qc_block_id", logging.ID(msg.LastViewTC.NewestQC.BlockID)).
-				Uint64("timeout_tick", msg.TimeoutTick).
-				Err(err).Msgf("received invalid timeout object message")
-			return nil
-		}
-		h.forwardToOwnTimeoutAggregator(t)
+	case *model.TimeoutObject:
+		h.forwardToOwnTimeoutAggregator(msg)
 	default:
 		h.log.Warn().
 			Bool(logging.KeySuspicious, true).

--- a/engine/consensus/message_hub/message_hub_test.go
+++ b/engine/consensus/message_hub/message_hub_test.go
@@ -193,15 +193,9 @@ func (s *MessageHubSuite) TestProcessValidIncomingMessages() {
 		require.NoError(s.T(), err)
 	})
 	s.Run("to-timeout-aggregator", func() {
-		expectedTimeout := helper.TimeoutObjectFixture(helper.WithTimeoutObjectSignerID(originID))
-		msg := &messages.TimeoutObject{
-			View:       expectedTimeout.View,
-			NewestQC:   expectedTimeout.NewestQC,
-			LastViewTC: expectedTimeout.LastViewTC,
-			SigData:    expectedTimeout.SigData,
-		}
-		s.timeoutAggregator.On("AddTimeout", expectedTimeout)
-		err := s.hub.Process(channel, originID, msg)
+		timeout := helper.TimeoutObjectFixture(helper.WithTimeoutObjectSignerID(originID))
+		s.timeoutAggregator.On("AddTimeout", timeout)
+		err := s.hub.Process(channel, originID, timeout)
 		require.NoError(s.T(), err)
 	})
 	s.Run("unsupported-msg-type", func() {
@@ -228,21 +222,6 @@ func (s *MessageHubSuite) TestProcessInvalidIncomingMessages() {
 
 		// AddVote should NOT be called for invalid Vote
 		s.voteAggregator.AssertNotCalled(s.T(), "AddVote", mock.Anything)
-	})
-	s.Run("to-timeout-aggregator", func() {
-		expectedTimeout := helper.TimeoutObjectFixture(helper.WithTimeoutObjectSignerID(originID))
-		msg := &messages.TimeoutObject{
-			View:       expectedTimeout.View,
-			NewestQC:   expectedTimeout.NewestQC,
-			LastViewTC: expectedTimeout.LastViewTC,
-			SigData:    nil, // invalid value
-		}
-
-		err := s.hub.Process(channel, originID, msg)
-		require.NoError(s.T(), err)
-
-		// AddTimeout should NOT be called for invalid TimeoutObject
-		s.timeoutAggregator.AssertNotCalled(s.T(), "AddTimeout", mock.Anything)
 	})
 	s.Run("unsupported-msg-type", func() {
 		err := s.hub.Process(channel, originID, struct{}{})
@@ -336,12 +315,7 @@ func (s *MessageHubSuite) TestProcessMultipleMessagesHappyPath() {
 		wg.Add(1)
 		// prepare timeout fixture
 		timeout := helper.TimeoutObjectFixture()
-		expectedBroadcastMsg := &messages.TimeoutObject{
-			View:       timeout.View,
-			NewestQC:   timeout.NewestQC,
-			LastViewTC: timeout.LastViewTC,
-			SigData:    timeout.SigData,
-		}
+		expectedBroadcastMsg := (*messages.TimeoutObject)(timeout)
 		s.con.On("Publish", expectedBroadcastMsg, s.participants[1].NodeID, s.participants[2].NodeID).
 			Run(func(_ mock.Arguments) { wg.Done() }).
 			Return(nil)

--- a/model/messages/consensus.go
+++ b/model/messages/consensus.go
@@ -3,6 +3,7 @@ package messages
 import (
 	"fmt"
 
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -41,21 +42,15 @@ func (b *BlockVote) ToInternal() (any, error) {
 
 // TimeoutObject is part of the consensus protocol and represents a consensus node
 // timing out in given round. Contains a sequential number for deduplication purposes.
-type TimeoutObject struct {
-	TimeoutTick uint64
-	View        uint64
-	NewestQC    *flow.QuorumCertificate
-	LastViewTC  *flow.TimeoutCertificate
-	SigData     []byte
-}
+type TimeoutObject model.UntrustedTimeoutObject
 
-// ToInternal converts the untrusted TimeoutObject into its trusted internal
-// representation.
+// ToInternal returns the internal type representation for TimeoutObject.
 //
-// This stub returns the receiver unchanged. A proper implementation
-// must perform validation checks and return a constructed internal
-// object.
+// All errors indicate that the decode target contains a structurally invalid representation of the internal model.TimeoutObject.
 func (t *TimeoutObject) ToInternal() (any, error) {
-	// TODO(malleability, #7700) implement with validation checks
-	return t, nil
+	internal, err := model.NewTimeoutObject(model.UntrustedTimeoutObject(*t))
+	if err != nil {
+		return nil, fmt.Errorf("could not convert %T to internal type: %w", t, err)
+	}
+	return internal, nil
 }


### PR DESCRIPTION
Closes #7700, #7704

## Context
- Changed from `messages.TimeoutObject` and `messages.ClusterTimeoutObject`  to `model.TimeoutObject` and `model.ClusterTimeoutObject` where they are used internally to be consistent.
- Implemented `ToInternal()` for corresponding `messages.*` types to convert to internal model.
- Updated test according to changes.