### PR TITLE
Apply any given `SetCodeAuthorization` list to `DryCall`

### DIFF
--- a/fvm/evm/offchain/query/view.go
+++ b/fvm/evm/offchain/query/view.go
@@ -110,6 +110,7 @@ func (v *View) DryCall(
 	from gethCommon.Address,
 	to gethCommon.Address,
 	data []byte,
+	authList []gethTypes.SetCodeAuthorization,
 	value *big.Int,
 	gasLimit uint64,
 	opts ...DryCallOption,
@@ -160,6 +161,13 @@ func (v *View) DryCall(
 	// not apply. These endpoints don't mutate the state, they
 	// simply read the state.
 	call.SkipTxGasLimitCheck()
+
+	// If we are given a non-empty list of SetCode authorizations,
+	// we need to set them, so that gas estimation works properly.
+	if len(authList) > 0 {
+		call.SetCodeAuthorizations(authList)
+	}
+
 	res, err := bv.DirectCall(call)
 	if err != nil {
 		return nil, err

--- a/fvm/evm/offchain/query/view_test.go
+++ b/fvm/evm/offchain/query/view_test.go
@@ -5,9 +5,11 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/onflow/flow-go/fvm/evm/handler"
@@ -91,6 +93,7 @@ func TestView(t *testing.T) {
 							testAccount.Address().ToCommon(),
 							testContract.DeployedAt.ToCommon(),
 							testContract.MakeCallData(t, "verifyArchCallToFlowBlockHeight", expectedFlowHeight),
+							[]gethTypes.SetCodeAuthorization{},
 							big.NewInt(0),
 							uint64(1_000_000),
 							query.WithExtraPrecompiledContracts(
@@ -110,6 +113,7 @@ func TestView(t *testing.T) {
 								testAccount.Address().ToCommon(),
 								newBalance,
 							),
+							[]gethTypes.SetCodeAuthorization{},
 							big.NewInt(0),
 							uint64(1_000_000),
 							query.WithStateOverrideBalance(
@@ -129,6 +133,7 @@ func TestView(t *testing.T) {
 								"store",
 								big.NewInt(2),
 							),
+							[]gethTypes.SetCodeAuthorization{},
 							big.NewInt(0),
 							params.MaxTxGas+1_000,
 						)
@@ -142,6 +147,7 @@ func TestView(t *testing.T) {
 								"store",
 								big.NewInt(2),
 							),
+							[]gethTypes.SetCodeAuthorization{},
 							big.NewInt(0),
 							maxCallGasLimit+1,
 						)
@@ -151,6 +157,29 @@ func TestView(t *testing.T) {
 							err,
 							"gas limit is bigger than max gas limit allowed 26777217 > 26777216",
 						)
+
+						// test non-empty SetCode authorization list
+						_, err = view.DryCall(
+							testAccount.Address().ToCommon(),
+							testContract.DeployedAt.ToCommon(),
+							testContract.MakeCallData(t,
+								"store",
+								big.NewInt(2),
+							),
+							[]gethTypes.SetCodeAuthorization{
+								gethTypes.SetCodeAuthorization{
+									ChainID: *uint256.NewInt(747),
+									Address: common.HexToAddress("0xD370975A6257fE8CeF93101799D602D30838BAad"),
+									Nonce:   1,
+									V:       28,
+									R:       *RandomUint256Int(15_000_000),
+									S:       *RandomUint256Int(15_000_000),
+								},
+							},
+							big.NewInt(0),
+							maxCallGasLimit,
+						)
+						require.NoError(t, err)
 					})
 				})
 		})
@@ -186,6 +215,7 @@ func TestViewStateOverrides(t *testing.T) {
 								testAccount.Address().ToCommon(),
 								testContract.DeployedAt.ToCommon(),
 								testContract.MakeCallData(t, "retrieve"),
+								nil,
 								big.NewInt(0),
 								uint64(1_000_000),
 								query.WithStateOverrideState(
@@ -225,6 +255,7 @@ func TestViewStateOverrides(t *testing.T) {
 								testAccount.Address().ToCommon(),
 								testContract.DeployedAt.ToCommon(),
 								testContract.MakeCallData(t, "retrieve"),
+								nil,
 								big.NewInt(0),
 								uint64(1_000_000),
 								query.WithStateOverrideStateDiff(
@@ -264,6 +295,7 @@ func TestViewStateOverrides(t *testing.T) {
 								testAccount.Address().ToCommon(),
 								testContract.DeployedAt.ToCommon(),
 								testContract.MakeCallData(t, "retrieve"),
+								nil,
 								big.NewInt(0),
 								uint64(1_000_000),
 								query.WithStateOverrideState(
@@ -304,6 +336,7 @@ func TestViewStateOverrides(t *testing.T) {
 								testAccount.Address().ToCommon(),
 								testContract.DeployedAt.ToCommon(),
 								testContract.MakeCallData(t, "retrieve"),
+								nil,
 								big.NewInt(0),
 								uint64(1_000_000),
 								query.WithStateOverrideStateDiff(
@@ -346,6 +379,7 @@ func TestViewStateOverrides(t *testing.T) {
 								testAccount.Address().ToCommon(),
 								newContractAddress,
 								testContract.MakeCallData(t, "retrieve"),
+								nil,
 								big.NewInt(0),
 								uint64(1_000_000),
 								query.WithStateOverrideCode(
@@ -391,6 +425,7 @@ func TestViewStateOverrides(t *testing.T) {
 								testAccount.Address().ToCommon(),
 								newContractAddress,
 								testContract.MakeCallData(t, "retrieve"),
+								nil,
 								big.NewInt(0),
 								uint64(1_000_000),
 								query.WithStateOverrideCode(

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -58,6 +58,10 @@ type DirectCall struct {
 	// Sets whether we skip or apply the EIP-7825 tx gas limit cap,
 	// introduced in `Osaka` hard-fork
 	skipTxGasLimitCheck bool
+
+	// setCodeAuthorizations is an authorization list from an account
+	// to deploy code at its address. Useful for EIP-7702 transactions.
+	setCodeAuthorizations []gethTypes.SetCodeAuthorization
 }
 
 // DirectCallFromEncoded constructs a DirectCall from encoded data
@@ -88,15 +92,16 @@ func (dc *DirectCall) Hash() gethCommon.Hash {
 // Message constructs a core.Message from the direct call
 func (dc *DirectCall) Message() *gethCore.Message {
 	return &gethCore.Message{
-		From:      dc.From.ToCommon(),
-		To:        dc.to(),
-		Value:     dc.Value,
-		Data:      dc.Data,
-		Nonce:     dc.Nonce,
-		GasLimit:  dc.GasLimit,
-		GasPrice:  big.NewInt(0), // price is set to zero fo direct calls
-		GasTipCap: big.NewInt(0), // also known as maxPriorityFeePerGas (in GWei)
-		GasFeeCap: big.NewInt(0), // also known as maxFeePerGas (in GWei)
+		From:                  dc.From.ToCommon(),
+		To:                    dc.to(),
+		Value:                 dc.Value,
+		Data:                  dc.Data,
+		Nonce:                 dc.Nonce,
+		GasLimit:              dc.GasLimit,
+		GasPrice:              big.NewInt(0),            // price is set to zero fo direct calls
+		GasTipCap:             big.NewInt(0),            // also known as maxPriorityFeePerGas (in GWei)
+		GasFeeCap:             big.NewInt(0),            // also known as maxFeePerGas (in GWei)
+		SetCodeAuthorizations: dc.setCodeAuthorizations, // introduced in EIP-7702 tx type
 		// TODO: maybe revisit setting the access list
 		// AccessList:        tx.AccessList(),
 		// When SkipNonceChecks is true, the message nonce is
@@ -141,6 +146,14 @@ func (dc *DirectCall) EmptyToField() bool {
 // SkipTxGasLimitCheck disables the EIP-7825 transaction gas limit cap
 func (dc *DirectCall) SkipTxGasLimitCheck() {
 	dc.skipTxGasLimitCheck = true
+}
+
+// SetCodeAuthorizations sets the given code authorizaions for EIP-7702
+// transaction types
+func (dc *DirectCall) SetCodeAuthorizations(
+	authList []gethTypes.SetCodeAuthorization,
+) {
+	dc.setCodeAuthorizations = authList
 }
 
 // ValidEIP7825GasLimit checks whether the `GasLimit` of the direct call


### PR DESCRIPTION
Work Towards: https://github.com/onflow/flow-evm-gateway/issues/920

This is only used off-chain, for gas estimation on EVM Gateway.