### PR TITLE
[Database] Remove execution data mode

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -161,7 +161,6 @@ type AccessNodeConfig struct {
 	rpcMetricsEnabled                    bool
 	executionDataSyncEnabled             bool
 	publicNetworkExecutionDataEnabled    bool
-	executionDataDBMode                  string
 	executionDataPrunerHeightRangeTarget uint64
 	executionDataPrunerThreshold         uint64
 	executionDataPruningInterval         time.Duration
@@ -277,7 +276,6 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 			MaxRetryDelay:      edrequester.DefaultMaxRetryDelay,
 		},
 		executionDataIndexingEnabled:         false,
-		executionDataDBMode:                  execution_data.ExecutionDataDBModePebble.String(),
 		executionDataPrunerHeightRangeTarget: 0,
 		executionDataPrunerThreshold:         pruner.DefaultThreshold,
 		executionDataPruningInterval:         pruner.DefaultPruningInterval,
@@ -591,7 +589,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 		Module("execution data datastore and blobstore", func(node *cmd.NodeConfig) error {
 			var err error
 			builder.ExecutionDatastoreManager, err = edstorage.CreateDatastoreManager(
-				node.Logger, builder.executionDataDir, builder.executionDataDBMode)
+				node.Logger, builder.executionDataDir)
 			if err != nil {
 				return fmt.Errorf("could not create execution data datastore manager: %w", err)
 			}
@@ -1362,10 +1360,13 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"execution-data-max-retry-delay",
 			defaultConfig.executionDataConfig.MaxRetryDelay,
 			"maximum delay for exponential backoff when fetching execution data fails e.g. 5m")
-		flags.StringVar(&builder.executionDataDBMode,
+
+		var builderexecutionDataDBMode string
+		flags.StringVar(&builderexecutionDataDBMode,
 			"execution-data-db",
-			defaultConfig.executionDataDBMode,
-			"[experimental] the DB type for execution datastore. One of [badger, pebble]")
+			"pebble",
+			"[deprecated] the DB type for execution datastore")
+
 		flags.Uint64Var(&builder.executionDataPrunerHeightRangeTarget,
 			"execution-data-height-range-target",
 			defaultConfig.executionDataPrunerHeightRangeTarget,

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -716,7 +716,7 @@ func (exeNode *ExecutionNode) LoadExecutionDataDatastore(
 	node *NodeConfig,
 ) (err error) {
 	exeNode.executionDataDatastore, err = edstorage.CreateDatastoreManager(
-		node.Logger, exeNode.exeConf.executionDataDir, exeNode.exeConf.executionDataDBMode)
+		node.Logger, exeNode.exeConf.executionDataDir)
 	if err != nil {
 		return fmt.Errorf("could not create execution data datastore manager: %w", err)
 	}

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -59,7 +59,6 @@ type ExecutionConfig struct {
 	importCheckpointWorkerCount           int
 	transactionExecutionMetricsEnabled    bool
 	transactionExecutionMetricsBufferSize uint
-	executionDataDBMode                   string
 	scheduleCallbacksEnabled              bool
 
 	computationConfig        computation.ComputationConfig
@@ -136,10 +135,12 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&exeConf.importCheckpointWorkerCount, "import-checkpoint-worker-count", 10, "number of workers to import checkpoint file during bootstrap")
 	flags.BoolVar(&exeConf.transactionExecutionMetricsEnabled, "tx-execution-metrics", true, "enable collection of transaction execution metrics")
 	flags.UintVar(&exeConf.transactionExecutionMetricsBufferSize, "tx-execution-metrics-buffer-size", 200, "buffer size for transaction execution metrics. The buffer size is the number of blocks that are kept in memory by the metrics provider engine")
-	flags.StringVar(&exeConf.executionDataDBMode,
+
+	var exeConfExecutionDataDBMode string
+	flags.StringVar(&exeConfExecutionDataDBMode,
 		"execution-data-db",
 		execution_data.ExecutionDataDBModePebble.String(),
-		"[experimental] the DB type for execution datastore. One of [badger, pebble]")
+		"[deprecated] the DB type for execution datastore. it's been deprecated")
 
 	flags.BoolVar(&exeConf.onflowOnlyLNs, "temp-onflow-only-lns", false, "do not use unless required. forces node to only request collections from onflow collection nodes")
 	flags.BoolVar(&exeConf.enableStorehouse, "enable-storehouse", false, "enable storehouse to store registers on disk, default is false")

--- a/integration/tests/access/cohort3/execution_state_sync_test.go
+++ b/integration/tests/access/cohort3/execution_state_sync_test.go
@@ -48,20 +48,14 @@ type ExecutionStateSyncSuite struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	net                 *testnet.FlowNetwork
-	executionDataDBMode execution_data.ExecutionDataDBMode
+	net *testnet.FlowNetwork
 }
 
 func (s *ExecutionStateSyncSuite) SetupTest() {
-	s.setup(execution_data.ExecutionDataDBModePebble)
-}
-
-func (s *ExecutionStateSyncSuite) setup(executionDataDBMode execution_data.ExecutionDataDBMode) {
 	s.log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 	s.log.Info().Msg("================> SetupTest")
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
-	s.executionDataDBMode = executionDataDBMode
 	s.buildNetworkConfig()
 
 	// start the network
@@ -95,7 +89,6 @@ func (s *ExecutionStateSyncSuite) buildNetworkConfig() {
 		testnet.WithAdditionalFlag(fmt.Sprintf("--execution-data-dir=%s", testnet.DefaultExecutionDataServiceDir)),
 		testnet.WithAdditionalFlag("--execution-data-retry-delay=1s"),
 		testnet.WithAdditionalFlagf("--public-network-execution-data-sync-enabled=true"),
-		testnet.WithAdditionalFlag(fmt.Sprintf("--execution-data-db=%s", s.executionDataDBMode.String())),
 	)
 
 	// add the ghost (access) node config
@@ -135,7 +128,6 @@ func (s *ExecutionStateSyncSuite) buildNetworkConfig() {
 			fmt.Sprintf("--execution-data-dir=%s", testnet.DefaultExecutionDataServiceDir),
 			"--execution-data-sync-enabled=true",
 			"--event-query-mode=execution-nodes-only",
-			fmt.Sprintf("--execution-data-db=%s", s.executionDataDBMode.String()),
 		},
 	}}
 
@@ -239,9 +231,7 @@ func (s *ExecutionStateSyncSuite) nodeExecutionDataStore(node *testnet.Container
 	var err error
 	dsPath := filepath.Join(node.ExecutionDataDBPath(), "blobstore")
 
-	if s.executionDataDBMode == execution_data.ExecutionDataDBModePebble {
-		ds, err = pebbleds.NewDatastore(dsPath, nil)
-	}
+	ds, err = pebbleds.NewDatastore(dsPath, nil)
 	require.NoError(s.T(), err, "could not get execution datastore")
 
 	return execution_data.NewExecutionDataStore(blobs.NewBlobstore(ds), execution_data.DefaultSerializer)

--- a/integration/tests/access/cohort3/pebble_execution_state_sync_test.go
+++ b/integration/tests/access/cohort3/pebble_execution_state_sync_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
-	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 )
 
 func TestPebbleExecutionStateSync(t *testing.T) {
@@ -14,10 +12,6 @@ func TestPebbleExecutionStateSync(t *testing.T) {
 
 type PebbleExecutionStateSync struct {
 	ExecutionStateSyncSuite
-}
-
-func (s *PebbleExecutionStateSync) SetupTest() {
-	s.setup(execution_data.ExecutionDataDBModePebble)
 }
 
 // TestPebbleDBHappyPath+ tests that Execution Nodes generate execution data, and Access Nodes are able to

--- a/module/executiondatasync/storage/datastore_factory.go
+++ b/module/executiondatasync/storage/datastore_factory.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/rs/zerolog"
-
-	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 )
 
 // CreateDatastoreManager creates a new datastore manager of the specified type.
@@ -15,7 +13,6 @@ import (
 func CreateDatastoreManager(
 	logger zerolog.Logger,
 	executionDataDir string,
-	executionDataDBModeStr string,
 ) (DatastoreManager, error) {
 
 	// create the datastore directory if it does not exist
@@ -25,24 +22,14 @@ func CreateDatastoreManager(
 		return nil, err
 	}
 
-	// parse the execution data DB mode
-	executionDataDBMode, err := execution_data.ParseExecutionDataDBMode(executionDataDBModeStr)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse execution data DB mode: %w", err)
-	}
-
 	// create the appropriate datastore manager based on the DB mode
 	var executionDatastoreManager DatastoreManager
-	if executionDataDBMode == execution_data.ExecutionDataDBModePebble {
-		logger.Info().Msgf("Using Pebble datastore for execution data at %s", datastoreDir)
-		executionDatastoreManager, err = NewPebbleDatastoreManager(
-			logger.With().Str("pebbledb", "endata").Logger(),
-			datastoreDir, nil)
-		if err != nil {
-			return nil, fmt.Errorf("could not create PebbleDatastoreManager for execution data: %w", err)
-		}
-	} else {
-		return nil, fmt.Errorf("does not support badger data store for execution data")
+	logger.Info().Msgf("Using Pebble datastore for execution data at %s", datastoreDir)
+	executionDatastoreManager, err = NewPebbleDatastoreManager(
+		logger.With().Str("pebbledb", "endata").Logger(),
+		datastoreDir, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not create PebbleDatastoreManager for execution data: %w", err)
 	}
 
 	return executionDatastoreManager, nil


### PR DESCRIPTION
This PR removes deprecated execution data mode flag, since we've deprecated badger db, and only support pebble db powered execution data store.