### PR TITLE
Prevent actions/stale from closing pull requests with "Preserve" label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,11 +7,12 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 90
           days-before-issue-close: 7
           exempt-issue-labels: 'Preserve,Idea'
+          exempt-pr-labels: 'Preserve'
           stale-issue-label: 'Stale'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
Closes #7935

This PR prevents `actions/stale` from closing pull requests with "Preserve" label.

Changes to stale.yml:
- added `exempt-pr-labels: 'Preserve'`
- bumped `actions/stale` from v9 to v10
