### PR TITLE
Add MonotonicEmulator to transient chains

### DIFF
--- a/model/flow/chain.go
+++ b/model/flow/chain.go
@@ -59,7 +59,7 @@ func AllChainIDs() ChainIDList {
 
 // Transient returns whether the chain ID is for a transient network.
 func (c ChainID) Transient() bool {
-	return c == Emulator || c == Localnet || c == Benchnet || c == BftTestnet || c == Previewnet
+	return c == Emulator || c == MonotonicEmulator || c == Localnet || c == Benchnet || c == BftTestnet || c == Previewnet
 }
 
 // getChainCodeWord derives the network type used for address generation from the globally


### PR DESCRIPTION
Adds missing `MonotonicEmulator` chain.  This was causing issues with the Cadence test framework, since the scheduled transaction child executor account was not being created in the latest versions of flow-go.

Closes #8158