### PR TITLE
Avoid unittest.BlockFixture to create invalid blocks when option WithParent is given

### DIFF
--- a/consensus/hotstuff/verification/combined_signer_v2_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v2_test.go
@@ -35,7 +35,6 @@ func TestCombinedSignWithBeaconKey(t *testing.T) {
 	proposerIdentity := identities[0]
 	fblock := unittest.BlockFixture(
 		unittest.Block.WithParent(unittest.IdentifierFixture(), proposerView-1, 0),
-		unittest.Block.WithView(proposerView),
 		unittest.Block.WithProposerID(proposerIdentity.NodeID),
 		unittest.Block.WithLastViewTC(nil),
 	)
@@ -145,7 +144,6 @@ func TestCombinedSignWithNoBeaconKey(t *testing.T) {
 
 	fblock := unittest.BlockFixture(
 		unittest.Block.WithParent(unittest.IdentifierFixture(), proposerView-1, 0),
-		unittest.Block.WithView(proposerView),
 		unittest.Block.WithLastViewTC(nil),
 	)
 	proposal := model.ProposalFromFlow(fblock.ToHeader())

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -283,7 +283,6 @@ func createBlock(b *testing.B, parentBlock *flow.Block, accs *testAccounts, colN
 
 	block := unittest.BlockFixture(
 		unittest.Block.WithParent(parentBlock.ID(), parentBlock.View, parentBlock.Height),
-		unittest.Block.WithView(parentBlock.View+1),
 		unittest.Block.WithPayload(
 			unittest.PayloadFixture(unittest.WithGuarantees(guarantees...)),
 		),

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -532,7 +532,6 @@ func createTestBlockAndRun(
 
 	block := unittest.BlockFixture(
 		unittest.Block.WithParent(parentBlock.ID(), parentBlock.View, parentBlock.Height),
-		unittest.Block.WithView(parentBlock.View+1),
 		unittest.Block.WithPayload(
 			unittest.PayloadFixture(unittest.WithGuarantees(guarantee)),
 		),

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -596,14 +596,11 @@ func TestExtendHeightTooSmall(t *testing.T) {
 	emptyPayload := unittest.PayloadFixture(unittest.WithProtocolStateID(rootProtocolStateID))
 	blockB := unittest.BlockFixture( // creates child with increased height and view (protocol compliant)
 		unittest.Block.WithParent(head.ID(), head.View, head.Height),
-		unittest.Block.WithHeight(head.Height+1),
-		unittest.Block.WithView(head.View+1),
 		unittest.Block.WithPayload(emptyPayload))
 
 	blockC := unittest.BlockFixture( // creates child with height identical to parent (protocol violation) but increased view (protocol compliant)
 		unittest.Block.WithParent(blockB.ID(), blockB.View, blockB.Height),
 		unittest.Block.WithHeight(blockB.Height),
-		unittest.Block.WithView(blockB.View+1),
 		unittest.Block.WithPayload(emptyPayload))
 
 	util.RunWithFullProtocolState(t, rootSnapshot, func(bdb *badger.DB, chainState *protocol.ParticipantState) {
@@ -1036,7 +1033,6 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		block3View := block2.View + 1
 		block3 := unittest.BlockFixture(
 			unittest.Block.WithParent(block2.ID(), block2.View, block2.Height),
-			unittest.Block.WithView(block3View),
 			unittest.Block.WithPayload(
 				flow.Payload{
 					Seals:           seals,
@@ -1117,7 +1113,6 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		block6View := block5.View + 1
 		block6 := unittest.BlockFixture(
 			unittest.Block.WithParent(block5.ID(), block5.View, block5.Height),
-			unittest.Block.WithView(block6View),
 			unittest.Block.WithPayload(
 				flow.Payload{
 					Seals:           seals,
@@ -2109,7 +2104,6 @@ func TestEpochFallbackMode(t *testing.T) {
 			block3View := block2.View + 1
 			block3 := unittest.BlockFixture(
 				unittest.Block.WithParent(block2.ID(), block2.View, block2.Height),
-				unittest.Block.WithView(block3View),
 				unittest.Block.WithPayload(
 					flow.Payload{
 						Seals:           seals,
@@ -2202,7 +2196,6 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 			block1View := head.View + 1
 			block1 := unittest.BlockFixture(
 				unittest.Block.WithParent(head.ID(), head.View, head.Height),
-				unittest.Block.WithView(block1View),
 				unittest.Block.WithPayload(
 					flow.Payload{
 						ProtocolStateID: expectedStateIdCalculator(head.ID(), block1View, nil),
@@ -2301,7 +2294,6 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 			block1View := head.View + 1
 			block1 := unittest.BlockFixture(
 				unittest.Block.WithParent(head.ID(), head.View, head.Height),
-				unittest.Block.WithView(block1View),
 				unittest.Block.WithPayload(
 					flow.Payload{
 						ProtocolStateID: expectedStateIdCalculator(head.ID(), block1View, nil),
@@ -2446,7 +2438,6 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 			block1View := head.View + 1
 			block1 := unittest.BlockFixture(
 				unittest.Block.WithParent(head.ID(), head.View, head.Height),
-				unittest.Block.WithView(block1View),
 				unittest.Block.WithPayload(
 					flow.Payload{
 						ProtocolStateID: expectedStateIdCalculator(head.ID(), block1View, nil),

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -360,7 +360,6 @@ func TestSealingSegment(t *testing.T) {
 			block3View := block2.View + 1
 			block3 := unittest.BlockFixture(
 				unittest.Block.WithParent(block2.ID(), block2.View, block2.Height),
-				unittest.Block.WithView(block3View),
 				unittest.Block.WithPayload(
 					flow.Payload{
 						Seals:           seals,
@@ -731,7 +730,6 @@ func TestSealingSegment(t *testing.T) {
 		util.RunWithFollowerProtocolState(t, rootSnapshot, func(db *badger.DB, state *bprotocol.FollowerState) {
 			root := unittest.BlockFixture(
 				unittest.Block.WithParent(head.ID(), head.View, head.Height),
-				unittest.Block.WithView(head.View+1), // set view so we are still in the same epoch
 				unittest.Block.WithPayload(unittest.PayloadFixture(unittest.WithProtocolStateID(rootProtocolStateID))),
 			)
 			buildFinalizedBlock(t, state, root)
@@ -741,7 +739,6 @@ func TestSealingSegment(t *testing.T) {
 			for i := 0; i < flow.DefaultTransactionExpiry+1; i++ {
 				next := unittest.BlockFixture(
 					unittest.Block.WithParent(parent.ID(), parent.View, parent.Height),
-					unittest.Block.WithView(parent.View+1), // set view so we are still in the same epoch
 					unittest.Block.WithPayload(unittest.PayloadFixture(
 						unittest.WithProtocolStateID(parent.Payload.ProtocolStateID)),
 					),
@@ -800,7 +797,6 @@ func TestSealingSegment(t *testing.T) {
 			// build a block to seal
 			block1 := unittest.BlockFixture(
 				unittest.Block.WithParent(head.ID(), head.View, head.Height),
-				unittest.Block.WithView(head.View+1), // set view so we are still in the same epoch
 				unittest.Block.WithPayload(unittest.PayloadFixture(unittest.WithProtocolStateID(rootProtocolStateID))),
 			)
 			buildFinalizedBlock(t, state, block1)
@@ -810,7 +806,6 @@ func TestSealingSegment(t *testing.T) {
 
 			block2 := unittest.BlockFixture(
 				unittest.Block.WithParent(block1.ID(), block1.View, block1.Height),
-				unittest.Block.WithView(block1.View+1), // set view so we are still in the same epoch
 				unittest.Block.WithPayload(unittest.PayloadFixture(
 					unittest.WithReceipts(receipt1),
 					unittest.WithProtocolStateID(rootProtocolStateID)),
@@ -821,7 +816,6 @@ func TestSealingSegment(t *testing.T) {
 			receipt2, seal2 := unittest.ReceiptAndSealForBlock(block2)
 			block3 := unittest.BlockFixture(
 				unittest.Block.WithParent(block2.ID(), block2.View, block2.Height),
-				unittest.Block.WithView(block2.View+1), // set view so we are still in the same epoch
 				unittest.Block.WithPayload(unittest.PayloadFixture(
 					unittest.WithSeals(seal1),
 					unittest.WithReceipts(receipt2),
@@ -833,7 +827,6 @@ func TestSealingSegment(t *testing.T) {
 			receipt3, seal3 := unittest.ReceiptAndSealForBlock(block3)
 			block4 := unittest.BlockFixture(
 				unittest.Block.WithParent(block3.ID(), block3.View, block3.Height),
-				unittest.Block.WithView(block3.View+1), // set view so we are still in the same epoch
 				unittest.Block.WithPayload(unittest.PayloadFixture(
 					unittest.WithReceipts(receipt3),
 					unittest.WithProtocolStateID(rootProtocolStateID)),
@@ -846,7 +839,6 @@ func TestSealingSegment(t *testing.T) {
 			for i := 0; i < 1.5*flow.DefaultTransactionExpiry; i++ {
 				next := unittest.BlockFixture(
 					unittest.Block.WithParent(parent.ID(), parent.View, parent.Height),
-					unittest.Block.WithView(parent.View+1), // set view so we are still in the same epoch
 					unittest.Block.WithPayload(unittest.PayloadFixture(
 						unittest.WithProtocolStateID(parent.Payload.ProtocolStateID)),
 					),

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -366,7 +366,6 @@ func TestBootstrapNonRoot(t *testing.T) {
 			block3View := block2.View + 1
 			block3 := unittest.BlockFixture(
 				unittest.Block.WithParent(block2.ID(), block2.View, block2.Height),
-				unittest.Block.WithView(block3View),
 				unittest.Block.WithPayload(
 					flow.Payload{
 						Seals:           seals,
@@ -507,7 +506,6 @@ func TestBootstrapNonRoot(t *testing.T) {
 			block3View := block2.View + 1
 			block3 := unittest.BlockFixture(
 				unittest.Block.WithParent(block2.ID(), block2.View, block2.Height),
-				unittest.Block.WithView(block3View),
 				unittest.Block.WithPayload(
 					flow.Payload{
 						Seals:           seals,

--- a/utils/unittest/block.go
+++ b/utils/unittest/block.go
@@ -25,6 +25,7 @@ func (f *blockFactory) WithParent(parentID flow.Identifier, parentView uint64, p
 		block.ParentID = parentID
 		block.ParentView = parentView
 		block.Height = parentHeight + 1
+		block.View = parentView + 1
 	}
 }
 

--- a/utils/unittest/protocol_state.go
+++ b/utils/unittest/protocol_state.go
@@ -96,7 +96,6 @@ func SealBlock(t *testing.T, st protocol.ParticipantState, mutableProtocolState 
 
 	block3 := BlockFixture(
 		Block.WithParent(block2.ID(), block2.View, block2.Height),
-		Block.WithView(block3View),
 		Block.WithPayload(
 			flow.Payload{
 				Seals:           seals,


### PR DESCRIPTION
Closes #7826

## Context
- Updated `WithParent` to set the `View`according to safety by default principle.
- Updated unit tests to avoid double setting the same `View`.