### PR TITLE
[DataAvailability] Improve derived tx status handling and documentation

### DIFF
--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -994,7 +994,7 @@ func (suite *Suite) TestGetTransactionResultByIndex() {
 		suite.snapshot.On("Head").Return(nil, err).Once()
 
 		// mock signaler context expect an error
-		signCtxErr := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		signCtxErr := fmt.Errorf("failed to derive transaction status: %w", irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err))
 		signalerCtx := rpcContextExpectError(suite.T(), context.Background(), signCtxErr)
 
 		actual, err := backend.GetTransactionResultByIndex(signalerCtx, blockId, index, entitiesproto.EventEncodingVersion_JSON_CDC_V0)
@@ -1060,7 +1060,7 @@ func (suite *Suite) TestGetTransactionResultsByBlockID() {
 		suite.snapshot.On("Head").Return(nil, err).Once()
 
 		// mock signaler context expect an error
-		signCtxErr := irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+		signCtxErr := fmt.Errorf("failed to derive transaction status: %w", irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err))
 		signalerCtx := rpcContextExpectError(suite.T(), context.Background(), signCtxErr)
 
 		actual, err := backend.GetTransactionResultsByBlockID(signalerCtx, blockId, entitiesproto.EventEncodingVersion_JSON_CDC_V0)

--- a/engine/access/rpc/backend/transactions/provider/execution_node.go
+++ b/engine/access/rpc/backend/transactions/provider/execution_node.go
@@ -19,7 +19,6 @@ import (
 	accessmodel "github.com/onflow/flow-go/model/access"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 )
@@ -98,12 +97,10 @@ func (e *ENTransactionProvider) TransactionResult(
 	}
 
 	// tx body is irrelevant to status if it's in an executed block
-	txStatus, err := e.txStatusDeriver.DeriveTransactionStatus(block.Height, true)
+	txStatus, err := e.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 	if err != nil {
-		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-			irrecoverable.Throw(ctx, err)
-		}
-		return nil, rpc.ConvertStorageError(err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
 	}
 
 	events, err := convert.MessagesToEventsWithEncodingConversion(resp.GetEvents(), resp.GetEventEncodingVersion(), requiredEventEncodingVersion)
@@ -152,12 +149,10 @@ func (e *ENTransactionProvider) TransactionResultByIndex(
 	}
 
 	// tx body is irrelevant to status if it's in an executed block
-	txStatus, err := e.txStatusDeriver.DeriveTransactionStatus(block.Height, true)
+	txStatus, err := e.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 	if err != nil {
-		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-			irrecoverable.Throw(ctx, err)
-		}
-		return nil, rpc.ConvertStorageError(err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
 	}
 
 	events, err := convert.MessagesToEventsWithEncodingConversion(resp.GetEvents(), resp.GetEventEncodingVersion(), encodingVersion)
@@ -223,12 +218,10 @@ func (e *ENTransactionProvider) TransactionResultsByBlockID(
 			txResult := resp.TransactionResults[i]
 
 			// tx body is irrelevant to status if it's in an executed block
-			txStatus, err := e.txStatusDeriver.DeriveTransactionStatus(block.Height, true)
+			txStatus, err := e.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 			if err != nil {
-				if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-					irrecoverable.Throw(ctx, err)
-				}
-				return nil, rpc.ConvertStorageError(err)
+				irrecoverable.Throw(ctx, err)
+				return nil, err
 			}
 			events, err := convert.MessagesToEventsWithEncodingConversion(txResult.GetEvents(), resp.GetEventEncodingVersion(), requiredEventEncodingVersion)
 			if err != nil {
@@ -272,12 +265,10 @@ func (e *ENTransactionProvider) TransactionResultsByBlockID(
 		}
 
 		systemTxResult := resp.TransactionResults[len(resp.TransactionResults)-1]
-		systemTxStatus, err := e.txStatusDeriver.DeriveTransactionStatus(block.Height, true)
+		systemTxStatus, err := e.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 		if err != nil {
-			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-				irrecoverable.Throw(ctx, err)
-			}
-			return nil, rpc.ConvertStorageError(err)
+			irrecoverable.Throw(ctx, err)
+			return nil, err
 		}
 
 		events, err := convert.MessagesToEventsWithEncodingConversion(systemTxResult.GetEvents(), resp.GetEventEncodingVersion(), requiredEventEncodingVersion)

--- a/engine/access/rpc/backend/transactions/provider/execution_node.go
+++ b/engine/access/rpc/backend/transactions/provider/execution_node.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/onflow/flow/protobuf/go/flow/entities"
 	execproto "github.com/onflow/flow/protobuf/go/flow/execution"
@@ -99,7 +100,7 @@ func (e *ENTransactionProvider) TransactionResult(
 	// tx body is irrelevant to status if it's in an executed block
 	txStatus, err := e.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 	if err != nil {
-		irrecoverable.Throw(ctx, err)
+		irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 		return nil, err
 	}
 
@@ -151,7 +152,7 @@ func (e *ENTransactionProvider) TransactionResultByIndex(
 	// tx body is irrelevant to status if it's in an executed block
 	txStatus, err := e.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 	if err != nil {
-		irrecoverable.Throw(ctx, err)
+		irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 		return nil, err
 	}
 
@@ -220,7 +221,7 @@ func (e *ENTransactionProvider) TransactionResultsByBlockID(
 			// tx body is irrelevant to status if it's in an executed block
 			txStatus, err := e.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 			if err != nil {
-				irrecoverable.Throw(ctx, err)
+				irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 				return nil, err
 			}
 			events, err := convert.MessagesToEventsWithEncodingConversion(txResult.GetEvents(), resp.GetEventEncodingVersion(), requiredEventEncodingVersion)
@@ -267,7 +268,7 @@ func (e *ENTransactionProvider) TransactionResultsByBlockID(
 		systemTxResult := resp.TransactionResults[len(resp.TransactionResults)-1]
 		systemTxStatus, err := e.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 		if err != nil {
-			irrecoverable.Throw(ctx, err)
+			irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 			return nil, err
 		}
 

--- a/engine/access/rpc/backend/transactions/provider/local.go
+++ b/engine/access/rpc/backend/transactions/provider/local.go
@@ -18,7 +18,6 @@ import (
 	accessmodel "github.com/onflow/flow-go/model/access"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 )
@@ -101,12 +100,10 @@ func (t *LocalTransactionProvider) TransactionResult(
 		txStatusCode = 1 // statusCode of 1 indicates an error and 0 indicates no error, the same as on EN
 	}
 
-	txStatus, err := t.txStatusDeriver.DeriveTransactionStatus(block.Height, true)
+	txStatus, err := t.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 	if err != nil {
-		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-			irrecoverable.Throw(ctx, err)
-		}
-		return nil, rpc.ConvertStorageError(err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
 	}
 
 	events, err := t.eventsIndex.ByBlockIDTransactionID(blockID, block.Height, transactionID)
@@ -167,12 +164,10 @@ func (t *LocalTransactionProvider) TransactionResultByIndex(
 		txStatusCode = 1 // statusCode of 1 indicates an error and 0 indicates no error, the same as on EN
 	}
 
-	txStatus, err := t.txStatusDeriver.DeriveTransactionStatus(block.Height, true)
+	txStatus, err := t.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 	if err != nil {
-		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-			irrecoverable.Throw(ctx, err)
-		}
-		return nil, rpc.ConvertStorageError(err)
+		irrecoverable.Throw(ctx, err)
+		return nil, err
 	}
 
 	events, err := t.eventsIndex.ByBlockIDTransactionIndex(blockID, block.Height, index)
@@ -255,12 +250,10 @@ func (t *LocalTransactionProvider) TransactionResultsByBlockID(
 			txStatusCode = 1
 		}
 
-		txStatus, err := t.txStatusDeriver.DeriveTransactionStatus(block.Height, true)
+		txStatus, err := t.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 		if err != nil {
-			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-				irrecoverable.Throw(ctx, err)
-			}
-			return nil, rpc.ConvertStorageError(err)
+			irrecoverable.Throw(ctx, err)
+			return nil, err
 		}
 
 		events, err := t.eventsIndex.ByBlockIDTransactionID(blockID, block.Height, txResult.TransactionID)

--- a/engine/access/rpc/backend/transactions/provider/local.go
+++ b/engine/access/rpc/backend/transactions/provider/local.go
@@ -102,7 +102,7 @@ func (t *LocalTransactionProvider) TransactionResult(
 
 	txStatus, err := t.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 	if err != nil {
-		irrecoverable.Throw(ctx, err)
+		irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 		return nil, err
 	}
 
@@ -166,7 +166,7 @@ func (t *LocalTransactionProvider) TransactionResultByIndex(
 
 	txStatus, err := t.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 	if err != nil {
-		irrecoverable.Throw(ctx, err)
+		irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 		return nil, err
 	}
 
@@ -252,7 +252,7 @@ func (t *LocalTransactionProvider) TransactionResultsByBlockID(
 
 		txStatus, err := t.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, true)
 		if err != nil {
-			irrecoverable.Throw(ctx, err)
+			irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 			return nil, err
 		}
 

--- a/engine/access/rpc/backend/transactions/retrier/retrier.go
+++ b/engine/access/rpc/backend/transactions/retrier/retrier.go
@@ -116,8 +116,8 @@ func (r *RetrierImpl) prune(height uint64) {
 // It looks up transactions at the specified height and retries sending
 // raw transactions for those that are still pending. It also cleans up
 // transactions that are no longer pending or have an unknown status.
-// Error returns:
-//   - errors are unexpected and potentially symptoms of internal implementation bugs or state corruption (fatal).
+//
+// No errors expected during normal operations.
 func (r *RetrierImpl) retryTxsAtHeight(heightToRetry uint64) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -139,10 +139,10 @@ func (r *RetrierImpl) retryTxsAtHeight(heightToRetry uint64) error {
 		} else {
 			status, err = r.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, false)
 		}
-
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to derive transaction status: %w", err)
 		}
+
 		if status == flow.TransactionStatusPending {
 			err = r.txSender.SendRawTransaction(context.Background(), tx)
 			if err != nil {

--- a/engine/access/rpc/backend/transactions/retrier/retrier.go
+++ b/engine/access/rpc/backend/transactions/retrier/retrier.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/onflow/flow-go/engine/access/rpc/backend/transactions/status"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/storage"
 )
 
@@ -138,14 +137,11 @@ func (r *RetrierImpl) retryTxsAtHeight(heightToRetry uint64) error {
 		if block == nil {
 			status, err = r.txStatusDeriver.DeriveUnknownTransactionStatus(tx.ReferenceBlockID)
 		} else {
-			status, err = r.txStatusDeriver.DeriveTransactionStatus(block.Height, false)
+			status, err = r.txStatusDeriver.DeriveFinalizedTransactionStatus(block.Height, false)
 		}
 
 		if err != nil {
-			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-				return err
-			}
-			continue
+			return err
 		}
 		if status == flow.TransactionStatusPending {
 			err = r.txSender.SendRawTransaction(context.Background(), tx)

--- a/engine/access/rpc/backend/transactions/status/deriver.go
+++ b/engine/access/rpc/backend/transactions/status/deriver.go
@@ -19,70 +19,69 @@ func NewTxStatusDeriver(state protocol.State, lastFullBlockHeight *counters.Pers
 	}
 }
 
-// DeriveUnknownTransactionStatus is used to determine the status of transaction
-// that are not in a block yet based on the provided reference block ID.
+// DeriveUnknownTransactionStatus is used to determine the status of transaction who's block is not
+// yet known, based on the transaction's reference block.
+//
+// No errors expected during normal operations.
 func (t *TxStatusDeriver) DeriveUnknownTransactionStatus(refBlockID flow.Identifier) (flow.TransactionStatus, error) {
-	referenceBlock, err := t.state.AtBlockID(refBlockID).Head()
+	refBlock, err := t.state.AtBlockID(refBlockID).Head()
 	if err != nil {
 		return flow.TransactionStatusUnknown, err
 	}
-	refHeight := referenceBlock.Height
-	// get the latest finalized block from the state
+
 	finalized, err := t.state.Final().Head()
 	if err != nil {
 		return flow.TransactionStatusUnknown, irrecoverable.NewExceptionf("failed to lookup final header: %w", err)
 	}
-	finalizedHeight := finalized.Height
 
-	// if we haven't seen the expiry block for this transaction, it's not expired
-	if !isExpired(refHeight, finalizedHeight) {
+	// if we haven't finalized the expiry block for this transaction, then it is not expired within
+	// our view of the chain.
+	if !isExpired(refBlock.Height, finalized.Height) {
 		return flow.TransactionStatusPending, nil
 	}
 
-	// At this point, we have seen the expiry block for the transaction.
-	// This means that, if no collections  prior to the expiry block contain
-	// the transaction, it can never be included and is expired.
+	// At this point, we have finalized the expiry block for the transaction, which means that
+	// if no collections prior to the expiry block contain the transaction, it can never be
+	// included and is expired.
 	//
-	// To ensure this, we need to have received all collections  up to the
-	// expiry block to ensure the transaction did not appear in any.
+	// To confirm this, we need to have received all collections up to the expiry block to ensure
+	// the transaction did not appear in any.
 
-	// the last full height is the height where we have received all
-	// collections  for all blocks with a lower height
+	// the last full height is the finalized height up to which we have received all collections
+	// for all blocks with lower heights.
 	fullHeight := t.lastFullBlockHeight.Value()
 
-	// if we have received collections  for all blocks up to the expiry block, the transaction is expired
-	if isExpired(refHeight, fullHeight) {
+	// if we have received collections for all blocks up to the expiry block, the transaction is expired.
+	if isExpired(refBlock.Height, fullHeight) {
 		return flow.TransactionStatusExpired, nil
 	}
 
-	// tx found in transaction storage and collection storage but not in block storage
-	// However, this will not happen as of now since the ingestion engine doesn't subscribe
-	// for collections
+	// otherwise, mark it as pending for now until more collections are indexed.
 	return flow.TransactionStatusPending, nil
 }
 
-// DeriveTransactionStatus is used to determine the status of a transaction based on the provided block height, and execution status.
+// DeriveFinalizedTransactionStatus is used to determine the status of a transaction in a finalized
+// block based the block's height and the transaction's executed status.
+//
+// CAUTION: this must only be used for transactions within FINALIZED blocks, otherwise inaccurate
+// results may be returned.
+//
 // No errors expected during normal operations.
-func (t *TxStatusDeriver) DeriveTransactionStatus(blockHeight uint64, executed bool) (flow.TransactionStatus, error) {
+func (t *TxStatusDeriver) DeriveFinalizedTransactionStatus(blockHeight uint64, executed bool) (flow.TransactionStatus, error) {
 	if !executed {
-		// If we've gotten here, but the block has not yet been executed, report it as only been finalized
 		return flow.TransactionStatusFinalized, nil
 	}
 
-	// From this point on, we know for sure this transaction has at least been executed
-
-	// get the latest sealed block from the State
 	sealed, err := t.state.Sealed().Head()
 	if err != nil {
 		return flow.TransactionStatusUnknown, irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
 	}
 
+	// CAUTION: this check is only safe for finalized blocks!
 	if blockHeight > sealed.Height {
-		// The block is not yet sealed, so we'll report it as only executed
 		return flow.TransactionStatusExecuted, nil
 	}
 
-	// otherwise, this block has been executed, and sealed, so report as sealed
 	return flow.TransactionStatusSealed, nil
 }
 

--- a/engine/access/rpc/backend/transactions/status/deriver_test.go
+++ b/engine/access/rpc/backend/transactions/status/deriver_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+// TestDeriveUnknownTransactionStatus tests each scenario when deriving the status of transaction whose block is not known.
 func TestDeriveUnknownTransactionStatus(t *testing.T) {
 	rootHeader := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(flow.DefaultTransactionExpiry + 1))
 	blocks := unittest.ChainBlockFixtureWithRoot(rootHeader, 10)
@@ -99,7 +100,8 @@ func TestDeriveUnknownTransactionStatus(t *testing.T) {
 	})
 }
 
-func TestDeriveTransactionStatus(t *testing.T) {
+// TestDeriveFinalizedTransactionStatus tests each scenario when deriving the status of transaction in a finalized block.
+func TestDeriveFinalizedTransactionStatus(t *testing.T) {
 	rootHeader := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(flow.DefaultTransactionExpiry + 1))
 	blocks := unittest.ChainBlockFixtureWithRoot(rootHeader, 10)
 
@@ -144,6 +146,7 @@ func TestDeriveTransactionStatus(t *testing.T) {
 	})
 }
 
+// TestIsExpired tests the isExpired function.
 func TestIsExpired(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/engine/access/rpc/backend/transactions/status/deriver_test.go
+++ b/engine/access/rpc/backend/transactions/status/deriver_test.go
@@ -1,0 +1,191 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/engine/access/testutil"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/counters"
+	"github.com/onflow/flow-go/storage"
+	storagemock "github.com/onflow/flow-go/storage/mock"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestDeriveUnknownTransactionStatus(t *testing.T) {
+	rootHeader := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(flow.DefaultTransactionExpiry + 1))
+	blocks := unittest.ChainBlockFixtureWithRoot(rootHeader, 10)
+
+	lastFullBlockHeight := func(height uint64) *counters.PersistentStrictMonotonicCounter {
+		progress := storagemock.NewConsumerProgress(t)
+		progress.On("ProcessedIndex").Return(height, nil)
+		lastFullBlockHeight, err := counters.NewPersistentStrictMonotonicCounter(progress)
+		require.NoError(t, err)
+		return lastFullBlockHeight
+	}
+
+	refBlock := blocks[0]
+	refBlockID := refBlock.ID()
+
+	expiredBlock := unittest.BlockFixture(unittest.Block.WithHeight(refBlock.Height - flow.DefaultTransactionExpiry - 1))
+	expiredBlockID := expiredBlock.ID()
+
+	t.Run("tx not expired", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		s.AllowValidBlocks(t)
+
+		deriver := NewTxStatusDeriver(s.State, lastFullBlockHeight(refBlock.Height))
+
+		status, err := deriver.DeriveUnknownTransactionStatus(refBlockID)
+		assert.NoError(t, err)
+		assert.Equal(t, flow.TransactionStatusPending, status)
+	})
+
+	t.Run("tx expired", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		s.AllowValidBlocks(t)
+
+		s.HeaderAt(t, expiredBlock.ToHeader())
+
+		deriver := NewTxStatusDeriver(s.State, lastFullBlockHeight(refBlock.Height))
+
+		status, err := deriver.DeriveUnknownTransactionStatus(expiredBlockID)
+		assert.NoError(t, err)
+		assert.Equal(t, flow.TransactionStatusExpired, status)
+	})
+
+	t.Run("tx not indexed", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		s.AllowValidBlocks(t)
+
+		s.HeaderAt(t, expiredBlock.ToHeader())
+
+		deriver := NewTxStatusDeriver(s.State, lastFullBlockHeight(expiredBlock.Height+1))
+
+		status, err := deriver.DeriveUnknownTransactionStatus(expiredBlockID)
+		assert.NoError(t, err)
+		assert.Equal(t, flow.TransactionStatusPending, status)
+	})
+
+	t.Run("reference block not found", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		s.AtBlockID(t, refBlockID).
+			On("Head").
+			Return(nil, storage.ErrNotFound)
+
+		deriver := NewTxStatusDeriver(s.State, lastFullBlockHeight(refBlock.Height))
+
+		status, err := deriver.DeriveUnknownTransactionStatus(refBlockID)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, storage.ErrNotFound)
+		assert.Equal(t, flow.TransactionStatusUnknown, status)
+	})
+
+	t.Run("error getting finalized header", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		s.HeaderAt(t, refBlock.ToHeader())
+		s.FinalizedSnapshot.
+			On("Head").
+			Return(nil, storage.ErrNotFound)
+
+		deriver := NewTxStatusDeriver(s.State, lastFullBlockHeight(refBlock.Height))
+
+		status, err := deriver.DeriveUnknownTransactionStatus(refBlockID)
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, storage.ErrNotFound)
+		assert.Equal(t, flow.TransactionStatusUnknown, status)
+	})
+}
+
+func TestDeriveTransactionStatus(t *testing.T) {
+	rootHeader := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(flow.DefaultTransactionExpiry + 1))
+	blocks := unittest.ChainBlockFixtureWithRoot(rootHeader, 10)
+
+	t.Run("tx not executed", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		deriver := NewTxStatusDeriver(s.State, nil)
+
+		status, err := deriver.DeriveFinalizedTransactionStatus(s.Finalized.Height, false)
+		assert.NoError(t, err)
+		assert.Equal(t, flow.TransactionStatusFinalized, status)
+	})
+
+	t.Run("error getting sealed header", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		s.SealedSnapshot.On("Head").Return(nil, storage.ErrNotFound)
+
+		deriver := NewTxStatusDeriver(s.State, nil)
+		status, err := deriver.DeriveFinalizedTransactionStatus(s.Finalized.Height, true)
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, storage.ErrNotFound)
+		assert.Equal(t, flow.TransactionStatusUnknown, status)
+	})
+
+	t.Run("tx not sealed", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		s.AllowValidBlocks(t)
+
+		deriver := NewTxStatusDeriver(s.State, nil)
+		status, err := deriver.DeriveFinalizedTransactionStatus(s.Finalized.Height, true)
+		assert.NoError(t, err)
+		assert.Equal(t, flow.TransactionStatusExecuted, status)
+	})
+
+	t.Run("tx sealed", func(t *testing.T) {
+		s := testutil.NewMockState(t, blocks)
+		s.AllowValidBlocks(t)
+
+		deriver := NewTxStatusDeriver(s.State, nil)
+		status, err := deriver.DeriveFinalizedTransactionStatus(s.Sealed.Height, true)
+		assert.NoError(t, err)
+		assert.Equal(t, flow.TransactionStatusSealed, status)
+	})
+}
+
+func TestIsExpired(t *testing.T) {
+	tests := []struct {
+		name              string
+		refHeight         uint64
+		finalizedToHeight uint64
+		expectedExpired   bool
+		description       string
+	}{
+		{
+			// transaction at same height as comparison should not be expired
+			name:              "not expired - same height",
+			refHeight:         100,
+			finalizedToHeight: 100,
+			expectedExpired:   false,
+		},
+		{
+			// transaction with higher reference height should not be expired
+			name:              "not expired - finalized height lower",
+			refHeight:         100,
+			finalizedToHeight: 50,
+			expectedExpired:   false,
+		},
+		{
+			// transaction exactly at expiry boundary should not be expired
+			name:              "not expired - within expiry window",
+			refHeight:         100,
+			finalizedToHeight: 100 + flow.DefaultTransactionExpiry,
+			expectedExpired:   false,
+		},
+		{
+			// transaction beyond expiry window should be expired
+			name:              "expired - beyond expiry window",
+			refHeight:         100,
+			finalizedToHeight: 100 + flow.DefaultTransactionExpiry + 1,
+			expectedExpired:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isExpired(tt.refHeight, tt.finalizedToHeight)
+			assert.Equal(t, tt.expectedExpired, result)
+		})
+	}
+}

--- a/engine/access/rpc/backend/transactions/stream/transaction_metadata.go
+++ b/engine/access/rpc/backend/transactions/stream/transaction_metadata.go
@@ -11,11 +11,9 @@ import (
 	txprovider "github.com/onflow/flow-go/engine/access/rpc/backend/transactions/provider"
 	txstatus "github.com/onflow/flow-go/engine/access/rpc/backend/transactions/status"
 	"github.com/onflow/flow-go/engine/access/subscription"
-	"github.com/onflow/flow-go/engine/common/rpc"
 	accessmodel "github.com/onflow/flow-go/model/access"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/storage"
 
 	"github.com/onflow/flow/protobuf/go/flow/entities"
@@ -146,22 +144,18 @@ func (t *TransactionMetadata) refreshStatus(ctx context.Context) error {
 
 		t.txResult.Status, err = t.txStatusDeriver.DeriveUnknownTransactionStatus(t.txReferenceBlockID)
 		if err != nil {
-			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-				irrecoverable.Throw(ctx, err)
-			}
-			return rpc.ConvertStorageError(err)
+			irrecoverable.Throw(ctx, err)
+			return err
 		}
 		return nil
 	}
 
 	// When the transaction is included in an executed block, the `txResult` may be updated during `Refresh`
 	// Recheck the status to ensure it's accurate.
-	t.txResult.Status, err = t.txStatusDeriver.DeriveTransactionStatus(t.blockWithTx.Height, t.txResult.IsExecuted())
+	t.txResult.Status, err = t.txStatusDeriver.DeriveFinalizedTransactionStatus(t.blockWithTx.Height, t.txResult.IsExecuted())
 	if err != nil {
-		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-			irrecoverable.Throw(ctx, err)
-		}
-		return rpc.ConvertStorageError(err)
+		irrecoverable.Throw(ctx, err)
+		return err
 	}
 	return nil
 }

--- a/engine/access/rpc/backend/transactions/stream/transaction_metadata.go
+++ b/engine/access/rpc/backend/transactions/stream/transaction_metadata.go
@@ -144,7 +144,7 @@ func (t *TransactionMetadata) refreshStatus(ctx context.Context) error {
 
 		t.txResult.Status, err = t.txStatusDeriver.DeriveUnknownTransactionStatus(t.txReferenceBlockID)
 		if err != nil {
-			irrecoverable.Throw(ctx, err)
+			irrecoverable.Throw(ctx, fmt.Errorf("failed to derive unknown transaction status: %w", err))
 			return err
 		}
 		return nil
@@ -154,7 +154,7 @@ func (t *TransactionMetadata) refreshStatus(ctx context.Context) error {
 	// Recheck the status to ensure it's accurate.
 	t.txResult.Status, err = t.txStatusDeriver.DeriveFinalizedTransactionStatus(t.blockWithTx.Height, t.txResult.IsExecuted())
 	if err != nil {
-		irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
+		irrecoverable.Throw(ctx, fmt.Errorf("failed to derive finalized transaction status: %w", err))
 		return err
 	}
 	return nil

--- a/engine/access/rpc/backend/transactions/stream/transaction_metadata.go
+++ b/engine/access/rpc/backend/transactions/stream/transaction_metadata.go
@@ -154,7 +154,7 @@ func (t *TransactionMetadata) refreshStatus(ctx context.Context) error {
 	// Recheck the status to ensure it's accurate.
 	t.txResult.Status, err = t.txStatusDeriver.DeriveFinalizedTransactionStatus(t.blockWithTx.Height, t.txResult.IsExecuted())
 	if err != nil {
-		irrecoverable.Throw(ctx, err)
+		irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 		return err
 	}
 	return nil

--- a/engine/access/rpc/backend/transactions/transactions.go
+++ b/engine/access/rpc/backend/transactions/transactions.go
@@ -398,7 +398,7 @@ func (t *Transactions) GetTransactionResult(
 		}
 
 		if err != nil {
-			irrecoverable.Throw(ctx, err)
+			irrecoverable.Throw(ctx, fmt.Errorf("failed to derive transaction status: %w", err))
 			return nil, err
 		}
 

--- a/engine/access/rpc/backend/transactions/transactions.go
+++ b/engine/access/rpc/backend/transactions/transactions.go
@@ -29,7 +29,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 )
@@ -395,14 +394,12 @@ func (t *Transactions) GetTransactionResult(
 		if block == nil {
 			txStatus, err = t.txStatusDeriver.DeriveUnknownTransactionStatus(tx.ReferenceBlockID)
 		} else {
-			txStatus, err = t.txStatusDeriver.DeriveTransactionStatus(blockHeight, false)
+			txStatus, err = t.txStatusDeriver.DeriveFinalizedTransactionStatus(blockHeight, false)
 		}
 
 		if err != nil {
-			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-				irrecoverable.Throw(ctx, err)
-			}
-			return nil, rpc.ConvertStorageError(err)
+			irrecoverable.Throw(ctx, err)
+			return nil, err
 		}
 
 		txResult = &accessmodel.TransactionResult{

--- a/engine/access/testutil/fixture.go
+++ b/engine/access/testutil/fixture.go
@@ -1,0 +1,235 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// ProtocolDataFixture holds data for blocks and their corresponding protocol data objects.
+// All data relationships are properly configured.
+type ProtocolDataFixture struct {
+	Headers      []*flow.Header
+	Blocks       []*flow.Block
+	Collections  map[flow.Identifier][]*flow.Collection
+	Transactions map[flow.Identifier][]*flow.TransactionBody
+	Results      []*flow.ExecutionResult
+	Receipts     []*flow.ExecutionReceipt
+
+	ExecutionNodes flow.IdentityList
+}
+
+func NewProtocolDataFixture() *ProtocolDataFixture {
+	return &ProtocolDataFixture{
+		Collections:  make(map[flow.Identifier][]*flow.Collection),
+		Transactions: make(map[flow.Identifier][]*flow.TransactionBody),
+	}
+}
+
+// HeaderByBlockID returns the header with the given block ID.
+// If the header is not found, t.Error is called.
+func (d *ProtocolDataFixture) HeaderByBlockID(t testing.TB, blockID flow.Identifier) *flow.Header {
+	for _, header := range d.Headers {
+		if header.ID() == blockID {
+			return header
+		}
+	}
+	t.Errorf("HeaderByBlockID: header %s not found", blockID)
+	return nil
+}
+
+// HeaderByHeight returns the header with the given height.
+// If the header is not found, t.Error is called.
+func (d *ProtocolDataFixture) HeaderByHeight(t testing.TB, height uint64) *flow.Header {
+	for _, header := range d.Headers {
+		if header.Height == height {
+			return header
+		}
+	}
+	t.Errorf("HeaderByHeight: header %d not found", height)
+	return nil
+}
+
+// BlockByID returns the block with the given ID.
+// If the block is not found, t.Error is called.
+func (d *ProtocolDataFixture) BlockByID(t testing.TB, blockID flow.Identifier) *flow.Block {
+	for _, block := range d.Blocks {
+		if block.ID() == blockID {
+			return block
+		}
+	}
+	t.Errorf("BlockByID: block %s not found", blockID)
+	return nil
+}
+
+// BlockByHeight returns the block with the given height.
+// If the block is not found, t.Error is called.
+func (d *ProtocolDataFixture) BlockByHeight(t testing.TB, height uint64) *flow.Block {
+	for _, block := range d.Blocks {
+		if block.Height == height {
+			return block
+		}
+	}
+	t.Errorf("BlockByHeight: block %d not found", height)
+	return nil
+}
+
+// CollectionByID returns the collection with the given ID.
+// If the collection is not found, t.Error is called.
+func (d *ProtocolDataFixture) CollectionByID(t testing.TB, collectionID flow.Identifier) *flow.Collection {
+	for _, blockCollections := range d.Collections {
+		for _, collection := range blockCollections {
+			if collection.ID() == collectionID {
+				return collection
+			}
+		}
+	}
+	t.Errorf("CollectionByID: collection %s not found", collectionID)
+	return nil
+}
+
+// TransactionByID returns the transaction with the given ID.
+// If the transaction is not found, t.Error is called.
+func (d *ProtocolDataFixture) TransactionByID(t testing.TB, transactionID flow.Identifier) *flow.TransactionBody {
+	for _, colTxs := range d.Transactions {
+		for _, transaction := range colTxs {
+			if transaction.ID() == transactionID {
+				return transaction
+			}
+		}
+	}
+	t.Errorf("TransactionByID: transaction %s not found", transactionID)
+	return nil
+}
+
+// TransactionsByBlockID returns an ordered list of transactions in the block.
+// If the block is not found, t.Error is called.
+func (d *ProtocolDataFixture) TransactionsByBlockID(t testing.TB, blockID flow.Identifier) []*flow.TransactionBody {
+	// make sure the block existgs
+	_ = d.BlockByID(t, blockID)
+
+	transactions := make([]*flow.TransactionBody, 0)
+	for _, col := range d.Collections[blockID] {
+		transactions = append(transactions, col.Transactions...)
+	}
+	return transactions
+}
+
+// CollectionIDByTransactionID returns the collection ID for the given transaction ID.
+// If the collection ID is not found, t.Error is called.
+func (d *ProtocolDataFixture) CollectionIDByTransactionID(t testing.TB, txID flow.Identifier) flow.Identifier {
+	for collectionID, colTxs := range d.Transactions {
+		for _, transaction := range colTxs {
+			if transaction.ID() == txID {
+				return collectionID
+			}
+		}
+	}
+	t.Errorf("CollectionIDByTransactionID: collection for transaction %s not found", txID)
+	return flow.ZeroID
+}
+
+type ProtocolDataFixtureBuilder struct {
+	blocks         int
+	txPerCol       int
+	colPerBlock    int
+	withReceipts   bool
+	executionNodes flow.IdentityList
+}
+
+func NewProtocolDataFixtureBuilder() *ProtocolDataFixtureBuilder {
+	return &ProtocolDataFixtureBuilder{
+		blocks:         10,
+		txPerCol:       1,
+		colPerBlock:    1,
+		withReceipts:   true,
+		executionNodes: unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution)),
+	}
+}
+
+func (tb *ProtocolDataFixtureBuilder) Blocks(n int) *ProtocolDataFixtureBuilder {
+	tb.blocks = n
+	return tb
+}
+
+func (tb *ProtocolDataFixtureBuilder) TransactionsPerCollection(n int) *ProtocolDataFixtureBuilder {
+	tb.txPerCol = n
+	return tb
+}
+
+func (tb *ProtocolDataFixtureBuilder) CollectionsPerBlock(n int) *ProtocolDataFixtureBuilder {
+	tb.colPerBlock = n
+	return tb
+}
+
+func (tb *ProtocolDataFixtureBuilder) Receipts() *ProtocolDataFixtureBuilder {
+	tb.withReceipts = true
+	return tb
+}
+
+func (tb *ProtocolDataFixtureBuilder) ExecutionNodes(nodes flow.IdentityList) *ProtocolDataFixtureBuilder {
+	tb.executionNodes = nodes
+	return tb
+}
+
+func (tb *ProtocolDataFixtureBuilder) Build(t testing.TB) *ProtocolDataFixture {
+	d := NewProtocolDataFixture()
+	d.ExecutionNodes = tb.executionNodes
+
+	d.Blocks, d.Headers, d.Collections, d.Transactions = tb.buildBlocks()
+
+	if tb.withReceipts {
+		d.Results, d.Receipts = tb.buildReceipts(d.Blocks, d.ExecutionNodes)
+	}
+
+	return d
+}
+
+func (tb *ProtocolDataFixtureBuilder) buildBlocks() ([]*flow.Block, []*flow.Header, map[flow.Identifier][]*flow.Collection, map[flow.Identifier][]*flow.TransactionBody) {
+	blocks := make([]*flow.Block, tb.blocks)
+	headers := make([]*flow.Header, tb.blocks)
+	collections := make(map[flow.Identifier][]*flow.Collection, tb.blocks*tb.colPerBlock)
+	txs := make(map[flow.Identifier][]*flow.TransactionBody, tb.blocks*tb.colPerBlock*tb.txPerCol)
+
+	parent := unittest.BlockFixture()
+	for i := range tb.blocks {
+		guarantees := make([]*flow.CollectionGuarantee, tb.colPerBlock)
+		blockCollections := make([]*flow.Collection, tb.colPerBlock)
+		for j := range tb.colPerBlock {
+			colTxs := unittest.TransactionBodyListFixture(tb.txPerCol)
+			col := unittest.CompleteCollectionFromTransactions(colTxs)
+			guarantees[j] = col.Guarantee
+
+			blockCollections[j] = col.Collection
+			txs[col.Guarantee.CollectionID] = colTxs
+		}
+
+		block := unittest.BlockFixture(
+			unittest.Block.WithParent(parent.ID(), parent.View, parent.Height),
+			unittest.Block.WithPayload(unittest.PayloadFixture(unittest.WithGuarantees(guarantees...))),
+		)
+
+		blocks[i] = block
+		headers[i] = block.ToHeader()
+		collections[block.ID()] = blockCollections
+		parent = block
+	}
+
+	return blocks, headers, collections, txs
+}
+
+func (tb *ProtocolDataFixtureBuilder) buildReceipts(blocks []*flow.Block, executionNodes flow.IdentityList) ([]*flow.ExecutionResult, []*flow.ExecutionReceipt) {
+	results := make([]*flow.ExecutionResult, len(blocks))
+	receipts := make([]*flow.ExecutionReceipt, 0, len(blocks)*len(executionNodes))
+	for i := range blocks {
+		results[i] = unittest.ExecutionResultFixture(unittest.WithBlock(blocks[i]))
+		for _, node := range executionNodes {
+			receipts = append(receipts, unittest.ExecutionReceiptFixture(
+				unittest.WithResult(results[i]),
+				unittest.WithExecutorID(node.NodeID),
+			))
+		}
+	}
+	return results, receipts
+}

--- a/engine/access/testutil/state.go
+++ b/engine/access/testutil/state.go
@@ -1,0 +1,87 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	protocolmock "github.com/onflow/flow-go/state/protocol/mock"
+)
+
+type MockState struct {
+	State  *protocolmock.State
+	Params *protocolmock.Params
+
+	Blocks []*flow.Block
+
+	Sealed    *flow.Block
+	Finalized *flow.Block
+
+	SealedSnapshot    *protocolmock.Snapshot
+	FinalizedSnapshot *protocolmock.Snapshot
+}
+
+// NewMockState creates a new mock state with the given blocks.
+// Blocks must have exactly 10 blocks, and blocks must form a chain.
+// Block at index 2 is the latest sealed block.
+// Block at index 6 is the latest finalized block.
+// generate blocks using unittest.ChainBlockFixtureWithRoot
+// e.g.
+//
+//	blocks := unittest.ChainBlockFixtureWithRoot(unittest.BlockHeaderFixture(), 10)
+func NewMockState(t testing.TB, blocks []*flow.Block) *MockState {
+	require.Len(t, blocks, 10)
+
+	s := &MockState{
+		State:             protocolmock.NewState(t),
+		Params:            protocolmock.NewParams(t),
+		SealedSnapshot:    protocolmock.NewSnapshot(t),
+		FinalizedSnapshot: protocolmock.NewSnapshot(t),
+		Blocks:            blocks,
+	}
+
+	s.Sealed = s.Blocks[2]
+	s.Finalized = s.Blocks[6]
+
+	// it's generally OK to ignore expectations on these because there will always be a subsequent
+	// call on the returned snapshot which will have additional expectations.
+	s.State.On("Sealed").Return(s.SealedSnapshot).Maybe()
+	s.State.On("Final").Return(s.FinalizedSnapshot).Maybe()
+	s.State.On("Params").Return(s.Params).Maybe()
+
+	return s
+}
+
+// AllowValidBlocks configures the state to return snapshots for Sealed, Final, and AtBlockID using
+// the configured blocks, as well as the Head method for each snapshot.
+//
+// While less precise than explicitly configuring expectations for each block, this makes it easier
+// to perform blockbox testing that allows any valid data to be accessed
+//
+// Note: AtBlockID is only configured for the blocks in the state. Calls for any other blocks will
+// cause the test to fail with an unexpected call error.
+func (s *MockState) AllowValidBlocks(t testing.TB) *MockState {
+	s.FinalizedSnapshot.On("Head").Return(s.Finalized.ToHeader(), nil).Maybe()
+	s.SealedSnapshot.On("Head").Return(s.Sealed.ToHeader(), nil).Maybe()
+	for _, block := range s.Blocks {
+		snapshot := protocolmock.NewSnapshot(t)
+		s.State.On("AtBlockID", block.ID()).Return(snapshot).Maybe()
+		snapshot.On("Head").Return(block.ToHeader(), nil).Maybe()
+	}
+	return s
+}
+
+// AtBlockID configures AtBlockID to return a snapshot, and returns the snapshot.
+func (s *MockState) AtBlockID(t testing.TB, blockID flow.Identifier) *protocolmock.Snapshot {
+	snapshot := protocolmock.NewSnapshot(t)
+	s.State.On("AtBlockID", blockID).Return(snapshot)
+	return snapshot
+}
+
+// HeaderAt configures AtBlockID to return a snapshot who's Head method will return the given header.
+func (s *MockState) HeaderAt(t testing.TB, header *flow.Header) {
+	snapshot := protocolmock.NewSnapshot(t)
+	s.State.On("AtBlockID", header.ID()).Return(snapshot)
+	snapshot.On("Head").Return(header, nil)
+}

--- a/module/mempool/herocache/transactions_test.go
+++ b/module/mempool/herocache/transactions_test.go
@@ -106,12 +106,12 @@ func TestValuesReturnsInOrder(t *testing.T) {
 		require.True(t, transactions.Add(txs[i].ID(), txs[i]))
 		tx, ok := transactions.Get(txs[i].ID())
 		require.True(t, ok)
-		require.Equal(t, txs[i], *tx)
+		require.Equal(t, txs[i], tx)
 	}
 
 	// all transactions must be retrieved in the same order as they are added
 	all := transactions.Values()
 	for i := 0; i < total; i++ {
-		require.Equal(t, txs[i], *all[i])
+		require.Equal(t, txs[i], all[i])
 	}
 }

--- a/module/mempool/herocache/transactions_test.go
+++ b/module/mempool/herocache/transactions_test.go
@@ -74,7 +74,7 @@ func TestConcurrentWriteAndRead(t *testing.T) {
 			require.True(t, transactions.Add(tx.ID(), &tx))
 
 			wg.Done()
-		}(txs[i])
+		}(*txs[i])
 	}
 
 	unittest.RequireReturnsBefore(t, wg.Wait, 100*time.Millisecond, "could not write all transactions on time")
@@ -89,7 +89,7 @@ func TestConcurrentWriteAndRead(t *testing.T) {
 			require.Equal(t, tx, *actual)
 
 			wg.Done()
-		}(txs[i])
+		}(*txs[i])
 	}
 	unittest.RequireReturnsBefore(t, wg.Wait, 100*time.Millisecond, "could not read all transactions on time")
 }
@@ -103,7 +103,7 @@ func TestValuesReturnsInOrder(t *testing.T) {
 
 	// storing all transactions
 	for i := 0; i < total; i++ {
-		require.True(t, transactions.Add(txs[i].ID(), &txs[i]))
+		require.True(t, transactions.Add(txs[i].ID(), txs[i]))
 		tx, ok := transactions.Get(txs[i].ID())
 		require.True(t, ok)
 		require.Equal(t, txs[i], *tx)

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -1497,10 +1497,11 @@ func TransactionBodyFixture(opts ...func(*flow.TransactionBody)) flow.Transactio
 	return tb
 }
 
-func TransactionBodyListFixture(n int) []flow.TransactionBody {
-	l := make([]flow.TransactionBody, n)
+func TransactionBodyListFixture(n int) []*flow.TransactionBody {
+	l := make([]*flow.TransactionBody, n)
 	for i := 0; i < n; i++ {
-		l[i] = TransactionBodyFixture()
+		tx := TransactionBodyFixture()
+		l[i] = &tx
 	}
 
 	return l


### PR DESCRIPTION
- Improve documentation for `TxStatusDeriver`
- Add tests
- Cleanup outdated error handling (methods no longer return `state.ErrUnknownSnapshotReference`)