### PR TITLE
[Access] Fix noisy and flaky unittests

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -3,7 +3,6 @@ package access_test
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -93,7 +92,7 @@ func TestAccess(t *testing.T) {
 
 func (suite *Suite) SetupTest() {
 	suite.lockManager = storage.NewTestingLockManager()
-	suite.log = zerolog.New(os.Stderr)
+	suite.log = unittest.Logger()
 	suite.net = new(mocknetwork.EngineRegistry)
 	suite.state = new(protocol.State)
 	suite.finalSnapshot = new(protocol.Snapshot)
@@ -774,6 +773,10 @@ func (suite *Suite) TestGetSealedTransaction() {
 		ctx := irrecoverable.NewMockSignalerContext(suite.T(), background)
 		ingestEng.Start(ctx)
 		<-ingestEng.Ready()
+		defer func() {
+			cancel()
+			<-ingestEng.Done()
+		}()
 
 		// 2. Ingest engine was notified by the follower engine about a new block.
 		// Follower engine --> Ingest engine

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -92,7 +92,7 @@ func (s *Suite) TearDownTest() {
 }
 
 func (s *Suite) SetupTest() {
-	s.log = zerolog.New(os.Stderr)
+	s.log = unittest.Logger()
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	db, dbDir := unittest.TempPebbleDB(s.T())
 	s.db = pebbleimpl.ToDB(db)

--- a/engine/access/ingestion/tx_error_messages/tx_error_messages_core_test.go
+++ b/engine/access/ingestion/tx_error_messages/tx_error_messages_core_test.go
@@ -3,7 +3,6 @@ package tx_error_messages
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	execproto "github.com/onflow/flow/protobuf/go/flow/execution"
@@ -72,7 +71,7 @@ type mockCloser struct{}
 func (mc *mockCloser) Close() error { return nil }
 
 func (s *TxErrorMessagesCoreSuite) SetupTest() {
-	s.log = zerolog.New(os.Stderr)
+	s.log = unittest.Logger()
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	// mock out protocol state
 	s.proto.state = protocol.NewFollowerState(s.T())

--- a/engine/access/ingestion/tx_error_messages/tx_error_messages_engine_test.go
+++ b/engine/access/ingestion/tx_error_messages/tx_error_messages_engine_test.go
@@ -82,7 +82,7 @@ func (s *TxErrorMessagesEngineSuite) TearDownTest() {
 }
 
 func (s *TxErrorMessagesEngineSuite) SetupTest() {
-	s.log = zerolog.New(os.Stderr)
+	s.log = unittest.Logger()
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	pdb, dbDir := unittest.TempPebbleDB(s.T())
 	s.db = pebbleimpl.ToDB(pdb)

--- a/engine/access/integration_unsecure_grpc_server_test.go
+++ b/engine/access/integration_unsecure_grpc_server_test.go
@@ -3,7 +3,6 @@ package access
 import (
 	"context"
 	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -96,7 +95,7 @@ type SameGRPCPortTestSuite struct {
 }
 
 func (suite *SameGRPCPortTestSuite) SetupTest() {
-	suite.log = zerolog.New(os.Stdout)
+	suite.log = unittest.Logger()
 	suite.net = new(network.EngineRegistry)
 	suite.state = new(protocol.State)
 	suite.snapshot = new(protocol.Snapshot)
@@ -315,6 +314,14 @@ func (suite *SameGRPCPortTestSuite) SetupTest() {
 	unittest.AssertClosesBefore(suite.T(), suite.rpcEng.Ready(), 2*time.Second)
 	// wait for the state stream engine to startup
 	unittest.AssertClosesBefore(suite.T(), suite.stateStreamEng.Ready(), 2*time.Second)
+}
+
+func (suite *SameGRPCPortTestSuite) TearDownTest() {
+	suite.cancel()
+	unittest.AssertClosesBefore(suite.T(), suite.secureGrpcServer.Done(), 2*time.Second)
+	unittest.AssertClosesBefore(suite.T(), suite.unsecureGrpcServer.Done(), 2*time.Second)
+	unittest.AssertClosesBefore(suite.T(), suite.rpcEng.Done(), 2*time.Second)
+	unittest.AssertClosesBefore(suite.T(), suite.stateStreamEng.Done(), 2*time.Second)
 }
 
 // TestEnginesOnTheSameGrpcPort verifies if both AccessAPI and ExecutionDataAPI client successfully connect and continue

--- a/engine/access/rest_api_test.go
+++ b/engine/access/rest_api_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -80,7 +79,7 @@ type RestAPITestSuite struct {
 }
 
 func (suite *RestAPITestSuite) SetupTest() {
-	suite.log = zerolog.New(os.Stdout)
+	suite.log = unittest.Logger()
 	suite.net = new(network.EngineRegistry)
 	suite.state = new(protocol.State)
 	suite.sealedSnaphost = new(protocol.Snapshot)

--- a/engine/access/rpc/backend/scripts/executor/compare.go
+++ b/engine/access/rpc/backend/scripts/executor/compare.go
@@ -31,7 +31,7 @@ func NewComparingScriptExecutor(
 	execNodeExecutor ScriptExecutor,
 ) *ComparingScriptExecutor {
 	return &ComparingScriptExecutor{
-		log:                   zerolog.New(log).With().Str("script_executor", "comparing").Logger(),
+		log:                   log.With().Str("script_executor", "comparing").Logger(),
 		metrics:               metrics,
 		scriptCache:           scriptCache,
 		localExecutor:         localExecutor,

--- a/engine/access/rpc/backend/scripts/executor/execution_node.go
+++ b/engine/access/rpc/backend/scripts/executor/execution_node.go
@@ -40,7 +40,7 @@ func NewENScriptExecutor(
 	scriptCache *LoggedScriptCache,
 ) *ENScriptExecutor {
 	return &ENScriptExecutor{
-		log:              zerolog.New(log).With().Str("script_executor", "execution_node").Logger(),
+		log:              log.With().Str("script_executor", "execution_node").Logger(),
 		metrics:          metrics,
 		nodeProvider:     nodeProvider,
 		nodeCommunicator: nodeCommunicator,

--- a/engine/access/rpc/backend/scripts/executor/local.go
+++ b/engine/access/rpc/backend/scripts/executor/local.go
@@ -32,7 +32,7 @@ func NewLocalScriptExecutor(
 	scriptCache *LoggedScriptCache,
 ) *LocalScriptExecutor {
 	return &LocalScriptExecutor{
-		log:            zerolog.New(log).With().Str("script_executor", "local").Logger(),
+		log:            log.With().Str("script_executor", "local").Logger(),
 		metrics:        metrics,
 		scriptCache:    scriptCache,
 		scriptExecutor: executor,

--- a/engine/access/rpc/backend/transactions/error_messages/provider_test.go
+++ b/engine/access/rpc/backend/transactions/error_messages/provider_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 
 	execproto "github.com/onflow/flow/protobuf/go/flow/execution"
@@ -64,8 +63,7 @@ func TestSuite(t *testing.T) {
 }
 
 func (suite *Suite) SetupTest() {
-	//suite.log = unittest.Logger()
-	suite.log = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout}).With().Timestamp().Logger()
+	suite.log = unittest.Logger()
 	suite.snapshot = protocolmock.NewSnapshot(suite.T())
 
 	header := unittest.BlockHeaderFixture()

--- a/engine/access/rpc/rate_limit_test.go
+++ b/engine/access/rpc/rate_limit_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -76,7 +75,7 @@ type RateLimitTestSuite struct {
 }
 
 func (suite *RateLimitTestSuite) SetupTest() {
-	suite.log = zerolog.New(os.Stdout)
+	suite.log = unittest.Logger()
 	suite.net = new(network.EngineRegistry)
 	suite.state = new(protocol.State)
 	suite.snapshot = new(protocol.Snapshot)

--- a/engine/access/secure_grpcr_test.go
+++ b/engine/access/secure_grpcr_test.go
@@ -3,7 +3,6 @@ package access
 import (
 	"context"
 	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -71,7 +70,7 @@ type SecureGRPCTestSuite struct {
 }
 
 func (suite *SecureGRPCTestSuite) SetupTest() {
-	suite.log = zerolog.New(os.Stdout)
+	suite.log = unittest.Logger()
 	suite.net = new(network.EngineRegistry)
 	suite.state = new(protocol.State)
 	suite.snapshot = new(protocol.Snapshot)

--- a/module/jobqueue/component_consumer_test.go
+++ b/module/jobqueue/component_consumer_test.go
@@ -3,12 +3,10 @@ package jobqueue
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -93,7 +91,7 @@ func (suite *ComponentConsumerSuite) prepareTest(
 	progressInitializer.On("Initialize", mock.AnythingOfType("uint64")).Return(progress, nil)
 
 	consumer, err := NewComponentConsumer(
-		zerolog.New(os.Stdout).With().Timestamp().Logger(),
+		unittest.Logger(),
 		workSignal,
 		progressInitializer,
 		jobs,


### PR DESCRIPTION
* use `unittest.Logger()` instead of logging to stdout/stderr
* ensure engine started during the test are shutdown properly. this was causing panics when the component continued attempting to write to pebble in some cases.