### PR TITLE
[Access] Allow streaming from the spork root block

### DIFF
--- a/engine/access/state_stream/backend/backend_account_statuses_test.go
+++ b/engine/access/state_stream/backend/backend_account_statuses_test.go
@@ -128,7 +128,7 @@ func (s *BackendAccountStatusesSuite) subscribeFromStartBlockIdTestCases() []tes
 		{
 			name:            "happy path - all new blocks",
 			highestBackfill: -1, // no backfill
-			startValue:      s.rootBlock.ID(),
+			startValue:      s.blocks[0].ID(),
 		},
 		{
 			name:            "happy path - partial backfill",
@@ -139,11 +139,6 @@ func (s *BackendAccountStatusesSuite) subscribeFromStartBlockIdTestCases() []tes
 			name:            "happy path - complete backfill",
 			highestBackfill: len(s.blocks) - 1, // backfill all blocks
 			startValue:      s.blocks[0].ID(),
-		},
-		{
-			name:            "happy path - start from root block by id",
-			highestBackfill: len(s.blocks) - 1, // backfill all blocks
-			startValue:      s.rootBlock.ID(),  // start from root block
 		},
 	}
 
@@ -156,7 +151,7 @@ func (s *BackendAccountStatusesSuite) subscribeFromStartHeightTestCases() []test
 		{
 			name:            "happy path - all new blocks",
 			highestBackfill: -1, // no backfill
-			startValue:      s.rootBlock.Height,
+			startValue:      s.blocks[0].Height,
 		},
 		{
 			name:            "happy path - partial backfill",
@@ -167,11 +162,6 @@ func (s *BackendAccountStatusesSuite) subscribeFromStartHeightTestCases() []test
 			name:            "happy path - complete backfill",
 			highestBackfill: len(s.blocks) - 1, // backfill all blocks
 			startValue:      s.blocks[0].Height,
-		},
-		{
-			name:            "happy path - start from root block by id",
-			highestBackfill: len(s.blocks) - 1,  // backfill all blocks
-			startValue:      s.rootBlock.Height, // start from root block
 		},
 	}
 
@@ -311,33 +301,20 @@ func (s *BackendAccountStatusesSuite) subscribeToAccountStatuses(
 					s.broadcaster.Publish()
 				}
 
-				expectedEvents := map[string]flow.EventsList{}
-				for _, event := range s.blockEvents[b.ID()] {
-					if test.filters.Match(event) {
-						var address string
-						switch event.Type {
-						case state_stream.CoreEventAccountCreated:
-							address = s.accountCreatedAddress.HexWithPrefix()
-						case state_stream.CoreEventAccountContractAdded:
-							address = s.accountContractAdded.HexWithPrefix()
-						case state_stream.CoreEventAccountContractUpdated:
-							address = s.accountContractUpdated.HexWithPrefix()
-						}
-						expectedEvents[address] = append(expectedEvents[address], event)
-					}
-				}
+				expectedEvents := s.expectedAccountStatuses(b.ID(), test.filters)
 
 				// Consume execution data from subscription
 				unittest.RequireReturnsBefore(s.T(), func() {
 					v, ok := <-sub.Channel()
 					require.True(s.T(), ok, "channel closed while waiting for exec data for block %d %v: err: %v", b.Height, b.ID(), sub.Err())
 
-					resp, ok := v.(*AccountStatusesResponse)
-					require.True(s.T(), ok, "unexpected response type: %T", v)
+					expected := &AccountStatusesResponse{
+						BlockID:       b.ID(),
+						Height:        b.Height,
+						AccountEvents: expectedEvents,
+					}
+					s.requireEventsResponse(v, expected)
 
-					assert.Equal(s.T(), b.ID(), resp.BlockID)
-					assert.Equal(s.T(), b.Height, resp.Height)
-					assert.Equal(s.T(), expectedEvents, resp.AccountEvents)
 				}, 60*time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
 			}
 
@@ -408,6 +385,102 @@ func (s *BackendAccountStatusesSuite) TestSubscribeAccountStatusesFromLatestBloc
 	s.subscribeToAccountStatuses(call, s.subscribeFromLatestTestCases())
 }
 
+// requireEventsResponse ensures that the received event information matches the expected data.
+func (s *BackendAccountStatusesSuite) requireEventsResponse(v interface{}, expected *AccountStatusesResponse) {
+	actual, ok := v.(*AccountStatusesResponse)
+	require.True(s.T(), ok, "unexpected response type: %T", v)
+
+	assert.Equal(s.T(), expected.BlockID, actual.BlockID)
+	assert.Equal(s.T(), expected.Height, actual.Height)
+	assert.Equal(s.T(), expected.AccountEvents, actual.AccountEvents)
+}
+
+// TestSubscribeAccountStatusesFromSporkRootBlock tests that events subscriptions starting from the spork
+// root block return an empty result for the root block.
+func (s *BackendAccountStatusesSuite) TestSubscribeAccountStatusesFromSporkRootBlock() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// setup the backend to have 1 available block
+	s.highestBlockHeader = s.blocks[0].ToHeader()
+
+	rootEventResponse := &AccountStatusesResponse{
+		BlockID:       s.rootBlock.ID(),
+		Height:        s.rootBlock.Height,
+		AccountEvents: map[string]flow.EventsList{},
+	}
+
+	filter, err := state_stream.NewAccountStatusFilter(state_stream.DefaultEventFilterConfig, chainID.Chain(), []string{}, []string{})
+	require.NoError(s.T(), err)
+
+	expectedEvents := s.expectedAccountStatuses(s.blocks[0].ID(), filter)
+	firstEventResponse := &AccountStatusesResponse{
+		BlockID:       s.blocks[0].ID(),
+		Height:        s.blocks[0].Height,
+		AccountEvents: expectedEvents,
+	}
+
+	assertSubscriptionResponses := func(sub subscription.Subscription, cancel context.CancelFunc) {
+		// the first response should have details from the root block and no events
+		resp := <-sub.Channel()
+		s.requireEventsResponse(resp, rootEventResponse)
+
+		// the second response should have details from the first block and its events
+		resp = <-sub.Channel()
+		s.requireEventsResponse(resp, firstEventResponse)
+
+		cancel()
+		resp, ok := <-sub.Channel()
+		assert.False(s.T(), ok)
+		assert.Nil(s.T(), resp)
+		assert.ErrorIs(s.T(), sub.Err(), context.Canceled)
+	}
+
+	s.Run("by height", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromHeight", s.rootBlock.Height).
+			Return(func(startHeight uint64) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromHeight(startHeight)
+			})
+
+		sub := s.backend.SubscribeAccountStatusesFromStartHeight(subCtx, s.rootBlock.Height, filter)
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by ID", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromBlockID", s.rootBlock.ID()).
+			Return(func(startBlockID flow.Identifier) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromBlockID(startBlockID)
+			})
+
+		sub := s.backend.SubscribeAccountStatusesFromStartBlockID(subCtx, s.rootBlock.ID(), filter)
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by latest", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		// simulate the case where the latest block is also the root block
+		s.snapshot.On("Head").Unset()
+		s.snapshot.On("Head").Return(s.rootBlock.ToHeader(), nil).Once()
+
+		s.executionDataTracker.On("GetStartHeightFromLatest", mock.Anything).
+			Return(func(ctx context.Context) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromLatest(ctx)
+			})
+
+		sub := s.backend.SubscribeAccountStatusesFromLatestBlock(subCtx, filter)
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+}
+
 // TestSubscribeAccountStatusesHandlesErrors tests handling of expected errors in the SubscribeAccountStatuses.
 func (s *BackendExecutionDataSuite) TestSubscribeAccountStatusesHandlesErrors() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -454,4 +527,23 @@ func (s *BackendExecutionDataSuite) TestSubscribeAccountStatusesHandlesErrors() 
 		sub := s.backend.SubscribeAccountStatusesFromStartHeight(subCtx, s.blocks[len(s.blocks)-1].Height+10, state_stream.AccountStatusFilter{})
 		assert.Equal(s.T(), codes.NotFound, status.Code(sub.Err()), "expected NotFound, got %v: %v", status.Code(sub.Err()).String(), sub.Err())
 	})
+}
+
+func (s *BackendAccountStatusesSuite) expectedAccountStatuses(blockID flow.Identifier, filter state_stream.AccountStatusFilter) map[string]flow.EventsList {
+	expectedEvents := map[string]flow.EventsList{}
+	for _, event := range s.blockEvents[blockID] {
+		if filter.Match(event) {
+			var address string
+			switch event.Type {
+			case state_stream.CoreEventAccountCreated:
+				address = s.accountCreatedAddress.HexWithPrefix()
+			case state_stream.CoreEventAccountContractAdded:
+				address = s.accountContractAdded.HexWithPrefix()
+			case state_stream.CoreEventAccountContractUpdated:
+				address = s.accountContractUpdated.HexWithPrefix()
+			}
+			expectedEvents[address] = append(expectedEvents[address], event)
+		}
+	}
+	return expectedEvents
 }

--- a/engine/access/state_stream/backend/backend_events_test.go
+++ b/engine/access/state_stream/backend/backend_events_test.go
@@ -191,33 +191,21 @@ func (s *BackendEventsSuite) TestSubscribeEventsFromLatestFromLocalStorage() {
 func (s *BackendEventsSuite) runTestSubscribeEvents() {
 	tests := []eventsTestType{
 		{
-			name:            "happy path - all new blocks",
+			name:            "happy path - all new blocks - latest",
 			highestBackfill: -1, // no backfill
 			startBlockID:    flow.ZeroID,
 			startHeight:     0,
 		},
 		{
-			name:            "happy path - partial backfill",
+			name:            "happy path - partial backfill - by height",
 			highestBackfill: 2, // backfill the first 3 blocks
 			startBlockID:    flow.ZeroID,
 			startHeight:     s.blocks[0].Height,
 		},
 		{
-			name:            "happy path - complete backfill",
+			name:            "happy path - complete backfill - by id",
 			highestBackfill: len(s.blocks) - 1, // backfill all blocks
 			startBlockID:    s.blocks[0].ID(),
-			startHeight:     0,
-		},
-		{
-			name:            "happy path - start from root block by height",
-			highestBackfill: len(s.blocks) - 1, // backfill all blocks
-			startBlockID:    flow.ZeroID,
-			startHeight:     s.rootBlock.Height, // start from root block
-		},
-		{
-			name:            "happy path - start from root block by id",
-			highestBackfill: len(s.blocks) - 1, // backfill all blocks
-			startBlockID:    s.rootBlock.ID(),  // start from root block
 			startHeight:     0,
 		},
 	}
@@ -235,7 +223,7 @@ func (s *BackendEventsSuite) runTestSubscribeEventsFromStartBlockID() {
 		{
 			name:            "happy path - all new blocks",
 			highestBackfill: -1, // no backfill
-			startBlockID:    s.rootBlock.ID(),
+			startBlockID:    s.blocks[0].ID(),
 		},
 		{
 			name:            "happy path - partial backfill",
@@ -246,11 +234,6 @@ func (s *BackendEventsSuite) runTestSubscribeEventsFromStartBlockID() {
 			name:            "happy path - complete backfill",
 			highestBackfill: len(s.blocks) - 1, // backfill all blocks
 			startBlockID:    s.blocks[0].ID(),
-		},
-		{
-			name:            "happy path - start from root block by id",
-			highestBackfill: len(s.blocks) - 1, // backfill all blocks
-			startBlockID:    s.rootBlock.ID(),  // start from root block
 		},
 	}
 
@@ -274,7 +257,7 @@ func (s *BackendEventsSuite) runTestSubscribeEventsFromStartHeight() {
 		{
 			name:            "happy path - all new blocks",
 			highestBackfill: -1, // no backfill
-			startHeight:     s.rootBlock.Height,
+			startHeight:     s.blocks[0].Height,
 		},
 		{
 			name:            "happy path - partial backfill",
@@ -285,11 +268,6 @@ func (s *BackendEventsSuite) runTestSubscribeEventsFromStartHeight() {
 			name:            "happy path - complete backfill",
 			highestBackfill: len(s.blocks) - 1, // backfill all blocks
 			startHeight:     s.blocks[0].Height,
-		},
-		{
-			name:            "happy path - start from root block by id",
-			highestBackfill: len(s.blocks) - 1,  // backfill all blocks
-			startHeight:     s.rootBlock.Height, // start from root block
 		},
 	}
 
@@ -381,10 +359,10 @@ func (s *BackendEventsSuite) subscribe(
 
 			subCtx, subCancel := context.WithCancel(ctx)
 
-			// mock latest sealed if test case no start value provided
+			// mock latest sealed if test case has no start value provided
 			if test.startBlockID == flow.ZeroID && test.startHeight == 0 {
 				s.snapshot.On("Head").Unset()
-				s.snapshot.On("Head").Return(s.rootBlock.ToHeader(), nil).Once()
+				s.snapshot.On("Head").Return(s.blocks[0].ToHeader(), nil).Once()
 			}
 
 			sub := subscribeFn(subCtx, test.startBlockID, test.startHeight, test.filter)
@@ -452,6 +430,131 @@ func (s *BackendEventsSuite) requireEventsResponse(v interface{}, expected *Even
 	assert.Equal(s.T(), expected.Height, actual.Height)
 	assert.Equal(s.T(), expected.Events, actual.Events)
 	assert.Equal(s.T(), expected.BlockTimestamp, actual.BlockTimestamp)
+}
+
+// TestSubscribeEventsFromSporkRootBlock tests that events subscriptions starting from the spork
+// root block return an empty result for the root block.
+func (s *BackendEventsSuite) TestSubscribeEventsFromSporkRootBlock() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// setup the backend to have 1 available block
+	s.highestBlockHeader = s.blocks[0].ToHeader()
+
+	rootEventResponse := &EventsResponse{
+		BlockID:        s.rootBlock.ID(),
+		Height:         s.rootBlock.Height,
+		BlockTimestamp: time.UnixMilli(int64(s.rootBlock.Timestamp)).UTC(),
+	}
+
+	firstEventResponse := &EventsResponse{
+		BlockID:        s.blocks[0].ID(),
+		Height:         s.blocks[0].Height,
+		BlockTimestamp: time.UnixMilli(int64(s.blocks[0].Timestamp)).UTC(),
+		Events:         flow.EventsList(s.blockEvents[s.blocks[0].ID()]),
+	}
+
+	assertSubscriptionResponses := func(sub subscription.Subscription, cancel context.CancelFunc) {
+		// the first response should have details from the root block and no events
+		resp := <-sub.Channel()
+		s.requireEventsResponse(resp, rootEventResponse)
+
+		// the second response should have details from the first block and its events
+		resp = <-sub.Channel()
+		s.requireEventsResponse(resp, firstEventResponse)
+
+		cancel()
+		resp, ok := <-sub.Channel()
+		assert.False(s.T(), ok)
+		assert.Nil(s.T(), resp)
+		assert.ErrorIs(s.T(), sub.Err(), context.Canceled)
+	}
+
+	s.Run("by height", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromHeight", s.rootBlock.Height).
+			Return(func(startHeight uint64) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromHeight(startHeight)
+			})
+
+		sub := s.backend.SubscribeEventsFromStartHeight(subCtx, s.rootBlock.Height, state_stream.EventFilter{})
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by height - legacy", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromHeight", s.rootBlock.Height).
+			Return(func(startHeight uint64) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromHeight(startHeight)
+			})
+
+		sub := s.backend.SubscribeEvents(subCtx, flow.ZeroID, s.rootBlock.Height, state_stream.EventFilter{})
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by ID", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromBlockID", s.rootBlock.ID()).
+			Return(func(startBlockID flow.Identifier) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromBlockID(startBlockID)
+			})
+
+		sub := s.backend.SubscribeEventsFromStartBlockID(subCtx, s.rootBlock.ID(), state_stream.EventFilter{})
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by ID - legacy", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromBlockID", s.rootBlock.ID()).
+			Return(func(startBlockID flow.Identifier) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromBlockID(startBlockID)
+			})
+
+		sub := s.backend.SubscribeEvents(subCtx, s.rootBlock.ID(), 0, state_stream.EventFilter{})
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by latest", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		// simulate the case where the latest block is also the root block
+		s.snapshot.On("Head").Unset()
+		s.snapshot.On("Head").Return(s.rootBlock.ToHeader(), nil).Once()
+
+		s.executionDataTracker.On("GetStartHeightFromLatest", mock.Anything).
+			Return(func(ctx context.Context) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromLatest(ctx)
+			})
+
+		sub := s.backend.SubscribeEventsFromLatest(subCtx, state_stream.EventFilter{})
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by latest - legacy", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		// simulate the case where the latest block is also the root block
+		s.snapshot.On("Head").Unset()
+		s.snapshot.On("Head").Return(s.rootBlock.ToHeader(), nil).Once()
+
+		s.executionDataTracker.On("GetStartHeightFromLatest", mock.Anything).
+			Return(func(ctx context.Context) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromLatest(ctx)
+			})
+
+		sub := s.backend.SubscribeEvents(subCtx, flow.ZeroID, 0, state_stream.EventFilter{})
+		assertSubscriptionResponses(sub, subCancel)
+	})
 }
 
 // TestSubscribeEventsHandlesErrors tests error handling for SubscribeEvents subscription

--- a/engine/access/state_stream/backend/backend_executiondata_test.go
+++ b/engine/access/state_stream/backend/backend_executiondata_test.go
@@ -198,6 +198,10 @@ func (s *BackendExecutionDataSuite) SetupTestMocks() {
 	s.state.On("Sealed").Return(s.snapshot, nil).Maybe()
 	s.snapshot.On("Head").Return(s.blocks[0].ToHeader(), nil).Maybe()
 
+	s.state.On("Params").Return(s.params).Maybe()
+	s.params.On("SporkRootBlockHeight").Return(s.rootBlock.Height, nil).Maybe()
+	s.headers.On("BlockIDByHeight", s.rootBlock.Height).Return(s.rootBlock.ID(), nil).Maybe()
+
 	s.seals.On("FinalizedSealForBlock", mock.AnythingOfType("flow.Identifier")).Return(
 		mocks.StorageMapGetter(s.sealMap),
 	).Maybe()
@@ -371,18 +375,6 @@ func (s *BackendExecutionDataSuite) TestSubscribeExecutionData() {
 			startBlockID:    s.blocks[0].ID(),
 			startHeight:     0,
 		},
-		{
-			name:            "happy path - start from root block by height",
-			highestBackfill: len(s.blocks) - 1, // backfill all blocks
-			startBlockID:    flow.ZeroID,
-			startHeight:     s.rootBlock.Height, // start from root block
-		},
-		{
-			name:            "happy path - start from root block by id",
-			highestBackfill: len(s.blocks) - 1, // backfill all blocks
-			startBlockID:    s.rootBlock.ID(),  // start from root block
-			startHeight:     0,
-		},
 	}
 
 	subFunc := func(ctx context.Context, blockID flow.Identifier, startHeight uint64) subscription.Subscription {
@@ -397,7 +389,7 @@ func (s *BackendExecutionDataSuite) TestSubscribeExecutionDataFromStartBlockID()
 		{
 			name:            "happy path - all new blocks",
 			highestBackfill: -1, // no backfill
-			startBlockID:    s.rootBlock.ID(),
+			startBlockID:    s.blocks[0].ID(),
 		},
 		{
 			name:            "happy path - partial backfill",
@@ -408,11 +400,6 @@ func (s *BackendExecutionDataSuite) TestSubscribeExecutionDataFromStartBlockID()
 			name:            "happy path - complete backfill",
 			highestBackfill: len(s.blocks) - 1, // backfill all blocks
 			startBlockID:    s.blocks[0].ID(),
-		},
-		{
-			name:            "happy path - start from root block by id",
-			highestBackfill: len(s.blocks) - 1, // backfill all blocks
-			startBlockID:    s.rootBlock.ID(),  // start from root block
 		},
 	}
 
@@ -435,7 +422,7 @@ func (s *BackendExecutionDataSuite) TestSubscribeExecutionDataFromStartBlockHeig
 		{
 			name:            "happy path - all new blocks",
 			highestBackfill: -1, // no backfill
-			startHeight:     s.rootBlock.Height,
+			startHeight:     s.blocks[0].Height,
 		},
 		{
 			name:            "happy path - partial backfill",
@@ -446,11 +433,6 @@ func (s *BackendExecutionDataSuite) TestSubscribeExecutionDataFromStartBlockHeig
 			name:            "happy path - complete backfill",
 			highestBackfill: len(s.blocks) - 1, // backfill all blocks
 			startHeight:     s.blocks[0].Height,
-		},
-		{
-			name:            "happy path - start from root block by id",
-			highestBackfill: len(s.blocks) - 1,  // backfill all blocks
-			startHeight:     s.rootBlock.Height, // start from root block
 		},
 	}
 
@@ -561,6 +543,137 @@ func (s *BackendExecutionDataSuite) subscribe(subscribeFunc func(ctx context.Con
 			}, 100*time.Millisecond, "timed out waiting for subscription to shutdown")
 		})
 	}
+}
+
+// TestSubscribeEventsFromSporkRootBlock tests that events subscriptions starting from the spork
+// root block return an empty result for the root block.
+func (s *BackendExecutionDataSuite) TestSubscribeExecutionFromSporkRootBlock() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// setup the backend to have 1 available block
+	s.highestBlockHeader = s.blocks[0].ToHeader()
+
+	rootEventResponse := &ExecutionDataResponse{
+		Height: s.rootBlock.Height,
+		ExecutionData: &execution_data.BlockExecutionData{
+			BlockID: s.rootBlock.ID(),
+		},
+	}
+
+	firstEventResponse := &ExecutionDataResponse{
+		Height:        s.blocks[0].Height,
+		ExecutionData: s.execDataMap[s.blocks[0].ID()].BlockExecutionData,
+	}
+
+	assertExecutionDataResponse := func(v interface{}, expected *ExecutionDataResponse) {
+		resp, ok := v.(*ExecutionDataResponse)
+		require.True(s.T(), ok, "unexpected response type: %T", v)
+
+		assert.Equal(s.T(), expected, resp)
+	}
+
+	assertSubscriptionResponses := func(sub subscription.Subscription, cancel context.CancelFunc) {
+		// the first response should have details from the root block and no events
+		resp := <-sub.Channel()
+		assertExecutionDataResponse(resp, rootEventResponse)
+
+		// the second response should have details from the first block and its events
+		resp = <-sub.Channel()
+		assertExecutionDataResponse(resp, firstEventResponse)
+
+		cancel()
+		resp, ok := <-sub.Channel()
+		assert.False(s.T(), ok)
+		assert.Nil(s.T(), resp)
+		assert.ErrorIs(s.T(), sub.Err(), context.Canceled)
+	}
+
+	s.Run("by height", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromHeight", s.rootBlock.Height).
+			Return(func(startHeight uint64) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromHeight(startHeight)
+			})
+
+		sub := s.backend.SubscribeExecutionDataFromStartBlockHeight(subCtx, s.rootBlock.Height)
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by height - legacy", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromHeight", s.rootBlock.Height).
+			Return(func(startHeight uint64) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromHeight(startHeight)
+			})
+
+		sub := s.backend.SubscribeExecutionData(subCtx, flow.ZeroID, s.rootBlock.Height)
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by ID", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromBlockID", s.rootBlock.ID()).
+			Return(func(startBlockID flow.Identifier) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromBlockID(startBlockID)
+			})
+
+		sub := s.backend.SubscribeExecutionDataFromStartBlockID(subCtx, s.rootBlock.ID())
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by ID - legacy", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		s.executionDataTracker.On("GetStartHeightFromBlockID", s.rootBlock.ID()).
+			Return(func(startBlockID flow.Identifier) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromBlockID(startBlockID)
+			})
+
+		sub := s.backend.SubscribeExecutionData(subCtx, s.rootBlock.ID(), 0)
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by latest", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		// simulate the case where the latest block is also the root block
+		s.snapshot.On("Head").Unset()
+		s.snapshot.On("Head").Return(s.rootBlock.ToHeader(), nil).Once()
+
+		s.executionDataTracker.On("GetStartHeightFromLatest", mock.Anything).
+			Return(func(ctx context.Context) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromLatest(ctx)
+			})
+
+		sub := s.backend.SubscribeExecutionDataFromLatest(subCtx)
+		assertSubscriptionResponses(sub, subCancel)
+	})
+
+	s.Run("by latest - legacy", func() {
+		subCtx, subCancel := context.WithCancel(ctx)
+		defer subCancel()
+
+		// simulate the case where the latest block is also the root block
+		s.snapshot.On("Head").Unset()
+		s.snapshot.On("Head").Return(s.rootBlock.ToHeader(), nil).Once()
+
+		s.executionDataTracker.On("GetStartHeightFromLatest", mock.Anything).
+			Return(func(ctx context.Context) (uint64, error) {
+				return s.executionDataTrackerReal.GetStartHeightFromLatest(ctx)
+			})
+
+		sub := s.backend.SubscribeExecutionData(subCtx, flow.ZeroID, 0)
+		assertSubscriptionResponses(sub, subCancel)
+	})
 }
 
 func (s *BackendExecutionDataSuite) TestSubscribeExecutionDataHandlesErrors() {

--- a/engine/access/subscription/tracker/base_tracker.go
+++ b/engine/access/subscription/tracker/base_tracker.go
@@ -18,7 +18,6 @@ import (
 // BaseTracker is an interface for a tracker that provides base GetStartHeight method related to both blocks and execution data tracking.
 type BaseTracker interface {
 	// GetStartHeightFromBlockID returns the start height based on the provided starting block ID.
-	// If the start block is the root block, skip it and begin from the next block.
 	//
 	// Parameters:
 	// - startBlockID: The identifier of the starting block.
@@ -33,7 +32,6 @@ type BaseTracker interface {
 	GetStartHeightFromBlockID(flow.Identifier) (uint64, error)
 
 	// GetStartHeightFromHeight returns the start height based on the provided starting block height.
-	// If the start block is the root block, skip it and begin from the next block.
 	//
 	// Parameters:
 	// - startHeight: The height of the starting block.
@@ -48,7 +46,6 @@ type BaseTracker interface {
 	GetStartHeightFromHeight(uint64) (uint64, error)
 
 	// GetStartHeightFromLatest returns the start height based on the latest sealed block.
-	// If the start block is the root block, skip it and begin from the next block.
 	//
 	// Parameters:
 	// - ctx: Context for the operation.
@@ -88,7 +85,6 @@ func NewBaseTrackerImpl(
 }
 
 // GetStartHeightFromBlockID returns the start height based on the provided starting block ID.
-// If the start block is the root block, skip it and begin from the next block.
 //
 // Parameters:
 // - startBlockID: The identifier of the starting block.
@@ -107,11 +103,10 @@ func (b *BaseTrackerImpl) GetStartHeightFromBlockID(startBlockID flow.Identifier
 	}
 
 	// ensure that the resolved start height is available
-	return b.checkStartHeight(header.Height), nil
+	return header.Height, nil
 }
 
 // GetStartHeightFromHeight returns the start height based on the provided starting block height.
-// If the start block is the root block, skip it and begin from the next block.
 //
 // Parameters:
 // - startHeight: The height of the starting block.
@@ -134,11 +129,10 @@ func (b *BaseTrackerImpl) GetStartHeightFromHeight(startHeight uint64) (uint64, 
 	}
 
 	// ensure that the resolved start height is available
-	return b.checkStartHeight(header.Height), nil
+	return header.Height, nil
 }
 
 // GetStartHeightFromLatest returns the start height based on the latest sealed block.
-// If the start block is the root block, skip it and begin from the next block.
 //
 // Parameters:
 // - ctx: Context for the operation.
@@ -155,24 +149,5 @@ func (b *BaseTrackerImpl) GetStartHeightFromLatest(ctx context.Context) (uint64,
 		return 0, err
 	}
 
-	return b.checkStartHeight(header.Height), nil
-}
-
-// checkStartHeight validates the provided start height and adjusts it if necessary.
-// If the start block is the root block, skip it and begin from the next block.
-//
-// Parameters:
-// - height: The start height to be checked.
-//
-// Returns:
-// - uint64: The adjusted start height.
-//
-// No errors are expected during normal operation.
-func (b *BaseTrackerImpl) checkStartHeight(height uint64) uint64 {
-	// if the start block is the root block, skip it and begin from the next block.
-	if height == b.rootBlockHeight {
-		height = b.rootBlockHeight + 1
-	}
-
-	return height
+	return header.Height, nil
 }

--- a/engine/access/subscription/tracker/execution_data_tracker.go
+++ b/engine/access/subscription/tracker/execution_data_tracker.go
@@ -38,7 +38,6 @@ type ExecutionDataTracker interface {
 	// Only one of startBlockID and startHeight may be set. Otherwise, an InvalidArgument error is returned.
 	// If a block is provided and does not exist, a NotFound error is returned.
 	// If neither startBlockID nor startHeight is provided, the latest sealed block is used.
-	// If the start block is the root block, skip it and begin from the next block.
 	//
 	// Parameters:
 	// - ctx: Context for the operation.
@@ -117,7 +116,6 @@ func NewExecutionDataTracker(
 // Only one of startBlockID and startHeight may be set. Otherwise, an InvalidArgument error is returned.
 // If a block is provided and does not exist, a NotFound error is returned.
 // If neither startBlockID nor startHeight is provided, the latest sealed block is used.
-// If the start block is the root block, skip it and begin from the next block.
 //
 // Parameters:
 // - ctx: Context for the operation.


### PR DESCRIPTION
All of the streaming APIs had a special validation for their start height, that would skip the spork root block. This was a legacy check that is only needed when streaming data using `BlockExecutionData`. The issue was that there is no execution data for the spork root block, so rather than returning an error or an empty result, it simply skipped it. When using the local index, queries against the root block will correctly return empty results.

This was causing issues for the EVM GW, which streams data for events across the spork boundary.

This PR removes this check, and instead updates the logic that queries `BlockExecutionData` to simply return an empty result for the root block.

The bulk of the changes in this PR are updates to testing. The actual changes are in 
- `engine/access/state_stream/backend/backend.go`
- `engine/access/subscription/tracker/base_tracker.go`