### PR TITLE
Consolidate InstanceParams into one storage object

### DIFF
--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -257,7 +257,12 @@ func (bs *BuilderSuite) SetupTest() {
 	// insert finalized height and root height
 	db := badgerimpl.ToDB(bs.db)
 	require.NoError(bs.T(), db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-		require.NoError(bs.T(), operation.InsertRootHeight(rw.Writer(), 13))
+		require.NoError(bs.T(), operation.InsertInstanceParams(
+			rw.Writer(),
+			operation.EncodableInstanceParams{
+				FinalizedRootID: unittest.IdentifierFixture(),
+				SealedRootID:    unittest.IdentifierFixture(),
+			}))
 		require.NoError(bs.T(), operation.UpsertFinalizedHeight(lctx, rw.Writer(), final.Height))
 		require.NoError(bs.T(), operation.IndexFinalizedBlockByHeight(lctx, rw, final.Height, bs.finalID))
 		require.NoError(bs.T(), operation.UpsertSealedHeight(lctx, rw.Writer(), first.Height))

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -557,16 +557,16 @@ func bootstrapStatePointers(lctx lockctx.Proof, rw storage.ReaderBatchWriter, ro
 		return fmt.Errorf("could not insert quorum certificate for the latest finalized block: %w", err)
 	}
 
+	enc := operation.EncodableInstanceParams{
+		FinalizedRootID: lastFinalized.ID(),
+		SealedRootID:    lastSealed.ID(),
+	}
+	err = operation.InsertInstanceParams(w, enc)
+	if err != nil {
+		return fmt.Errorf("could not store instance params: %w", err)
+	}
+
 	// insert height pointers
-	err = operation.InsertRootHeight(w, lastFinalized.Height)
-	if err != nil {
-		return fmt.Errorf("could not insert finalized root height: %w", err)
-	}
-	// the sealed root height is the lastSealed block in sealing segment
-	err = operation.InsertSealedRootHeight(w, lastSealed.Height)
-	if err != nil {
-		return fmt.Errorf("could not insert sealed root height: %w", err)
-	}
 	err = operation.UpsertFinalizedHeight(lctx, w, lastFinalized.Height)
 	if err != nil {
 		return fmt.Errorf("could not insert finalized height: %w", err)

--- a/state/protocol/datastore/params.go
+++ b/state/protocol/datastore/params.go
@@ -31,52 +31,33 @@ type InstanceParams struct {
 var _ protocol.InstanceParams = (*InstanceParams)(nil)
 
 // ReadInstanceParams reads the instance parameters from the database and returns them as in-memory representation.
+// It serves as a constructor for InstanceParams and only requires a read-only database handle,
+// emphasizing that it only reads and never writes.
+// This information is immutable and may be cached.
 // No errors are expected during normal operation.
 func ReadInstanceParams(r storage.Reader, headers storage.Headers, seals storage.Seals) (*InstanceParams, error) {
 	params := &InstanceParams{}
 
 	// The values below are written during bootstrapping and immutable for the lifetime of the node. All
 	// following parameters are uniquely defined by the values initially read. No atomicity is required.
-	var (
-		finalizedRootHeight uint64 // height of the highest finalized block contained in the root snapshot
-		sealedRootHeight    uint64 // height of the highest sealed block contained in the root snapshot
-	)
-
-	// root height
-	err := operation.RetrieveRootHeight(r, &finalizedRootHeight)
+	var enc operation.EncodableInstanceParams
+	err := operation.RetrieveInstanceParams(r, &enc)
 	if err != nil {
-		return nil, fmt.Errorf("could not read root block to populate cache: %w", err)
-	}
-	// sealed root height
-	err = operation.RetrieveSealedRootHeight(r, &sealedRootHeight)
-	if err != nil {
-		return nil, fmt.Errorf("could not read sealed root block to populate cache: %w", err)
+		return nil, fmt.Errorf("could not read instance params to populate cache: %w", err)
 	}
 
-	// look up 'finalized root block'
-	var finalizedRootID flow.Identifier
-	err = operation.LookupBlockHeight(r, finalizedRootHeight, &finalizedRootID)
-	if err != nil {
-		return nil, fmt.Errorf("could not look up finalized root height: %w", err)
-	}
-	params.finalizedRoot, err = headers.ByBlockID(finalizedRootID)
+	params.finalizedRoot, err = headers.ByBlockID(enc.FinalizedRootID)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve finalized root header: %w", err)
 	}
 
-	// look up the sealed block as of the 'finalized root block'
-	var sealedRootID flow.Identifier
-	err = operation.LookupBlockHeight(r, sealedRootHeight, &sealedRootID)
-	if err != nil {
-		return nil, fmt.Errorf("could not look up sealed root height: %w", err)
-	}
-	params.sealedRoot, err = headers.ByBlockID(sealedRootID)
+	params.sealedRoot, err = headers.ByBlockID(enc.SealedRootID)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve sealed root header: %w", err)
 	}
 
 	// retrieve the root seal
-	params.rootSeal, err = seals.HighestInFork(finalizedRootID)
+	params.rootSeal, err = seals.HighestInFork(enc.FinalizedRootID)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve root seal: %w", err)
 	}
@@ -101,28 +82,4 @@ func (p *InstanceParams) SealedRoot() *flow.Header {
 // `SealedRoot` block that was used to bootstrap this state. It may differ from node to node.
 func (p *InstanceParams) Seal() *flow.Seal {
 	return p.rootSeal
-}
-
-// ReadFinalizedRoot retrieves the root block's header from the database.
-// This information is immutable for the runtime of the software and may be cached.
-func ReadFinalizedRoot(r storage.Reader) (*flow.Header, error) {
-	// The values below are written during bootstrapping and immutable for the lifetime of the node. All
-	// following parameters are uniquely defined by the values initially read. No atomicity is required.
-	var finalizedRootHeight uint64
-	var rootID flow.Identifier
-	err := operation.RetrieveRootHeight(r, &finalizedRootHeight)
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve finalized root height: %w", err)
-	}
-	err = operation.LookupBlockHeight(r, finalizedRootHeight, &rootID) // look up root block ID
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve root header's ID by height: %w", err)
-	}
-
-	var rootHeader flow.Header
-	err = operation.RetrieveHeader(r, rootID, &rootHeader) // retrieve root header
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve root header: %w", err)
-	}
-	return &rootHeader, nil
 }

--- a/storage/operation/heights.go
+++ b/storage/operation/heights.go
@@ -9,22 +9,6 @@ import (
 	"github.com/onflow/flow-go/storage"
 )
 
-func InsertRootHeight(w storage.Writer, height uint64) error {
-	return UpsertByKey(w, MakePrefix(codeFinalizedRootHeight), height)
-}
-
-func RetrieveRootHeight(r storage.Reader, height *uint64) error {
-	return RetrieveByKey(r, MakePrefix(codeFinalizedRootHeight), height)
-}
-
-func InsertSealedRootHeight(w storage.Writer, height uint64) error {
-	return UpsertByKey(w, MakePrefix(codeSealedRootHeight), height)
-}
-
-func RetrieveSealedRootHeight(r storage.Reader, height *uint64) error {
-	return RetrieveByKey(r, MakePrefix(codeSealedRootHeight), height)
-}
-
 // UpsertFinalizedHeight upserts the finalized height index, overwriting the current value.
 // Updates to this index must strictly increase the finalized height.
 // To enforce this, the caller must check the current finalized height while holding [storage.LockFinalizeBlock].

--- a/storage/operation/instance_params.go
+++ b/storage/operation/instance_params.go
@@ -1,0 +1,35 @@
+package operation
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+)
+
+// EncodableInstanceParams is the consolidated, serializable form of protocol instance parameters
+// that are constant throughout the lifetime of a node.
+//
+// Fields:
+//   - FinalizedRootID: ID of the finalized root block used to bootstrap
+//   - SealedRootID: ID of the sealed root block
+type EncodableInstanceParams struct {
+	FinalizedRootID flow.Identifier
+	SealedRootID    flow.Identifier
+}
+
+// InsertInstanceParams stores the consolidated instance params under a single key.
+// If the key already exists, the value will be overwritten.
+// Error returns:
+//   - generic error in case of unexpected failure from the database layer or
+//     encoding failure.
+func InsertInstanceParams(w storage.Writer, params EncodableInstanceParams) error {
+	return UpsertByKey(w, MakePrefix(codeInstanceParams), params)
+}
+
+// RetrieveInstanceParams reads the consolidated instance params from storage.
+// Error returns:
+//   - storage.ErrNotFound if the key does not exist in the database
+//   - generic error in case of unexpected failure from the database layer, or failure
+//     to decode an existing database value
+func RetrieveInstanceParams(r storage.Reader, params *EncodableInstanceParams) error {
+	return RetrieveByKey(r, MakePrefix(codeInstanceParams), params)
+}

--- a/storage/operation/prefix.go
+++ b/storage/operation/prefix.go
@@ -30,10 +30,11 @@ const (
 	codeSealedHeight            = 21 // latest sealed block height
 	codeClusterHeight           = 22 // latest finalized height on cluster
 	codeExecutedBlock           = 23 // latest executed block with max height
-	codeFinalizedRootHeight     = 24 // the height of the highest finalized block contained in the root snapshot
+	codeFinalizedRootHeight     = 24 // DEPRECATED: 24 was used for the height of the highest finalized block contained in the root snapshot
 	codeLastCompleteBlockHeight = 25 // the height of the last block for which all collections were received
 	codeEpochFirstHeight        = 26 // the height of the first block in a given epoch
-	codeSealedRootHeight        = 27 // the height of the highest sealed block contained in the root snapshot
+	codeSealedRootHeight        = 27 // DEPRECATED: 27 was used for the height of the highest sealed block contained in the root snapshot
+	codeInstanceParams          = 28 // instance parameters which are constant throughout the lifetime of a node(finalized root, sealed root, root seal)
 
 	// codes for single entity storage
 	codeHeader               = 30


### PR DESCRIPTION
Closes #7837

## Context

- Refactored the storage of `InstanceParams` in `flow-go/state/protocol/badger/params.go`.
- Previously, the individual fields (`finalizedRoot`, `sealedRoot`, etc.) were stored separately, which added unnecessary complexity and overhead.

## Changes
- Store `InstanceParams` as a single data structure instead of multiple individual fields.
- Added support for including `SporkRootBlock` in `InstanceParams`.