### PR TITLE
Support account status v4 in checkpoint-collect-stats util

### DIFF
--- a/cmd/util/cmd/checkpoint-collect-stats/cmd.go
+++ b/cmd/util/cmd/checkpoint-collect-stats/cmd.go
@@ -476,7 +476,16 @@ func getRegisterType(key ledger.Key) string {
 		return "uuid generator state"
 	}
 	if strings.HasPrefix(kstr, "public_key_") {
-		return "public key"
+		return "legacy public key"
+	}
+	if kstr == "apk_0" {
+		return "account public key 0"
+	}
+	if strings.HasPrefix(kstr, flow.BatchPublicKeyRegisterKeyPrefix) {
+		return "batch public key"
+	}
+	if strings.HasPrefix(kstr, flow.SequenceNumberRegisterKeyPrefix) {
+		return "sequence number"
 	}
 	if strings.HasPrefix(kstr, flow.CodeKeyPrefix) {
 		return "contract content"


### PR DESCRIPTION
Closes #7924 
Updates #7573

The checkpoint-collect-stats subcommand reports unknown payload key if the payload is using the new data format using account status format v4.

The new data format was introduced by the migration PR https://github.com/onflow/flow-go/pull/7738 and testnet was migrated on Sept. 17, 2025.