### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -671,7 +671,6 @@ func generateEvents(t *testing.T, collection *flow.Collection, includeServiceEve
 	// service events are also included as regular events
 	if includeServiceEvent {
 		for _, e := range serviceEventsList {
-			e := e
 			event, err := convert.ServiceEvent(testChain, e)
 			require.NoError(t, err)
 

--- a/module/component/component.go
+++ b/module/component/component.go
@@ -264,7 +264,6 @@ func (c *ComponentManager) Start(parent irrecoverable.SignalerContext) {
 
 	// launch workers
 	for _, worker := range c.workers {
-		worker := worker
 		go func() {
 			defer workersDone.Done()
 			var readyOnce sync.Once

--- a/module/component/component_manager_test.go
+++ b/module/component/component_manager_test.go
@@ -531,8 +531,6 @@ func (c *ComponentManagerMachine) ExecuteStateTransition(t *rapid.T) {
 	}
 
 	for i, workerId := range st.workerIDs {
-		i := i
-		workerId := workerId
 		addTransition(func() {
 			wst := st.workerTransitions[i]
 			t.Logf("executing worker %v transition: %v\n", workerId, wst)

--- a/module/executiondatasync/execution_data/downloader.go
+++ b/module/executiondatasync/execution_data/downloader.go
@@ -105,8 +105,6 @@ func (d *downloader) Get(ctx context.Context, executionDataID flow.Identifier) (
 	var mu sync.Mutex
 
 	for i, chunkDataID := range edRoot.ChunkExecutionDataIDs {
-		i := i
-		chunkDataID := chunkDataID
 
 		g.Go(func() error {
 			ced, cids, err := d.getChunkExecutionData(

--- a/module/executiondatasync/provider/provider.go
+++ b/module/executiondatasync/provider/provider.go
@@ -160,8 +160,6 @@ func (p *ExecutionDataProvider) provide(ctx context.Context, blockHeight uint64,
 
 	chunkDataIDs := make([]cid.Cid, len(executionData.ChunkExecutionDatas))
 	for i, chunkExecutionData := range executionData.ChunkExecutionDatas {
-		i := i
-		chunkExecutionData := chunkExecutionData
 
 		g.Go(func() error {
 			logger.Debug().Int("chunk_index", i).Msg("adding chunk execution data")

--- a/module/mempool/queue/heroQueue_test.go
+++ b/module/mempool/queue/heroQueue_test.go
@@ -73,7 +73,6 @@ func TestHeroQueue_Concurrent(t *testing.T) {
 	entities := unittest.EntityListFixture(uint(sizeLimit))
 	// pushing entities concurrently.
 	for _, e := range entities {
-		e := e // suppress loop variable
 		go func() {
 			require.True(t, q.Push(e.Identifier, e))
 			pushWG.Done()

--- a/module/mempool/queue/heroStore_test.go
+++ b/module/mempool/queue/heroStore_test.go
@@ -56,7 +56,6 @@ func TestHeroStore_Concurrent(t *testing.T) {
 	messages := unittest.EngineMessageFixtures(sizeLimit)
 	// putting messages concurrently.
 	for _, m := range messages {
-		m := m
 		go func() {
 			require.True(t, store.Put(m))
 			putWG.Done()

--- a/module/state_synchronization/requester/unittest/unittest.go
+++ b/module/state_synchronization/requester/unittest/unittest.go
@@ -29,7 +29,6 @@ func MockBlobService(bs blockstore.Blockstore) *mocknetwork.BlobService {
 			wg.Add(len(cids))
 
 			for _, c := range cids {
-				c := c
 				go func() {
 					defer wg.Done()
 

--- a/module/trace/trace_test.go
+++ b/module/trace/trace_test.go
@@ -43,7 +43,6 @@ func BenchmarkStartBlockSpan(b *testing.B) {
 		{name: "cacheHit", n: 100},
 		{name: "cacheMiss", n: 100000},
 	} {
-		t := t
 		b.Run(t.name, func(b *testing.B) {
 			randomIDs := make([]flow.Identifier, 0, t.n)
 			for i := 0; i < t.n; i++ {

--- a/module/util/util_test.go
+++ b/module/util/util_test.go
@@ -138,8 +138,6 @@ func TestMergeChannels(t *testing.T) {
 		channels := []chan int{make(chan int), make(chan int), make(chan int)}
 		merged := util.MergeChannels(channels).(<-chan int)
 		for i, ch := range channels {
-			i := i
-			ch := ch
 			go func() {
 				ch <- i
 				close(ch)

--- a/network/alsp/internal/cache_test.go
+++ b/network/alsp/internal/cache_test.go
@@ -539,7 +539,6 @@ func TestSpamRecordCache_ConcurrentInitAndRemove(t *testing.T) {
 
 	// initialize spam records concurrently
 	for _, originID := range originIDsToAdd {
-		originID := originID // capture range variable
 		go func() {
 			defer wg.Done()
 			penalty, err := cache.AdjustWithInit(originID, adjustFnNoOp)
@@ -612,7 +611,6 @@ func TestSpamRecordCache_ConcurrentInitRemoveAdjust(t *testing.T) {
 
 	// Initialize spam records concurrently
 	for _, originID := range originIDsToAdd {
-		originID := originID // capture range variable
 		go func() {
 			defer wg.Done()
 			penalty, err := cache.AdjustWithInit(originID, adjustFnNoOp)
@@ -684,7 +682,6 @@ func TestSpamRecordCache_ConcurrentInitRemoveAndAdjust(t *testing.T) {
 
 	// initialize spam records concurrently
 	for _, originID := range originIDsToAdd {
-		originID := originID
 		go func() {
 			defer wg.Done()
 			penalty, err := cache.AdjustWithInit(originID, adjustFnNoOp)
@@ -695,7 +692,6 @@ func TestSpamRecordCache_ConcurrentInitRemoveAndAdjust(t *testing.T) {
 
 	// remove spam records concurrently
 	for _, originID := range originIDsToRemove {
-		originID := originID
 		go func() {
 			defer wg.Done()
 			cache.Remove(originID)
@@ -704,7 +700,6 @@ func TestSpamRecordCache_ConcurrentInitRemoveAndAdjust(t *testing.T) {
 
 	// adjust spam records concurrently
 	for _, originID := range originIDsToAdjust {
-		originID := originID
 		go func() {
 			defer wg.Done()
 			_, err := cache.AdjustWithInit(originID, func(record *model.ProtocolSpamRecord) (*model.ProtocolSpamRecord, error) {
@@ -773,7 +768,6 @@ func TestSpamRecordCache_ConcurrentIdentitiesAndOperations(t *testing.T) {
 
 	// initialize spam records concurrently
 	for _, originID := range originIDsToAdd {
-		originID := originID
 		go func() {
 			defer wg.Done()
 			penalty, err := cache.AdjustWithInit(originID, adjustFnNoOp)
@@ -787,7 +781,6 @@ func TestSpamRecordCache_ConcurrentIdentitiesAndOperations(t *testing.T) {
 
 	// remove spam records concurrently
 	for _, originID := range originIDsToRemove {
-		originID := originID
 		go func() {
 			defer wg.Done()
 			require.True(t, cache.Remove(originID))

--- a/network/p2p/scoring/internal/subscriptionCache_test.go
+++ b/network/p2p/scoring/internal/subscriptionCache_test.go
@@ -258,7 +258,6 @@ func TestSubscriptionCache_ConcurrentUpdate(t *testing.T) {
 	// verify that all peers have all topics; concurrently
 	allTopicsVerified := sync.WaitGroup{}
 	for _, pid := range peerIds {
-		pid := pid
 		allTopicsVerified.Add(1)
 		go func() {
 			defer allTopicsVerified.Done()

--- a/network/p2p/test/fixtures.go
+++ b/network/p2p/test/fixtures.go
@@ -752,7 +752,6 @@ func EnsureNoPubsubMessageExchange(t *testing.T,
 
 	wg := &sync.WaitGroup{}
 	for _, node := range from {
-		node := node // capture range variable
 		for i := 0; i < count; i++ {
 			wg.Add(1)
 			go func() {

--- a/network/p2p/tracer/internal/rpc_sent_tracker_test.go
+++ b/network/p2p/tracer/internal/rpc_sent_tracker_test.go
@@ -54,7 +54,6 @@ func TestRPCSentTracker_IHave(t *testing.T) {
 		}
 		iHaves := make([]*pb.ControlIHave, len(testCases))
 		for i, testCase := range testCases {
-			testCase := testCase
 			iHaves[i] = &pb.ControlIHave{
 				MessageIDs: testCase.messageIDS,
 			}


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore