### PR TITLE
[Access] Fix ExecutionResultInfoProvider for nodes bootstrapped after spork

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -2118,17 +2118,13 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				fixedENIdentifiers,
 			)
 
-			execResultInfoProvider, err := execution_result.NewExecutionResultInfoProvider(
+			execResultInfoProvider := execution_result.NewExecutionResultInfoProvider(
 				node.Logger,
 				node.State,
-				node.Storage.Headers,
 				node.Storage.Receipts,
 				execNodeSelector,
 				optimistic_sync.DefaultCriteria,
 			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create execution result provider: %w", err)
-			}
 
 			// TODO: use real objects instead of mocks once they're implemented
 			snapshot := osyncsnapshot.NewSnapshotMock(

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -1977,17 +1977,13 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 			fixedENIdentifiers,
 		)
 
-		execResultInfoProvider, err := execution_result.NewExecutionResultInfoProvider(
+		execResultInfoProvider := execution_result.NewExecutionResultInfoProvider(
 			node.Logger,
 			node.State,
-			node.Storage.Headers,
 			node.Storage.Receipts,
 			execNodeSelector,
 			optimistic_sync.DefaultCriteria,
 		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create execution result provider: %w", err)
-		}
 
 		// TODO: use real objects instead of mocks once they're implemented
 		snapshot := osyncsnapshot.NewSnapshotMock(

--- a/module/executiondatasync/optimistic_sync/execution_result/info_provider_test.go
+++ b/module/executiondatasync/optimistic_sync/execution_result/info_provider_test.go
@@ -62,17 +62,13 @@ func (suite *ExecutionResultInfoProviderSuite) createProvider(
 	preferredExecutors flow.IdentifierList,
 	operatorCriteria optimistic_sync.Criteria,
 ) *Provider {
-	provider, err := NewExecutionResultInfoProvider(
+	return NewExecutionResultInfoProvider(
 		suite.log,
 		suite.state,
-		suite.headers,
 		suite.receipts,
 		NewExecutionNodeSelector(preferredExecutors, operatorCriteria.RequiredExecutors),
 		operatorCriteria,
 	)
-	suite.Require().NoError(err)
-
-	return provider
 }
 
 // setupIdentitiesMock sets up the mock for identity-related calls.


### PR DESCRIPTION
Closes: #7864

The original version of the `ExecutionResultInfoProvider` returned an error if the node did not have the spork root block's result in storage. This broke nodes that were bootstrapped after the spork. Fixed to correctly handle this case.