### PR TITLE
Suggested amendments for PR `7995`

### DIFF
--- a/state/cluster/badger/mutator.go
+++ b/state/cluster/badger/mutator.go
@@ -347,7 +347,7 @@ func (m *MutableState) checkPayloadTransactions(lctx lockctx.Proof, ctx extendCo
 	}
 
 	// With the call of `checkDupeTransactionsInUnfinalizedAncestry` above, we have now scanned the candidate's ancestry
-	// up the height `ctx.finalizedClusterBlock + 1`. At the beginning of the `Extend` process, we verified (function
+	// down to the height `ctx.finalizedClusterBlock + 1`. At the beginning of the `Extend` process, we verified (function
 	// `checkConnectsToFinalizedState`) that the candidate block descends from the finalized block at height
 	// `ctx.finalizedClusterBlock`.
 	// The function `checkDupeTransactionsInFinalizedAncestry` below determines whether the finalized fork up to


### PR DESCRIPTION
Suggested amendments for [PR #7995](https://github.com/onflow/flow-go/pull/7995). 
**Documentation changes only**:
* [Context] In [#7995](https://github.com/onflow/flow-go/pull/7995), the documentation of the algorithm is great (thank you), but quite low level. We are documenting assumptions about other functions being called first on a higher level. These are very broadly important requirements, but almost buried in the business logic. I am worried they might be easily overlooked during future maintenance work, and hence more easily broken.
*  The function that ultimately is responsible for the correct ancestry being scanned for duplicates is `checkPayloadTransactions`. I propose to start there with a more formalized argument of why we scan the correct fork for duplicated transactions.

