### PR TITLE
InstanceParams no longer reads anything from the database; hence remove database field

### DIFF
--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -793,7 +793,7 @@ func OpenState(
 			SporkRootBlockView:   sporkRootBlock.View,
 		},
 	)
-	instanceParams, err := ReadInstanceParams(db, headers, seals)
+	instanceParams, err := ReadInstanceParams(db.Reader(), headers, seals)
 	if err != nil {
 		return nil, fmt.Errorf("could not read instance params: %w", err)
 	}


### PR DESCRIPTION
Closes: #7836

## Context
This PR refactors `InstanceParams` to better reflect its intended usage:
- Removed the `db` `storage.DB` reference, since all values are static and never re-fetched from the database.
- Clarified in documentation that `InstanceParams` are constant throughout the lifetime of a node, and therefore non-atomic field reads are acceptable.
- Updated `ReadInstanceParams` to serve as a constructor that only requires a database reader. This enforces a stronger API contract by ensuring the method only reads (never writes) from storage.