### PR TITLE
Metric for emergency seals

### DIFF
--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -69,8 +69,8 @@ const (
 	ResourceProtocolStateByBlockID                           = "protocol_state_by_block_id"
 	ResourceProtocolKVStore                                  = "protocol_kv_store"
 	ResourceProtocolKVStoreByBlockID                         = "protocol_kv_store_by_block_id"
-	ResourceApproval                                         = "approval"
-	ResourceSeal                                             = "seal"
+	ResourceSeal                                             = "seal"           // block seals (including emergency seals)
+	ResourceEmergencySeal                                    = "emergency_seal" // any seal which does not include a verifier signature
 	ResourcePendingIncorporatedSeal                          = "pending_incorporated_seal"
 	ResourceCommit                                           = "commit"
 	ResourceTransaction                                      = "transaction"


### PR DESCRIPTION
This PR adds a resource label to existing block finalization metrics to count seals which don't include verifier signatures.

[Testing on Benchnet](https://flowfoundation.grafana.net/d/PkvVJj4Mz/mainnet-general?orgId=1&from=2025-09-10T16:03:01.045Z&to=2025-09-10T16:30:30.606Z&timezone=America%2FVancouver&var-network=seal-metrics&refresh=10s)

<img width="1193" height="362" alt="image" src="https://github.com/user-attachments/assets/1f372e6c-37d2-4af9-b5c0-20b4f9efc10f" />
From Benchnet testing, the first spike is from enabling emergency sealing on SN1 and shutting off VN1 (only VN). Second spike is from setting `--required-construction-seal-approvals=0` on SN1. This plots the number of emergency seals as a percentage of total seals. 

```
100 *
sum(increase(consensus_compliance_finalized_payload_total{resource="emergency_seal",network="seal-metrics"}[5m]))
/
sum(increase(consensus_compliance_finalized_payload_total{resource="seal",network="seal-metrics"}[5m]))
```