### PR TITLE
Add .dockerignore for .git/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+# Do not copy the user's project git directory into the container
+# it's not needed to build the project, and causes issues when working within git worktrees
+.git/
+
 integration/localnet/bootstrap/
 integration/localnet/profiler/
 integration/localnet/data/


### PR DESCRIPTION
This was breaking integration tests when run from a git worktree directory because docker failed to run `git config`.

```
 > [build-env 4/6] RUN git config --global url.git@github.com:.insteadOf https://github.com/:
0.090 fatal: not a git repository: /Users/peter/go/src/github.com/onflow/flow-go/.git/worktrees/sc-api-system-tx-id
```

Git worktrees use a symlink to the .git directory from the main checkout. When it is copied into the docker container, the symlink is broken, causing `git config` calls to break.

We don't actually need it to do any of the build operations, so just ignore it from the docker context.