### PR TITLE
Change system chunk logging

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -586,6 +586,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		assert.LessOrEqual(t, vm.CallCount(), (1+totalTransactionCount)/2*totalTransactionCount)
 	})
 
+	// TODO: this test is flaky with a low probability of failing
 	t.Run(
 		"service events are emitted", func(t *testing.T) {
 			execCtx := fvm.NewContext(
@@ -1510,7 +1511,7 @@ func testScheduledCallbackWithError(t *testing.T, chain flow.Chain, callbackEven
 	exemetrics.On("ExecutionTransactionExecuted",
 		mock.Anything,
 		mock.MatchedBy(func(arg module.TransactionExecutionResultStats) bool {
-			return !arg.Failed && arg.SystemTransaction
+			return !arg.Failed && (arg.SystemTransaction || arg.ScheduledTransaction)
 		}),
 		mock.Anything).
 		Return(nil).

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -240,7 +240,7 @@ func (collector *resultCollector) processTransactionResult(
 			Logger()
 		logger.Info().Msg("transaction execution failed")
 
-		if txn.isSystemTransaction {
+		if txn.transactionType == ComputerTransactionTypeSystem {
 			// This log is used as the data source for an alert on grafana.
 			// The critical_error field must not be changed without adding
 			// the corresponding changes in grafana.
@@ -311,8 +311,8 @@ func (collector *resultCollector) handleTransactionExecutionMetrics(
 		ComputationIntensities:     output.ComputationIntensities,
 		NumberOfTxnConflictRetries: numConflictRetries,
 		Failed:                     output.Err != nil,
-		ScheduledTransaction:       txn.isScheduledTransaction,
-		SystemTransaction:          txn.isSystemTransaction,
+		ScheduledTransaction:       txn.transactionType == ComputerTransactionTypeScheduled,
+		SystemTransaction:          txn.transactionType == ComputerTransactionTypeSystem,
 	}
 	for _, entry := range txnExecutionSnapshot.UpdatedRegisters() {
 		transactionExecutionStats.NumberOfBytesWrittenToRegisters += len(entry.Value)

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -242,12 +242,9 @@ func (collector *resultCollector) processTransactionResult(
 
 		if txn.isSystemTransaction {
 			// This log is used as the data source for an alert on grafana.
-			// The system_chunk_error field must not be changed without adding
+			// The critical_error field must not be changed without adding
 			// the corresponding changes in grafana.
-			// https://github.com/dapperlabs/flow-internal/issues/1546
 			logger.Error().
-				Bool("system_chunk_error", true).
-				Bool("system_transaction_error", true).
 				Bool("critical_error", true).
 				Msg("error executing system chunk transaction")
 		}
@@ -314,6 +311,7 @@ func (collector *resultCollector) handleTransactionExecutionMetrics(
 		ComputationIntensities:     output.ComputationIntensities,
 		NumberOfTxnConflictRetries: numConflictRetries,
 		Failed:                     output.Err != nil,
+		ScheduledTransaction:       txn.isScheduledTransaction,
 		SystemTransaction:          txn.isSystemTransaction,
 	}
 	for _, entry := range txnExecutionSnapshot.UpdatedRegisters() {

--- a/engine/execution/computation/computer/transaction_coordinator_test.go
+++ b/engine/execution/computation/computer/transaction_coordinator_test.go
@@ -122,6 +122,8 @@ func (db *testCoordinator) newTransaction(txnIndex uint32) (
 			zerolog.Nop(),
 			txnIndex,
 			&flow.TransactionBody{},
+			false,
+			false,
 			false),
 		0)
 }

--- a/engine/execution/computation/computer/transaction_coordinator_test.go
+++ b/engine/execution/computation/computer/transaction_coordinator_test.go
@@ -122,8 +122,7 @@ func (db *testCoordinator) newTransaction(txnIndex uint32) (
 			zerolog.Nop(),
 			txnIndex,
 			&flow.TransactionBody{},
-			false,
-			false,
+			ComputerTransactionTypeUser,
 			false),
 		0)
 }

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -946,6 +946,7 @@ type TransactionExecutionResultStats struct {
 	ExecutionResultStats
 	NumberOfTxnConflictRetries int
 	Failed                     bool
+	ScheduledTransaction       bool
 	SystemTransaction          bool
 	ComputationIntensities     meter.MeteredComputationIntensities
 }

--- a/utils/unittest/fvm.go
+++ b/utils/unittest/fvm.go
@@ -5,27 +5,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
-
-func IsServiceEvent(event flow.Event, chainID flow.ChainID) bool {
-	serviceEvents := systemcontracts.ServiceEventsForChain(chainID)
-	for _, serviceEvent := range serviceEvents.All() {
-		if serviceEvent.EventType() == event.Type {
-			return true
-		}
-	}
-	return false
-}
 
 // EnsureEventsIndexSeq checks if values of given event index sequence are monotonically increasing.
 func EnsureEventsIndexSeq(t *testing.T, events []flow.Event, chainID flow.ChainID) {
 	expectedEventIndex := uint32(0)
 	for _, event := range events {
-		if expectedEventIndex != event.EventIndex {
-			require.Equal(t, expectedEventIndex, event.EventIndex)
-		}
 		require.Equal(t, expectedEventIndex, event.EventIndex)
 		expectedEventIndex++
 	}

--- a/utils/unittest/fvm.go
+++ b/utils/unittest/fvm.go
@@ -23,6 +23,9 @@ func IsServiceEvent(event flow.Event, chainID flow.ChainID) bool {
 func EnsureEventsIndexSeq(t *testing.T, events []flow.Event, chainID flow.ChainID) {
 	expectedEventIndex := uint32(0)
 	for _, event := range events {
+		if expectedEventIndex != event.EventIndex {
+			require.Equal(t, expectedEventIndex, event.EventIndex)
+		}
 		require.Equal(t, expectedEventIndex, event.EventIndex)
 		expectedEventIndex++
 	}


### PR DESCRIPTION
After changes from https://github.com/onflow/flow-go/pull/7944 the logs have the problem logs contain `"critical_error":true` even if the transaction was successfully executed.

I changed the semantics a little bit with the code and the logging. The `process` and the "old" system transaction are now considered to be system transactions, but the scheduled transactions are not.

Full log after https://github.com/onflow/flow-go/pull/7944.

```
{
  "level": "info",
  "node_role": "execution",
  "node_id": "5f6c73a22445d7d958c6a37c1f3be99c72cacd39894a3e46d6647a9adb007b4d",
  "module": "FVM",
  "block_id": "d2dbaa58604f13d1c3ec16654612cda6eeddc36a8d9cb8fb0ee321d3ef5eef16",
  "height": 282459901,
  "system_chunk": true,
  "system_transaction": true,
  "critical_error": true,
  "num_collections": 0,
  "num_txs": 2,
  "tx_id": "dadf3e1bf916f6cb2510cbea00ed9be78cc1b7d2b9ec29f0ef1d469ead2dda2d",
  "tx_index": 1,
  "computation_used": 128,
  "memory_used": 23252315,
  "time_spent_in_ms": 5,
  "normalized_time_per_computation": 0.39058593750000004,
  "time": "2025-09-30T17:39:14.704923103Z",
  "message": "transaction executed successfully"
}
```