### PR TITLE
Refactor notifier_test to use synctest

### DIFF
--- a/engine/notifier_test.go
+++ b/engine/notifier_test.go
@@ -183,8 +183,6 @@ func TestNotifier_AllWorkProcessed(t *testing.T) {
 
 			// wait for all producers and consumers to block. at this point, all jobs should be consumed.
 			synctest.Wait()
-
-			// verify all scheduled jobs were consumed.
 			assert.Equal(t, producerCount*producerJobs, consumedWork.Load())
 
 			// shutdown blocked consumers and wait for them to complete


### PR DESCRIPTION
`testing/synctest` allows for easy concurrency testing without needing to use sleeps. See the [blog post](https://go.dev/blog/synctest) going into detail on usage.

I believe the following updates achieve the same level of rigor in the test without using any wall clock delays. The original version takes 82 seconds to complete. This test takes 8 seconds to complete 2500 iteration.

```
$ go test -run "^TestNotifier_" github.com/onflow/flow-go/engine -count=1 
ok      github.com/onflow/flow-go/engine        82.776s
```
vs
```
$ go test -run "^TestNotifier_" github.com/onflow/flow-go/engine -count=2500
ok      github.com/onflow/flow-go/engine        8.126s
```