### PR TITLE
[Access] Call ready when ping engine started

### DIFF
--- a/engine/access/ping/engine.go
+++ b/engine/access/ping/engine.go
@@ -95,6 +95,7 @@ func (e *Engine) pingLoop(ctx irrecoverable.SignalerContext, ready component.Rea
 	ticker := time.NewTicker(PingInterval)
 	defer ticker.Stop()
 
+	ready()
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
We never called ready, so nodes that run the ping engine (currently only FF's AN3) never completed node startup