### PR TITLE
Suggested amendments for PR #7930

### DIFF
--- a/state/cluster/badger/snapshot.go
+++ b/state/cluster/badger/snapshot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	clusterState "github.com/onflow/flow-go/state/cluster"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/operation"
@@ -15,18 +16,28 @@ import (
 // Snapshot represents a snapshot of chain state anchored at a particular
 // reference block.
 type Snapshot struct {
-	err     error
 	state   *State
 	blockID flow.Identifier
 }
 
 var _ clusterState.Snapshot = (*Snapshot)(nil)
 
-func (s *Snapshot) Collection() (*flow.Collection, error) {
-	if s.err != nil {
-		return nil, s.err
+// newSnapshot instantiates a new snapshot for the given collection ID.
+// CAUTION: This constructor must be called for KNOWN blocks.
+// For unknown blocks, please use `invalid.NewSnapshot` or `invalid.NewSnapshotf`.
+func newSnapshot(state *State, blockID flow.Identifier) *Snapshot {
+	return &Snapshot{
+		state:   state,
+		blockID: blockID,
 	}
+}
 
+// Collection returns the collection designated as the reference for this
+// snapshot. Technically, this is a portion of the payload of a cluster block.
+//
+// By contract of the constructor, the blockID must correspond to a known collection in the database.
+// No error returns are expected during normal operation.
+func (s *Snapshot) Collection() (*flow.Collection, error) {
 	// get the payload
 	var payload cluster.Payload
 	err := procedure.RetrieveClusterPayload(s.state.db.Reader(), s.blockID, &payload)
@@ -38,37 +49,35 @@ func (s *Snapshot) Collection() (*flow.Collection, error) {
 	return &collection, nil
 }
 
+// Head returns the header of the collection that designated as the reference for this
+// snapshot.
+//
+// By contract of the constructor, the blockID must correspond to a known collection in the database.
+// No error returns are expected during normal operation.
 func (s *Snapshot) Head() (*flow.Header, error) {
-	if s.err != nil {
-		return nil, s.err
-	}
-
 	var head flow.Header
-	err := s.head(&head)
+	err := operation.RetrieveHeader(s.state.db.Reader(), s.blockID, &head)
+	if err != nil {
+		// `storage.ErrNotFound` is the only error that the storage layer may return other than exceptions.
+		// In the context of this call, `s.blockID` should correspond to a known block, so receiving a
+		// `storage.ErrNotFound` is an exception here.
+		return nil, irrecoverable.NewExceptionf("could not retrieve header for block (%s): %w", s.blockID, err)
+	}
 	return &head, err
 }
 
-// Pending returns all pending block IDs that descend from the snapshot's reference block.
-// Note, the caller must have checked that the block of the snapshot does exist in the database.
-// This is currently true, because the Snapshot instance is only created by AtBlockID and AtHeight
-// method of State, which both check the existence of the block first.
+// Pending returns the IDs of all collections descending from the snapshot's head collection.
+// The result is ordered such that parents are included before their children. While only valid
+// descendants will be returned, note that the descendants may not be finalized yet.
+// By contract of the constructor, the blockID must correspond to a known collection in the database.
+// No error returns are expected during normal operation.
 func (s *Snapshot) Pending() ([]flow.Identifier, error) {
-	if s.err != nil {
-		return nil, s.err
-	}
 	return s.pending(s.blockID)
 }
 
-// head finds the header referenced by the snapshot.
-func (s *Snapshot) head(head *flow.Header) error {
-	// get the snapshot header
-	err := operation.RetrieveHeader(s.state.db.Reader(), s.blockID, head)
-	if err != nil {
-		return fmt.Errorf("could not retrieve header for block (%s): %w", s.blockID, err)
-	}
-	return nil
-}
-
+// pending returns a slice with all blocks descending from the given blockID (children, grandchildren, etc).
+// CAUTION: this function behaves only correctly for known blocks. This is the case if and only if s.err == nil.
+// No error returns are expected during normal operation.
 func (s *Snapshot) pending(blockID flow.Identifier) ([]flow.Identifier, error) {
 	var pendingIDs flow.IdentifierList
 	err := operation.RetrieveBlockChildren(s.state.db.Reader(), blockID, &pendingIDs)
@@ -77,12 +86,12 @@ func (s *Snapshot) pending(blockID flow.Identifier) ([]flow.Identifier, error) {
 			return nil, fmt.Errorf("could not get pending block %v: %w", blockID, err)
 		}
 
-		// err not found means two case:
-		// 1. the block doesn't exist
-		// 2. the block exists but has no children
-		// since the snapshot is created only when s.err == nil, which means the block exists,
-		// so only case 2 is possible here. In this case, we just return
-		// empty children list.
+		// The low-level storage returns `storage.ErrNotFound` in two cases:
+		// 1. the block/collection is unknown
+		// 2. the block/collection is known but no children have been indexed yet
+		// By contract of the constructor, the blockID must correspond to a known collection in the database.
+		// A snapshot with s.err == nil is only created for known blocks. Hence, only case 2 is
+		// possible here, and we just return an empty list.
 	}
 
 	for _, pendingID := range pendingIDs {

--- a/state/cluster/badger/state.go
+++ b/state/cluster/badger/state.go
@@ -24,6 +24,8 @@ type State struct {
 	epoch     uint64       // the operating epoch for the cluster
 }
 
+var _ cluster.State = (*State)(nil)
+
 // Bootstrap initializes the persistent cluster state with a genesis block.
 // The genesis block must have height 0, a parent hash of 32 zero bytes,
 // and an empty collection as payload.
@@ -133,34 +135,21 @@ func (s *State) Params() cluster.Params {
 }
 
 func (s *State) Final() cluster.Snapshot {
-	// get the finalized block ID
-	var blockID flow.Identifier
-	err := (func(r storage.Reader) error {
-		var boundary uint64
-		err := operation.RetrieveClusterFinalizedHeight(r, s.clusterID, &boundary)
-		if err != nil {
-			return fmt.Errorf("could not retrieve finalized boundary: %w", err)
-		}
-
-		err = operation.LookupClusterBlockHeight(r, s.clusterID, boundary, &blockID)
-		if err != nil {
-			return fmt.Errorf("could not retrieve finalized ID: %w", err)
-		}
-
-		return nil
-	})(s.db.Reader())
-
+	// get height of latest finalized collection and then the ID of the collection with the corresponding height
+	r := s.db.Reader()
+	var latestFinalizedClusterHeight uint64
+	err := operation.RetrieveClusterFinalizedHeight(r, s.clusterID, &latestFinalizedClusterHeight)
 	if err != nil {
-		return &Snapshot{
-			err: err,
-		}
+		return invalid.NewSnapshotf("could not retrieve finalized boundary: %w", err)
 	}
 
-	snapshot := &Snapshot{
-		state:   s,
-		blockID: blockID,
+	var blockID flow.Identifier
+	err = operation.LookupClusterBlockHeight(r, s.clusterID, latestFinalizedClusterHeight, &blockID)
+	if err != nil {
+		return invalid.NewSnapshotf("could not retrieve finalized ID: %w", err)
 	}
-	return snapshot
+
+	return newSnapshot(s, blockID)
 }
 
 // AtBlockID returns the snapshot of the persistent cluster at the given
@@ -177,12 +166,7 @@ func (s *State) AtBlockID(blockID flow.Identifier) cluster.Snapshot {
 	if !exists {
 		return invalid.NewSnapshotf("unknown block %x: %w", blockID, state.ErrUnknownSnapshotReference)
 	}
-
-	snapshot := &Snapshot{
-		state:   s,
-		blockID: blockID,
-	}
-	return snapshot
+	return newSnapshot(s, blockID)
 }
 
 // IsBootstrapped returns whether the database contains a bootstrapped state.

--- a/state/cluster/snapshot.go
+++ b/state/cluster/snapshot.go
@@ -5,22 +5,32 @@ import (
 )
 
 // Snapshot represents an immutable snapshot at a specific point in the cluster
-// state history.
+// state history. Specifically, a valid snapshot references a [cluster.Block],
+// which designates the head of one specific cluster-consensus fork. This head
+// has
 type Snapshot interface {
 
-	// Collection returns the collection generated in this step of the cluster
-	// state history.
+	// Collection returns the collection designated as the reference for this
+	// snapshot. Technically, this is a portion of the payload of a cluster block.
+	//
+	// Expected error returns during normal operations:
+	//  - If the snapshot is for an unknown collection [state.ErrUnknownSnapshotReference]
 	Collection() (*flow.Collection, error)
 
-	// Head returns the latest block at the selected point of the cluster state
-	// history. If the snapshot was selected by block ID, returns the header
-	// with that block ID. If the snapshot was selected as final, returns the
-	// latest finalized block.
+	// Head returns the header of the collection that designated as the reference for this
+	// snapshot. Technically, this is the header of a [cluster.Block]
+	//
+	// Expected error returns during normal operations:
+	//  - If the snapshot is for an unknown collection [state.ErrUnknownSnapshotReference]
 	Head() (*flow.Header, error)
 
-	// Pending returns the IDs of all blocks descending from the snapshot head, which thus were
-	// potential extensions of the protocol state at this snapshot. The result
-	// is ordered such that parents are included before their children. These
-	// are NOT guaranteed to have been validated by HotStuff.
+	// Pending returns the IDs of all collections descending from the snapshot's head collection.
+	// The result is ordered such that parents are included before their children. While only valid
+	// descendants will be returned, note that the descendants may not be finalized yet.
+	//
+	// CAUTION: the list of descendants returned by this function is
+	//
+	// Expected error returns during normal operations:
+	//  - If the snapshot is for an unknown collection [state.ErrUnknownSnapshotReference]
 	Pending() ([]flow.Identifier, error)
 }


### PR DESCRIPTION
**Suggested amendments for PR https://github.com/onflow/flow-go/pull/7930**

_Context:_
* We are already assuming that the [cluster `Snapshot` implementation](https://github.com/onflow/flow-go/blob/bffeac9814d744e6bf22beb1412911db6fca242f/state/cluster/badger/snapshot.go#L83-L85) https://github.com/onflow/flow-go/blob/bffeac9814d744e6bf22beb1412911db6fca242f/state/cluster/badger/snapshot.go#L83-L85 is only created for _existing blocks_ (unless the [`Snapshot.err` field](https://github.com/onflow/flow-go/blob/bffeac9814d744e6bf22beb1412911db6fca242f/state/cluster/badger/snapshot.go#L18) is set). 
* We have a dedicated instance for invalid cluster snapshot. In addition, [cluster `Snapshot` implementation](https://github.com/onflow/flow-go/blob/bffeac9814d744e6bf22beb1412911db6fca242f/state/cluster/badger/snapshot.go#L83-L85) can also represent an invalid snapshot making its logic more complicated. 

_Overview of this PR:_
* changed [cluster `Snapshot` implementation](https://github.com/onflow/flow-go/blob/edd6ad1eccea66438bf311c3b8813485c40da85a/state/cluster/badger/snapshot.go#L16-L21) to only represent the happy path snapshot
* extended documentation of [cluster `Snapshot` implementation](https://github.com/onflow/flow-go/blob/edd6ad1eccea66438bf311c3b8813485c40da85a/state/cluster/badger/snapshot.go#L16-L21) _and_ it's interface
   * documented that [cluster `Snapshot` implementation](https://github.com/onflow/flow-go/blob/edd6ad1eccea66438bf311c3b8813485c40da85a/state/cluster/badger/snapshot.go#L16-L21) should only be created for existing blocks
   * Increased specificity of the cluster state snapshot, which is not specifically talking about collections 
   * I do not like that methods place expectations on the caller: https://github.com/onflow/flow-go/blob/bffeac9814d744e6bf22beb1412911db6fca242f/state/cluster/badger/snapshot.go#L52 Instead of requiring the caller to check, we should check at time of construction. This is addressed by introducing a constructor for the  [cluster `Snapshot` implementation](https://github.com/onflow/flow-go/blob/edd6ad1eccea66438bf311c3b8813485c40da85a/state/cluster/badger/snapshot.go#L16-L21) and clarified by introducing a constructors 