### PR TITLE
[Cadence VM] Handle invalid addresses

### DIFF
--- a/cmd/util/cmd/compare-cadence-vm/cmd.go
+++ b/cmd/util/cmd/compare-cadence-vm/cmd.go
@@ -87,7 +87,7 @@ func run(_ *cobra.Command, args []string) {
 
 	var remoteClient debug.RemoteClient
 	if flagUseExecutionDataAPI {
-		remoteClient, err = debug.NewExecutionDataRemoteClient(flagAccessAddress)
+		remoteClient, err = debug.NewExecutionDataRemoteClient(flagAccessAddress, chain)
 	} else if flagExecutionAddress != "" {
 		remoteClient, err = debug.NewExecutionNodeRemoteClient(flagExecutionAddress)
 	} else {

--- a/cmd/util/cmd/debug-script/cmd.go
+++ b/cmd/util/cmd/debug-script/cmd.go
@@ -101,7 +101,7 @@ func run(*cobra.Command, []string) {
 
 	var remoteClient debug.RemoteClient
 	if flagUseExecutionDataAPI {
-		remoteClient, err = debug.NewExecutionDataRemoteClient(flagAccessAddress)
+		remoteClient, err = debug.NewExecutionDataRemoteClient(flagAccessAddress, chain)
 	} else if flagExecutionAddress != "" {
 		remoteClient, err = debug.NewExecutionNodeRemoteClient(flagExecutionAddress)
 	} else {

--- a/cmd/util/cmd/debug-tx/cmd.go
+++ b/cmd/util/cmd/debug-tx/cmd.go
@@ -87,7 +87,7 @@ func run(_ *cobra.Command, args []string) {
 
 	var remoteClient debug.RemoteClient
 	if flagUseExecutionDataAPI {
-		remoteClient, err = debug.NewExecutionDataRemoteClient(flagAccessAddress)
+		remoteClient, err = debug.NewExecutionDataRemoteClient(flagAccessAddress, chain)
 	} else if flagExecutionAddress != "" {
 		remoteClient, err = debug.NewExecutionNodeRemoteClient(flagExecutionAddress)
 	} else {
@@ -421,13 +421,17 @@ func RunTransaction(
 	computeLimit uint64,
 ) debug.Result {
 
+	log := log.With().
+		Str("tx", tx.ID().String()).
+		Logger()
+
 	var fvmOptions []fvm.Option
 
 	if spanExporter != nil {
 
 		const sync = true
 		tracer, err := trace.NewTracerWithExporter(
-			log.Logger,
+			log,
 			"debug-tx",
 			string(chain.ChainID()),
 			trace.SensitivityCaptureAll,
@@ -450,13 +454,13 @@ func RunTransaction(
 
 	debugger := debug.NewRemoteDebugger(
 		chain,
-		log.Logger,
+		log,
 		useVM,
 		useVM,
 		fvmOptions...,
 	)
 
-	log.Info().Msgf("Running transaction %s ...", tx.ID())
+	log.Info().Msgf("Running transaction ...")
 
 	result, err := debugger.RunSDKTransaction(
 		tx,

--- a/utils/debug/remoteClient.go
+++ b/utils/debug/remoteClient.go
@@ -51,12 +51,13 @@ func (c *ExecutionNodeRemoteClient) Close() error {
 // ExecutionDataRemoteClient is a remote client that connects to an access node
 // and uses the execution data API to fetch execution data.
 type ExecutionDataRemoteClient struct {
-	conn *grpc.ClientConn
+	conn  *grpc.ClientConn
+	chain flow.Chain
 }
 
 var _ RemoteClient = &ExecutionDataRemoteClient{}
 
-func NewExecutionDataRemoteClient(address string) (*ExecutionDataRemoteClient, error) {
+func NewExecutionDataRemoteClient(address string, chain flow.Chain) (*ExecutionDataRemoteClient, error) {
 	accessConn, err := grpc.NewClient(
 		address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -66,7 +67,8 @@ func NewExecutionDataRemoteClient(address string) (*ExecutionDataRemoteClient, e
 	}
 
 	return &ExecutionDataRemoteClient{
-		conn: accessConn,
+		conn:  accessConn,
+		chain: chain,
 	}, nil
 }
 
@@ -75,7 +77,7 @@ func (c *ExecutionDataRemoteClient) StorageSnapshot(blockHeight uint64, _ flow.I
 
 	// The execution data API provides the *resulting* data,
 	// so fetch the data for the parent block for the *initial* data.
-	return NewExecutionDataStorageSnapshot(executionDataClient, blockHeight-1)
+	return NewExecutionDataStorageSnapshot(executionDataClient, c.chain, blockHeight-1)
 }
 
 func (c *ExecutionDataRemoteClient) Close() error {


### PR DESCRIPTION
Improve the remote debugging commands (`debug-tx`, `debug-script`, `compare-cadence-vm`).

The AN rejects register value requests for invalid addresses. Handle this gracefully and assume the register is empty.