### PR TITLE
[Access] Request collections immediately

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -137,6 +137,7 @@ func (suite *Suite) SetupTest() {
 
 	suite.request = new(mockmodule.Requester)
 	suite.request.On("EntityByID", mock.Anything, mock.Anything)
+	suite.request.On("Force").Return()
 
 	suite.me = new(mockmodule.Local)
 

--- a/engine/access/ingestion/collection_syncer.go
+++ b/engine/access/ingestion/collection_syncer.go
@@ -158,7 +158,7 @@ func (s *CollectionSyncer) requestMissingCollections() error {
 			Int("missing_collection_count", len(collections)).
 			Msg("re-requesting missing collections")
 
-		s.requestCollections(collections, false)
+		s.requestCollections(collections)
 	}
 
 	return nil

--- a/engine/access/ingestion/collection_syncer.go
+++ b/engine/access/ingestion/collection_syncer.go
@@ -178,7 +178,7 @@ func (s *CollectionSyncer) requestMissingCollectionsBlocking(ctx context.Context
 		return nil
 	}
 
-	s.requestCollections(missingCollections, true)
+	s.requestCollections(missingCollections)
 
 	collectionsToBeDownloaded := make(map[flow.Identifier]struct{})
 	for _, collection := range missingCollections {
@@ -304,12 +304,12 @@ func (s *CollectionSyncer) RequestCollectionsForBlock(height uint64, missingColl
 		return
 	}
 
-	s.requestCollections(missingCollections, false)
+	s.requestCollections(missingCollections)
 }
 
 // requestCollections registers collection download requests in the requester engine,
 // optionally forcing immediate dispatch.
-func (s *CollectionSyncer) requestCollections(collections []*flow.CollectionGuarantee, immediately bool) {
+func (s *CollectionSyncer) requestCollections(collections []*flow.CollectionGuarantee) {
 	for _, guarantee := range collections {
 		guarantors, err := protocol.FindGuarantors(s.state, guarantee)
 		if err != nil {
@@ -319,7 +319,7 @@ func (s *CollectionSyncer) requestCollections(collections []*flow.CollectionGuar
 		s.requester.EntityByID(guarantee.CollectionID, filter.HasNodeID[flow.Identity](guarantors...))
 	}
 
-	if immediately {
+	if len(collections) > 0 {
 		s.requester.Force()
 	}
 }

--- a/engine/access/ingestion/collection_syncer.go
+++ b/engine/access/ingestion/collection_syncer.go
@@ -307,7 +307,7 @@ func (s *CollectionSyncer) RequestCollectionsForBlock(height uint64, missingColl
 	s.requestCollections(missingCollections)
 }
 
-// requestCollections registers collection download requests in the requester engine and 
+// requestCollections registers collection download requests in the requester engine and
 // causes the requester to immediately dispatch requests.
 func (s *CollectionSyncer) requestCollections(collections []*flow.CollectionGuarantee) {
 	for _, guarantee := range collections {

--- a/engine/access/ingestion/collection_syncer.go
+++ b/engine/access/ingestion/collection_syncer.go
@@ -307,8 +307,8 @@ func (s *CollectionSyncer) RequestCollectionsForBlock(height uint64, missingColl
 	s.requestCollections(missingCollections)
 }
 
-// requestCollections registers collection download requests in the requester engine,
-// optionally forcing immediate dispatch.
+// requestCollections registers collection download requests in the requester engine and 
+// causes the requester to immediately dispatch requests.
 func (s *CollectionSyncer) requestCollections(collections []*flow.CollectionGuarantee) {
 	for _, guarantee := range collections {
 		guarantors, err := protocol.FindGuarantors(s.state, guarantee)

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -310,6 +310,9 @@ func (s *Suite) TestOnFinalizedBlockSingle() {
 		}).Once()
 	}
 
+	// force should be called once
+	s.request.On("Force").Return()
+
 	// process the block through the finalized callback
 	eng.OnFinalizedBlock(&hotstuffBlock)
 
@@ -375,6 +378,9 @@ func (s *Suite) TestOnFinalizedBlockSeveralBlocksAhead() {
 				wg.Done()
 			}).Once()
 		}
+		// force should be called once
+		s.request.On("Force").Return()
+
 		for _, seal := range block.Payload.Seals {
 			s.results.On("Index", seal.BlockID, seal.ResultID).Return(nil).Once()
 		}
@@ -717,6 +723,9 @@ func (s *Suite) TestProcessBackgroundCalls() {
 				s.request.On("EntityByID", cg.CollectionID, mock.Anything).Return().Once()
 			}
 		}
+
+		// force should be called once
+		s.request.On("Force").Return()
 
 		err := syncer.requestMissingCollections()
 		s.Require().NoError(err)

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -311,7 +311,7 @@ func (s *Suite) TestOnFinalizedBlockSingle() {
 	}
 
 	// force should be called once
-	s.request.On("Force").Return()
+	s.request.On("Force").Return().Once()
 
 	// process the block through the finalized callback
 	eng.OnFinalizedBlock(&hotstuffBlock)
@@ -379,7 +379,7 @@ func (s *Suite) TestOnFinalizedBlockSeveralBlocksAhead() {
 			}).Once()
 		}
 		// force should be called once
-		s.request.On("Force").Return()
+		s.request.On("Force").Return().Once()
 
 		for _, seal := range block.Payload.Seals {
 			s.results.On("Index", seal.BlockID, seal.ResultID).Return(nil).Once()
@@ -723,9 +723,8 @@ func (s *Suite) TestProcessBackgroundCalls() {
 				s.request.On("EntityByID", cg.CollectionID, mock.Anything).Return().Once()
 			}
 		}
-
 		// force should be called once
-		s.request.On("Force").Return()
+		s.request.On("Force").Return().Once()
 
 		err := syncer.requestMissingCollections()
 		s.Require().NoError(err)
@@ -752,6 +751,8 @@ func (s *Suite) TestProcessBackgroundCalls() {
 				s.request.On("EntityByID", cg.CollectionID, mock.Anything).Return().Once()
 			}
 		}
+		// force should be called once
+		s.request.On("Force").Return().Once()
 
 		err := syncer.requestMissingCollections()
 		s.Require().NoError(err)


### PR DESCRIPTION
Closes: #7929

Currently, Access nodes will batch collection requests within the requester engine, and allow the requester to decide when to send them. In the worst case, this could end up taking 2x the batch interval, which defaults to 1 second. We've observed that ANs tend to get collections 1-3 seconds after the block is finalized.

This PR updates ANs to send the collections request immediately after the block is finalized.