### PR TITLE
[Access] reduce logging from execution data syncing

### DIFF
--- a/module/state_synchronization/requester/execution_data_requester.go
+++ b/module/state_synchronization/requester/execution_data_requester.go
@@ -410,7 +410,7 @@ func (e *executionDataRequester) processFetchRequest(parentCtx irrecoverable.Sig
 		parentCtx.Throw(err)
 	}
 
-	logger.Info().
+	logger.Debug().
 		Hex("execution_data_id", logging.ID(execData.ExecutionDataID)).
 		Msg("execution data fetched")
 


### PR DESCRIPTION
This message is logged for every block. it is rarely needed and the latest height is available from the metrics.