### PR TITLE
[CI] Fix codecov action args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
       timeout-minutes: 1
       continue-on-error: true
       with:
-        file: ./coverage.txt
+        files: ./coverage.txt
         flags: unittests
         name: codecov-umbrella
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -285,7 +285,7 @@ jobs:
         timeout-minutes: 1
         continue-on-error: true
         with:
-          file: ./coverage.txt
+          files: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -389,7 +389,7 @@ jobs:
         timeout-minutes: 1
         continue-on-error: true
         with:
-          file: ./coverage.txt
+          files: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
`file` was deprecated in favor of `files`
https://github.com/codecov/codecov-action#migration-guide