### PR TITLE
[Access] Request collections immediately - v0.42

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -133,6 +133,7 @@ func (suite *Suite) SetupTest() {
 
 	suite.request = new(mockmodule.Requester)
 	suite.request.On("EntityByID", mock.Anything, mock.Anything)
+	suite.request.On("Force").Return()
 
 	suite.me = new(mockmodule.Local)
 

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -299,6 +299,7 @@ func (s *Suite) TestOnFinalizedBlockSingle() {
 			wg.Done()
 		}).Once()
 	}
+	s.request.On("Force").Return().Once()
 
 	// process the block through the finalized callback
 	eng.OnFinalizedBlock(&hotstuffBlock)
@@ -365,6 +366,7 @@ func (s *Suite) TestOnFinalizedBlockSeveralBlocksAhead() {
 				wg.Done()
 			}).Once()
 		}
+		s.request.On("Force").Return().Once()
 		for _, seal := range block.Payload.Seals {
 			s.results.On("Index", seal.BlockID, seal.ResultID).Return(nil).Once()
 		}
@@ -724,6 +726,7 @@ func (s *Suite) TestProcessBackgroundCalls() {
 				s.request.On("EntityByID", cg.CollectionID, mock.Anything).Return().Once()
 			}
 		}
+		s.request.On("Force").Return().Once()
 
 		err := eng.checkMissingCollections()
 		s.Require().NoError(err)
@@ -750,6 +753,7 @@ func (s *Suite) TestProcessBackgroundCalls() {
 				s.request.On("EntityByID", cg.CollectionID, mock.Anything).Return().Once()
 			}
 		}
+		s.request.On("Force").Return().Once()
 
 		err := eng.checkMissingCollections()
 		s.Require().NoError(err)


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-go/pull/7926

Currently, Access nodes will batch collection requests within the requester engine, and allow the requester to decide when to send them. In the worst case, this could end up taking 2x the batch interval, which defaults to 1 second. We've observed that ANs tend to get collections 1-3 seconds after the block is finalized.

This PR updates ANs to send the collections request immediately after the block is finalized.