### PR TITLE
Reduce register reads by using Accounts.GetRuntimeAccountPublicKey

### DIFF
--- a/fvm/environment/account_key_reader.go
+++ b/fvm/environment/account_key_reader.go
@@ -120,7 +120,7 @@ func (reader *accountKeyReader) GetAccountKey(
 	address := flow.ConvertAddress(runtimeAddress)
 
 	// address verification is also done in this step
-	accountPublicKey, err := reader.accounts.GetAccountPublicKey(
+	accountPublicKey, err := reader.accounts.GetRuntimeAccountPublicKey(
 		address,
 		keyIndex)
 	if err != nil {
@@ -174,7 +174,7 @@ func (reader *accountKeyReader) AccountKeysCount(
 }
 
 func FlowToRuntimeAccountKey(
-	flowKey flow.AccountPublicKey,
+	flowKey flow.RuntimeAccountPublicKey,
 ) (
 	*runtime.AccountKey,
 	error,

--- a/fvm/environment/account_key_reader_test.go
+++ b/fvm/environment/account_key_reader_test.go
@@ -37,7 +37,7 @@ func TestKeyConversionValidAlgorithms(t *testing.T) {
 	t.Run("invalid hash algo", func(t *testing.T) {
 		t.Parallel()
 
-		accountKey := FakePublicKey{}.toAccountPublicKey()
+		accountKey := FakePublicKey{}.toRuntimeAccountPublicKey()
 		accountKey.HashAlgo = hash.UnknownHashingAlgorithm
 
 		rtKey, err := environment.FlowToRuntimeAccountKey(accountKey)
@@ -48,7 +48,7 @@ func TestKeyConversionValidAlgorithms(t *testing.T) {
 	t.Run("invalid sign algo", func(t *testing.T) {
 		t.Parallel()
 
-		accountKey := FakePublicKey{}.toAccountPublicKey()
+		accountKey := FakePublicKey{}.toRuntimeAccountPublicKey()
 		accountKey.SignAlgo = crypto.UnknownSigningAlgorithm
 
 		rtKey, err := environment.FlowToRuntimeAccountKey(accountKey)
@@ -59,7 +59,7 @@ func TestKeyConversionValidAlgorithms(t *testing.T) {
 	t.Run("valid key", func(t *testing.T) {
 		t.Parallel()
 
-		accountKey := FakePublicKey{}.toAccountPublicKey()
+		accountKey := FakePublicKey{}.toRuntimeAccountPublicKey()
 
 		rtKey, err := environment.FlowToRuntimeAccountKey(accountKey)
 		require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestAccountKeyReader_get_valid_key(t *testing.T) {
 	require.NoError(t, err)
 
 	expected, err := environment.FlowToRuntimeAccountKey(
-		FakePublicKey{}.toAccountPublicKey(),
+		FakePublicKey{}.toRuntimeAccountPublicKey(),
 	)
 
 	require.NoError(t, err)

--- a/fvm/environment/account_key_updater.go
+++ b/fvm/environment/account_key_updater.go
@@ -304,8 +304,7 @@ func (updater *accountKeyUpdater) revokeAccountKey(
 		return nil, fmt.Errorf("revoking account key failed: %w", err)
 	}
 
-	// TODO (faye): replace GetAccountPublicKey with GetStoredPublicKey
-	publicKey, err := updater.accounts.GetAccountPublicKey(address, keyIndex)
+	publicKey, err := updater.accounts.GetRuntimeAccountPublicKey(address, keyIndex)
 	if err != nil {
 		return nil, err
 	}

--- a/fvm/environment/account_key_updater_test.go
+++ b/fvm/environment/account_key_updater_test.go
@@ -130,6 +130,17 @@ func (f FakePublicKey) toAccountPublicKey() flow.AccountPublicKey {
 	}
 }
 
+func (f FakePublicKey) toRuntimeAccountPublicKey() flow.RuntimeAccountPublicKey {
+	return flow.RuntimeAccountPublicKey{
+		Index:     1,
+		PublicKey: f,
+		SignAlgo:  crypto.ECDSASecp256k1,
+		HashAlgo:  hash.SHA3_256,
+		Weight:    1000,
+		Revoked:   false,
+	}
+}
+
 func (f FakePublicKey) Encode() []byte {
 	return f.data
 }
@@ -162,6 +173,12 @@ func (f FakeAccounts) GetAccountPublicKey(address flow.Address, keyIndex uint32)
 		return flow.AccountPublicKey{}, errors.NewAccountPublicKeyNotFoundError(address, keyIndex)
 	}
 	return FakePublicKey{}.toAccountPublicKey(), nil
+}
+func (f FakeAccounts) GetRuntimeAccountPublicKey(address flow.Address, keyIndex uint32) (flow.RuntimeAccountPublicKey, error) {
+	if keyIndex >= f.keyCount {
+		return flow.RuntimeAccountPublicKey{}, errors.NewAccountPublicKeyNotFoundError(address, keyIndex)
+	}
+	return FakePublicKey{}.toRuntimeAccountPublicKey(), nil
 }
 func (f FakeAccounts) GetAccountPublicKeys(address flow.Address) ([]flow.AccountPublicKey, error) {
 	return make([]flow.AccountPublicKey, f.keyCount), nil

--- a/fvm/environment/accounts.go
+++ b/fvm/environment/accounts.go
@@ -26,6 +26,7 @@ type Accounts interface {
 	Get(address flow.Address) (*flow.Account, error)
 	GetAccountPublicKeyCount(address flow.Address) (uint32, error)
 	AppendAccountPublicKey(address flow.Address, key flow.AccountPublicKey) error
+	GetRuntimeAccountPublicKey(address flow.Address, keyIndex uint32) (flow.RuntimeAccountPublicKey, error)
 	GetAccountPublicKey(address flow.Address, keyIndex uint32) (flow.AccountPublicKey, error)
 	GetAccountPublicKeys(address flow.Address) ([]flow.AccountPublicKey, error)
 	RevokeAccountPublicKey(address flow.Address, keyIndex uint32) error
@@ -271,6 +272,60 @@ func (a *StatefulAccounts) GetAccountPublicKey(
 		SignAlgo:  storedKey.SignAlgo,
 		HashAlgo:  storedKey.HashAlgo,
 		SeqNumber: sequenceNumber,
+		Weight:    int(weight),
+		Revoked:   revoked,
+	}, nil
+}
+
+func (a *StatefulAccounts) GetRuntimeAccountPublicKey(
+	address flow.Address,
+	keyIndex uint32,
+) (
+	flow.RuntimeAccountPublicKey,
+	error,
+) {
+	err := a.accountPublicKeyIndexInRange(address, keyIndex)
+	if err != nil {
+		return flow.RuntimeAccountPublicKey{}, err
+	}
+
+	if keyIndex == 0 {
+		key, err := getAccountPublicKey0(a, address)
+		if err != nil {
+			return flow.RuntimeAccountPublicKey{}, fmt.Errorf("failed to get account public key at index %d for %s: %w", keyIndex, address, err)
+		}
+		return flow.RuntimeAccountPublicKey{
+			Index:     keyIndex,
+			PublicKey: key.PublicKey,
+			SignAlgo:  key.SignAlgo,
+			HashAlgo:  key.HashAlgo,
+			Weight:    key.Weight,
+			Revoked:   key.Revoked,
+		}, nil
+	}
+
+	status, err := a.getAccountStatus(address)
+	if err != nil {
+		return flow.RuntimeAccountPublicKey{}, err
+	}
+
+	// Get account public key metadata.
+	weight, revoked, storedKeyIndex, err := status.AccountPublicKeyMetadata(keyIndex)
+	if err != nil {
+		return flow.RuntimeAccountPublicKey{}, fmt.Errorf("failed to get account public key at index %d for %s: %w", keyIndex, address, err)
+	}
+
+	// Get stored public key.
+	storedKey, err := getStoredPublicKey(a, address, storedKeyIndex)
+	if err != nil {
+		return flow.RuntimeAccountPublicKey{}, fmt.Errorf("failed to get account public key at index %d for %s: %w", keyIndex, address, err)
+	}
+
+	return flow.RuntimeAccountPublicKey{
+		Index:     keyIndex,
+		PublicKey: storedKey.PublicKey,
+		SignAlgo:  storedKey.SignAlgo,
+		HashAlgo:  storedKey.HashAlgo,
 		Weight:    int(weight),
 		Revoked:   revoked,
 	}, nil

--- a/fvm/environment/mock/accounts.go
+++ b/fvm/environment/mock/accounts.go
@@ -415,6 +415,34 @@ func (_m *Accounts) GetContractNames(address flow.Address) ([]string, error) {
 	return r0, r1
 }
 
+// GetRuntimeAccountPublicKey provides a mock function with given fields: address, keyIndex
+func (_m *Accounts) GetRuntimeAccountPublicKey(address flow.Address, keyIndex uint32) (flow.RuntimeAccountPublicKey, error) {
+	ret := _m.Called(address, keyIndex)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRuntimeAccountPublicKey")
+	}
+
+	var r0 flow.RuntimeAccountPublicKey
+	var r1 error
+	if rf, ok := ret.Get(0).(func(flow.Address, uint32) (flow.RuntimeAccountPublicKey, error)); ok {
+		return rf(address, keyIndex)
+	}
+	if rf, ok := ret.Get(0).(func(flow.Address, uint32) flow.RuntimeAccountPublicKey); ok {
+		r0 = rf(address, keyIndex)
+	} else {
+		r0 = ret.Get(0).(flow.RuntimeAccountPublicKey)
+	}
+
+	if rf, ok := ret.Get(1).(func(flow.Address, uint32) error); ok {
+		r1 = rf(address, keyIndex)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetStorageUsed provides a mock function with given fields: address
 func (_m *Accounts) GetStorageUsed(address flow.Address) (uint64, error) {
 	ret := _m.Called(address)

--- a/fvm/transactionSequenceNum_test.go
+++ b/fvm/transactionSequenceNum_test.go
@@ -43,9 +43,9 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		require.NoError(t, err)
 
 		// get fetch the sequence number and it should be updated
-		key, err := accounts.GetAccountPublicKey(address, 0)
+		seqNumber, err := accounts.GetAccountPublicKeySequenceNumber(address, 0)
 		require.NoError(t, err)
-		require.Equal(t, key.SeqNumber, uint64(1))
+		require.Equal(t, seqNumber, uint64(1))
 	})
 	t.Run("invalid sequence number", func(t *testing.T) {
 		txnState := testutils.NewSimpleTransaction(nil)
@@ -77,9 +77,9 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		require.True(t, errors.HasErrorCode(err, errors.ErrCodeInvalidProposalSeqNumberError))
 
 		// get fetch the sequence number and check it to be  unchanged
-		key, err := accounts.GetAccountPublicKey(address, 0)
+		seqNumber, err := accounts.GetAccountPublicKeySequenceNumber(address, 0)
 		require.NoError(t, err)
-		require.Equal(t, key.SeqNumber, uint64(0))
+		require.Equal(t, seqNumber, uint64(0))
 	})
 	t.Run("invalid address", func(t *testing.T) {
 		txnState := testutils.NewSimpleTransaction(nil)
@@ -110,8 +110,8 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		require.Error(t, err)
 
 		// get fetch the sequence number and check it to be unchanged
-		key, err := accounts.GetAccountPublicKey(address, 0)
+		seqNumber, err := accounts.GetAccountPublicKeySequenceNumber(address, 0)
 		require.NoError(t, err)
-		require.Equal(t, key.SeqNumber, uint64(0))
+		require.Equal(t, seqNumber, uint64(0))
 	})
 }

--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -38,7 +38,7 @@ type signatureContinuation struct {
 	signatureEntry
 
 	// accountKey is set by getAccountKeys().
-	accountKey flow.AccountPublicKey
+	accountKey flow.RuntimeAccountPublicKey
 
 	// invokedVerify and verifyErr are set by verifyAccountSignatures().  Note
 	// that	verifyAccountSignatures() is always called after getAccountKeys()
@@ -266,7 +266,7 @@ func (v *TransactionVerifier) getAccountKeys(
 ) error {
 	foundProposalSignature := false
 	for _, signature := range signatures {
-		accountKey, err := accounts.GetAccountPublicKey(
+		accountKey, err := accounts.GetRuntimeAccountPublicKey(
 			signature.Address,
 			signature.KeyIndex)
 		if err != nil {

--- a/model/flow/account.go
+++ b/model/flow/account.go
@@ -129,3 +129,14 @@ func CompatibleAlgorithms(sigAlgo crypto.SigningAlgorithm, hashAlgo hash.Hashing
 	}
 	return false
 }
+
+// RuntimeAccountPublicKey is a public key associated with an account for Cadence runtime that doesn't need sequence number.
+// A runtime account public key contains the public key, signing and hashing algorithms, a key weight, and revoked status.
+type RuntimeAccountPublicKey struct {
+	PublicKey crypto.PublicKey
+	SignAlgo  crypto.SigningAlgorithm
+	HashAlgo  hash.HashingAlgorithm
+	Weight    int
+	Index     uint32
+	Revoked   bool
+}


### PR DESCRIPTION
This PR allows some use cases of FVM and Cadence runtime to read one less register (sequence number register) when retrieving or revoking account public key because sequences will be stored in separate registers (after migration #7738) to avoid blocking some use cases involving concurrent execution.

Specifically, this makes `accountKeyReader`, `accountKeyUpdater`, and `TransactionVerifier` use `GetRuntimeAccountPublicKey()` instead of `GetAccountPublicKey()`.