### PR TITLE
[Flow EVM] Add the `MaxGasConsumed` field in EVM `Result` type

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -675,7 +675,7 @@ func (proc *procedure) run(
 	// if pre-checks are passed, the exec result won't be nil
 	if execResult != nil {
 		res.GasConsumed = execResult.UsedGas
-		res.GasRefund = proc.state.GetRefund()
+		res.MaxGasConsumed = execResult.MaxUsedGas
 		res.Index = uint16(txIndex)
 		res.CumulativeGasUsed = execResult.UsedGas + proc.config.BlockTotalGasUsedSoFar
 		res.PrecompiledCalls, err = proc.config.PCTracker.CapturedCalls()

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -205,6 +205,8 @@ func TestEVMRun(t *testing.T) {
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
 				require.Empty(t, res.ErrorMessage)
 				require.Nil(t, res.DeployedContractAddress)
+				require.Equal(t, uint64(23_520), res.GasConsumed)
+				require.Equal(t, uint64(23_520), res.MaxGasConsumed)
 				require.Equal(t, num, new(big.Int).SetBytes(res.ReturnedData).Int64())
 			})
 	})

--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -1178,6 +1178,7 @@ func ResultSummaryFromEVMResultValue(val cadence.Value) (*types.ResultSummary, e
 		ErrorCode:               types.ErrorCode(errorCode),
 		ErrorMessage:            string(errorMsg),
 		GasConsumed:             uint64(gasUsed),
+		MaxGasConsumed:          uint64(gasUsed),
 		ReturnedData:            convertedData,
 		DeployedContractAddress: convertedDeployedAddress,
 	}, nil

--- a/fvm/evm/types/result.go
+++ b/fvm/evm/types/result.go
@@ -47,7 +47,7 @@ type ResultSummary struct {
 	ErrorCode               ErrorCode
 	ErrorMessage            string
 	GasConsumed             uint64
-	GasRefund               uint64
+	MaxGasConsumed          uint64
 	DeployedContractAddress *Address
 	ReturnedData            Data
 }
@@ -78,12 +78,12 @@ type Result struct {
 	// type of transaction defined by the evm package
 	// see DirectCallTxType as extra type we added type for direct calls.
 	TxType uint8
-	// total gas consumed during execution
+	// total gas consumed during execution, not including the refunded gas
 	GasConsumed uint64
+	// maximum gas consumed during execution, excluding gas refunds
+	MaxGasConsumed uint64
 	// total gas used by the block after this tx execution
 	CumulativeGasUsed uint64
-	// total gas refunds after transaction execution
-	GasRefund uint64
 	// the address where the contract is deployed (if any)
 	DeployedContractAddress *Address
 	// returned data from a function call
@@ -280,7 +280,7 @@ func (res *Result) LightReceipt() *LightReceipt {
 func (res *Result) ResultSummary() *ResultSummary {
 	rs := &ResultSummary{
 		GasConsumed:             res.GasConsumed,
-		GasRefund:               res.GasRefund,
+		MaxGasConsumed:          res.MaxGasConsumed,
 		DeployedContractAddress: res.DeployedContractAddress,
 		ReturnedData:            res.ReturnedData,
 		Status:                  StatusSuccessful,


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/7950

This field was added as part of https://github.com/ethereum/go-ethereum/pull/31735, and it basically replaced the `GasRefund` field.
The main usage for this field is for the gas estimation, which happens on EVM Gateway side.