### PR TITLE
Improve conversion of Flow address to Cadence address

### DIFF
--- a/cmd/util/ledger/migrations/account_based_migration_test.go
+++ b/cmd/util/ledger/migrations/account_based_migration_test.go
@@ -21,7 +21,7 @@ func accountStatusPayload(address common.Address) *ledger.Payload {
 
 	return ledger.NewPayload(
 		convert.RegisterIDToLedgerKey(
-			flow.AccountStatusRegisterID(flow.ConvertAddress(address)),
+			flow.AccountStatusRegisterID(flow.Address(address)),
 		),
 		accountStatus.ToBytes(),
 	)

--- a/cmd/util/ledger/migrations/add_key_migration.go
+++ b/cmd/util/ledger/migrations/add_key_migration.go
@@ -128,7 +128,7 @@ func (m *AddKeyMigration) MigrateAccount(
 		return err
 	}
 
-	account, err := migrationRuntime.Accounts.Get(flow.ConvertAddress(address))
+	account, err := migrationRuntime.Accounts.Get(flow.Address(address))
 	if err != nil {
 		return fmt.Errorf("could not find account at address %s", address)
 	}
@@ -147,7 +147,7 @@ func (m *AddKeyMigration) MigrateAccount(
 		Weight:    fvm.AccountKeyWeightThreshold,
 	}
 
-	flowAddress := flow.ConvertAddress(address)
+	flowAddress := flow.Address(address)
 
 	keyIndex, err := migrationRuntime.Accounts.GetAccountPublicKeyCount(flowAddress)
 	if err != nil {

--- a/cmd/util/ledger/migrations/cadence_value_diff_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff_test.go
@@ -193,7 +193,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			accountStatus := environment.NewAccountStatus()
 			accountStatusPayload := ledger.NewPayload(
 				convert.RegisterIDToLedgerKey(
-					flow.AccountStatusRegisterID(flow.ConvertAddress(address)),
+					flow.AccountStatusRegisterID(flow.Address(address)),
 				),
 				accountStatus.ToBytes(),
 			)
@@ -313,7 +313,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			accountStatus := environment.NewAccountStatus()
 			accountStatusPayload := ledger.NewPayload(
 				convert.RegisterIDToLedgerKey(
-					flow.AccountStatusRegisterID(flow.ConvertAddress(address)),
+					flow.AccountStatusRegisterID(flow.Address(address)),
 				),
 				accountStatus.ToBytes(),
 			)
@@ -432,7 +432,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			accountStatus := environment.NewAccountStatus()
 			accountStatusPayload := ledger.NewPayload(
 				convert.RegisterIDToLedgerKey(
-					flow.AccountStatusRegisterID(flow.ConvertAddress(address)),
+					flow.AccountStatusRegisterID(flow.Address(address)),
 				),
 				accountStatus.ToBytes(),
 			)
@@ -562,7 +562,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			accountStatus := environment.NewAccountStatus()
 			accountStatusPayload := ledger.NewPayload(
 				convert.RegisterIDToLedgerKey(
-					flow.AccountStatusRegisterID(flow.ConvertAddress(address)),
+					flow.AccountStatusRegisterID(flow.Address(address)),
 				),
 				accountStatus.ToBytes(),
 			)
@@ -703,7 +703,7 @@ func createStorageMapRegisters(
 	accountStatus := environment.NewAccountStatus()
 	accountStatusPayload := ledger.NewPayload(
 		convert.RegisterIDToLedgerKey(
-			flow.AccountStatusRegisterID(flow.ConvertAddress(address)),
+			flow.AccountStatusRegisterID(flow.Address(address)),
 		),
 		accountStatus.ToBytes(),
 	)
@@ -759,7 +759,7 @@ func createTestRegisters(t *testing.T, address common.Address, domain common.Sto
 	accountStatus := environment.NewAccountStatus()
 	accountStatusPayload := ledger.NewPayload(
 		convert.RegisterIDToLedgerKey(
-			flow.AccountStatusRegisterID(flow.ConvertAddress(address)),
+			flow.AccountStatusRegisterID(flow.Address(address)),
 		),
 		accountStatus.ToBytes(),
 	)

--- a/cmd/util/ledger/migrations/storage_used_migration_test.go
+++ b/cmd/util/ledger/migrations/storage_used_migration_test.go
@@ -32,7 +32,7 @@ func TestAccountStatusMigration(t *testing.T) {
 
 	sizeOfTheStatusPayload := uint64(
 		environment.RegisterSize(
-			flow.AccountStatusRegisterID(flow.ConvertAddress(address)),
+			flow.AccountStatusRegisterID(flow.Address(address)),
 			environment.NewAccountStatus().ToBytes(),
 		),
 	)
@@ -210,7 +210,7 @@ func TestAccountStatusMigration(t *testing.T) {
 
 		dataRegisterSize := uint64(environment.RegisterSize(
 			flow.RegisterID{
-				Owner: string(flow.ConvertAddress(address).Bytes()),
+				Owner: string(flow.Address(address).Bytes()),
 				Key:   "1",
 			},
 			make([]byte, 100),

--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -217,7 +217,7 @@ func (c *balanceProcessor) reportAccountData(indx uint64) {
 		return
 	}
 
-	runtimeAddress := common.MustBytesToAddress(address.Bytes())
+	runtimeAddress := common.Address(address)
 
 	u, err := c.env.GetStorageUsed(runtimeAddress)
 	if err != nil {

--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -309,7 +309,7 @@ func CreateAccountsWithSimpleAddresses(
 					stdlib.AccountEventAddressParameter.Identifier,
 				).(cadence.Address)
 
-				addr = flow.ConvertAddress(address)
+				addr = flow.Address(address)
 				break
 			}
 		}

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -80,7 +80,7 @@ func createAccount(
 
 	event := data.(cadence.Event)
 
-	address := flow.ConvertAddress(
+	address := flow.Address(
 		cadence.SearchFieldByName(
 			event,
 			stdlib.AccountEventAddressParameter.Identifier,
@@ -401,7 +401,7 @@ func TestCreateAccount(t *testing.T) {
 
 				event := data.(cadence.Event)
 
-				address := flow.ConvertAddress(
+				address := flow.Address(
 					cadence.SearchFieldByName(
 						event,
 						stdlib.AccountEventAddressParameter.Identifier,
@@ -454,7 +454,7 @@ func TestCreateAccount(t *testing.T) {
 
 					event := data.(cadence.Event)
 
-					address := flow.ConvertAddress(
+					address := flow.Address(
 						cadence.SearchFieldByName(
 							event,
 							stdlib.AccountEventAddressParameter.Identifier,

--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -266,10 +266,10 @@ func (creator *accountCreator) CreateAccount(
 	// don't enforce limit during account creation
 	var address flow.Address
 	creator.txnState.RunWithMeteringDisabled(func() {
-		address, err = creator.createAccount(flow.ConvertAddress(runtimePayer))
+		address, err = creator.createAccount(flow.Address(runtimePayer))
 	})
 
-	return common.MustBytesToAddress(address.Bytes()), err
+	return common.Address(address), err
 }
 
 func (creator *accountCreator) createAccount(

--- a/fvm/environment/account_info.go
+++ b/fvm/environment/account_info.go
@@ -179,7 +179,7 @@ func (info *accountInfo) GetStorageUsed(
 	}
 
 	value, err := info.accounts.GetStorageUsed(
-		flow.ConvertAddress(runtimeAddress))
+		flow.Address(runtimeAddress))
 	if err != nil {
 		return 0, fmt.Errorf("get storage used failed: %w", err)
 	}
@@ -214,7 +214,7 @@ func (info *accountInfo) GetStorageCapacity(
 	}
 
 	result, invokeErr := info.systemContracts.AccountStorageCapacity(
-		flow.ConvertAddress(runtimeAddress))
+		flow.Address(runtimeAddress))
 	if invokeErr != nil {
 		return 0, invokeErr
 	}
@@ -243,7 +243,7 @@ func (info *accountInfo) GetAccountBalance(
 		return 0, fmt.Errorf("get account balance failed: %w", err)
 	}
 
-	result, invokeErr := info.systemContracts.AccountBalance(flow.ConvertAddress(runtimeAddress))
+	result, invokeErr := info.systemContracts.AccountBalance(flow.Address(runtimeAddress))
 	if invokeErr != nil {
 		return 0, invokeErr
 	}
@@ -270,7 +270,7 @@ func (info *accountInfo) GetAccountAvailableBalance(
 		return 0, fmt.Errorf("get account available balance failed: %w", err)
 	}
 
-	result, invokeErr := info.systemContracts.AccountAvailableBalance(flow.ConvertAddress(runtimeAddress))
+	result, invokeErr := info.systemContracts.AccountAvailableBalance(flow.Address(runtimeAddress))
 	if invokeErr != nil {
 		return 0, invokeErr
 	}
@@ -293,7 +293,7 @@ func (info *accountInfo) GetAccount(
 
 	if info.serviceAccountEnabled {
 		balance, err := info.GetAccountBalance(
-			common.MustBytesToAddress(address.Bytes()))
+			common.Address(address))
 		if err != nil {
 			return nil, err
 		}

--- a/fvm/environment/account_key_reader.go
+++ b/fvm/environment/account_key_reader.go
@@ -117,7 +117,7 @@ func (reader *accountKeyReader) GetAccountKey(
 		return formatErr(err)
 	}
 
-	address := flow.ConvertAddress(runtimeAddress)
+	address := flow.Address(runtimeAddress)
 
 	// address verification is also done in this step
 	accountPublicKey, err := reader.accounts.GetRuntimeAccountPublicKey(
@@ -168,7 +168,8 @@ func (reader *accountKeyReader) AccountKeysCount(
 
 	// address verification is also done in this step
 	keyCount, err := reader.accounts.GetAccountPublicKeyCount(
-		flow.ConvertAddress(runtimeAddress))
+		flow.Address(runtimeAddress),
+	)
 
 	return keyCount, err
 }

--- a/fvm/environment/account_key_updater.go
+++ b/fvm/environment/account_key_updater.go
@@ -362,10 +362,11 @@ func (updater *accountKeyUpdater) AddAccountKey(
 	}
 
 	accKey, err := updater.addAccountKey(
-		flow.ConvertAddress(runtimeAddress),
+		flow.Address(runtimeAddress),
 		publicKey,
 		hashAlgo,
-		weight)
+		weight,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("add account key failed: %w", err)
 	}
@@ -393,6 +394,7 @@ func (updater *accountKeyUpdater) RevokeAccountKey(
 	}
 
 	return updater.revokeAccountKey(
-		flow.ConvertAddress(runtimeAddress),
-		keyIndex)
+		flow.Address(runtimeAddress),
+		keyIndex,
+	)
 }

--- a/fvm/environment/account_local_id_generator.go
+++ b/fvm/environment/account_local_id_generator.go
@@ -77,6 +77,6 @@ func (generator *accountLocalIDGenerator) GenerateAccountID(
 	}
 
 	return generator.accounts.GenerateAccountLocalID(
-		flow.ConvertAddress(runtimeAddress),
+		flow.Address(runtimeAddress),
 	)
 }

--- a/fvm/environment/account_local_id_generator_test.go
+++ b/fvm/environment/account_local_id_generator_test.go
@@ -29,7 +29,7 @@ func Test_accountLocalIDGenerator_GenerateAccountID(t *testing.T) {
 		).Return(nil)
 
 		accounts := envMock.NewAccounts(t)
-		accounts.On("GenerateAccountLocalID", flow.ConvertAddress(address)).
+		accounts.On("GenerateAccountLocalID", flow.Address(address)).
 			Return(uint64(1), nil)
 
 		generator := environment.NewAccountLocalIDGenerator(
@@ -78,7 +78,7 @@ func Test_accountLocalIDGenerator_GenerateAccountID(t *testing.T) {
 		).Return(nil)
 
 		accounts := envMock.NewAccounts(t)
-		accounts.On("GenerateAccountLocalID", flow.ConvertAddress(address)).
+		accounts.On("GenerateAccountLocalID", flow.Address(address)).
 			Return(uint64(0), expectedErr)
 
 		generator := environment.NewAccountLocalIDGenerator(

--- a/fvm/environment/contract_reader.go
+++ b/fvm/environment/contract_reader.go
@@ -55,7 +55,7 @@ func (reader *ContractReader) GetAccountContractNames(
 		return nil, fmt.Errorf("get account contract names failed: %w", err)
 	}
 
-	address := flow.ConvertAddress(runtimeAddress)
+	address := flow.Address(runtimeAddress)
 
 	return reader.accounts.GetContractNames(address)
 }
@@ -127,7 +127,7 @@ func ResolveLocation(
 			return nil, fmt.Errorf("no identifiers provided")
 		}
 
-		address := flow.ConvertAddress(addressLocation.Address)
+		address := flow.Address(addressLocation.Address)
 
 		contractNames, err := getContractNames(address)
 		if err != nil {
@@ -184,7 +184,7 @@ func (reader *ContractReader) getCode(
 		return nil, fmt.Errorf("get code failed: %w", err)
 	}
 
-	add, err := reader.accounts.GetContract(location.Name, flow.ConvertAddress(location.Address))
+	add, err := reader.accounts.GetContract(location.Name, flow.Address(location.Address))
 	if err != nil {
 		return nil, fmt.Errorf("get code failed: %w", err)
 	}

--- a/fvm/environment/contract_updater.go
+++ b/fvm/environment/contract_updater.go
@@ -191,7 +191,7 @@ func (impl *contractUpdaterStubsImpl) getIsContractDeploymentRestricted() (
 	defer impl.runtime.ReturnCadenceRuntime(runtime)
 
 	value, err := runtime.ReadStored(
-		common.MustBytesToAddress(service.Bytes()),
+		common.Address(service),
 		blueprints.IsContractDeploymentRestrictedPath)
 	if err != nil {
 		impl.logger.
@@ -238,7 +238,7 @@ func (impl *contractUpdaterStubsImpl) GetAuthorizedAccounts(
 	defer impl.runtime.ReturnCadenceRuntime(runtime)
 
 	value, err := runtime.ReadStored(
-		common.MustBytesToAddress(service.Bytes()),
+		common.Address(service),
 		path)
 
 	const warningMsg = "failed to read contract authorized accounts from " +
@@ -378,7 +378,7 @@ func (updater *ContractUpdaterImpl) SetContract(
 	// Initial contract deployments must be authorized by signing accounts.
 	//
 	// Contract updates are always allowed.
-	exists, err := updater.accounts.ContractExists(location.Name, flow.ConvertAddress(location.Address))
+	exists, err := updater.accounts.ContractExists(location.Name, flow.Address(location.Address))
 	if err != nil {
 		return err
 	}
@@ -433,7 +433,7 @@ func (updater *ContractUpdaterImpl) Commit() (ContractUpdates, error) {
 	var err error
 	for _, v := range updateList {
 		var currentlyExists bool
-		currentlyExists, err = updater.accounts.ContractExists(v.Location.Name, flow.ConvertAddress(v.Location.Address))
+		currentlyExists, err = updater.accounts.ContractExists(v.Location.Name, flow.Address(v.Location.Address))
 		if err != nil {
 			return ContractUpdates{}, err
 		}
@@ -442,7 +442,7 @@ func (updater *ContractUpdaterImpl) Commit() (ContractUpdates, error) {
 		if shouldDelete {
 			// this is a removal
 			contractUpdates.Deletions = append(contractUpdates.Deletions, v.Location)
-			err = updater.accounts.DeleteContract(v.Location.Name, flow.ConvertAddress(v.Location.Address))
+			err = updater.accounts.DeleteContract(v.Location.Name, flow.Address(v.Location.Address))
 			if err != nil {
 				return ContractUpdates{}, err
 			}
@@ -455,7 +455,11 @@ func (updater *ContractUpdaterImpl) Commit() (ContractUpdates, error) {
 				contractUpdates.Updates = append(contractUpdates.Updates, v.Location)
 			}
 
-			err = updater.accounts.SetContract(v.Location.Name, flow.ConvertAddress(v.Location.Address), v.Code)
+			err = updater.accounts.SetContract(
+				v.Location.Name,
+				flow.Address(v.Location.Address),
+				v.Code,
+			)
 			if err != nil {
 				return ContractUpdates{}, err
 			}
@@ -541,7 +545,7 @@ func cadenceValueToAddressSlice(value cadence.Value) (
 		if !ok {
 			return nil, false
 		}
-		addresses = append(addresses, flow.ConvertAddress(a))
+		addresses = append(addresses, flow.Address(a))
 	}
 	return addresses, true
 }

--- a/fvm/environment/contract_updater_test.go
+++ b/fvm/environment/contract_updater_test.go
@@ -60,7 +60,7 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	err = contractUpdater.SetContract(
 		common.AddressLocation{
 			Name:    "testContract",
-			Address: common.MustBytesToAddress(address.Bytes())},
+			Address: common.Address(address)},
 		[]byte("ABC"),
 		nil)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	err = contractUpdater.SetContract(
 		common.AddressLocation{
 			Name:    "testContract2",
-			Address: common.MustBytesToAddress(address.Bytes())},
+			Address: common.Address(address)},
 		[]byte("ABC"),
 		nil)
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	// remove
 	err = contractUpdater.RemoveContract(common.AddressLocation{
 		Name:    "testContract",
-		Address: common.MustBytesToAddress(address.Bytes())}, nil)
+		Address: common.Address(address)}, nil)
 	require.NoError(t, err)
 
 	// contract still there because no commit yet
@@ -160,7 +160,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.SetContract(
 			common.AddressLocation{
 				Name:    "testContract1",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]byte("ABC"),
 			[]flow.Address{unAuth})
 		require.Error(t, err)
@@ -173,7 +173,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.SetContract(
 			common.AddressLocation{
 				Name:    "testContract1",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]byte("ABC"),
 			[]flow.Address{authRemove})
 		require.Error(t, err)
@@ -186,7 +186,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.SetContract(
 			common.AddressLocation{
 				Name:    "testContract2",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]byte("ABC"),
 			[]flow.Address{authAdd})
 		require.NoError(t, err)
@@ -199,7 +199,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.SetContract(
 			common.AddressLocation{
 				Name:    "testContract2",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]byte("ABC"),
 			[]flow.Address{authBoth})
 		require.NoError(t, err)
@@ -212,7 +212,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.SetContract(
 			common.AddressLocation{
 				Name:    "testContract1",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]byte("ABC"),
 			[]flow.Address{authAdd})
 		require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.RemoveContract(
 			common.AddressLocation{
 				Name:    "testContract2",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]flow.Address{unAuth})
 		require.Error(t, err)
 		require.False(t, contractUpdater.HasUpdates())
@@ -234,7 +234,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.SetContract(
 			common.AddressLocation{
 				Name:    "testContract1",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]byte("ABC"),
 			[]flow.Address{authAdd})
 		require.NoError(t, err)
@@ -244,7 +244,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.RemoveContract(
 			common.AddressLocation{
 				Name:    "testContract2",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]flow.Address{authRemove})
 		require.NoError(t, err)
 		require.True(t, contractUpdater.HasUpdates())
@@ -256,7 +256,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.SetContract(
 			common.AddressLocation{
 				Name:    "testContract1",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]byte("ABC"),
 			[]flow.Address{authAdd})
 		require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.RemoveContract(
 			common.AddressLocation{
 				Name:    "testContract2",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]flow.Address{authAdd})
 		require.Error(t, err)
 		require.False(t, contractUpdater.HasUpdates())
@@ -278,7 +278,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.SetContract(
 			common.AddressLocation{
 				Name:    "testContract1",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]byte("ABC"),
 			[]flow.Address{authAdd})
 		require.NoError(t, err)
@@ -288,7 +288,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 		err = contractUpdater.RemoveContract(
 			common.AddressLocation{
 				Name:    "testContract2",
-				Address: common.MustBytesToAddress(authAdd.Bytes())},
+				Address: common.Address(authAdd)},
 			[]flow.Address{authBoth})
 		require.NoError(t, err)
 		require.True(t, contractUpdater.HasUpdates())
@@ -316,21 +316,21 @@ func TestContract_DeterministicErrorOnCommit(t *testing.T) {
 	err := contractUpdater.SetContract(
 		common.AddressLocation{
 			Name:    "A",
-			Address: common.MustBytesToAddress(address2.Bytes())},
+			Address: common.Address(address2)},
 		[]byte("ABC"), nil)
 	require.NoError(t, err)
 
 	err = contractUpdater.SetContract(
 		common.AddressLocation{
 			Name:    "B",
-			Address: common.MustBytesToAddress(address1.Bytes())},
+			Address: common.Address(address1)},
 		[]byte("ABC"), nil)
 	require.NoError(t, err)
 
 	err = contractUpdater.SetContract(
 		common.AddressLocation{
 			Name:    "A",
-			Address: common.MustBytesToAddress(address1.Bytes())},
+			Address: common.Address(address1)},
 		[]byte("ABC"), nil)
 	require.NoError(t, err)
 
@@ -355,7 +355,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 		location := common.AddressLocation{
 			Name:    "TestContract",
-			Address: common.MustBytesToAddress(flowAddress.Bytes())}
+			Address: common.Address(flowAddress)}
 
 		// deploy contract with voucher
 		err = contractUpdater.SetContract(
@@ -411,7 +411,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 		location := common.AddressLocation{
 			Name:    "TestContract",
-			Address: common.MustBytesToAddress(flowAddress.Bytes())}
+			Address: common.Address(flowAddress)}
 
 		// deploy contract with voucher
 		err = contractUpdater.SetContract(

--- a/fvm/environment/derived_data_invalidator_test.go
+++ b/fvm/environment/derived_data_invalidator_test.go
@@ -28,7 +28,7 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 	// ```
 
 	addressA := flow.HexToAddress("0xa")
-	cAddressA := common.MustBytesToAddress(addressA.Bytes())
+	cAddressA := common.Address(addressA)
 	programALoc := common.AddressLocation{Address: cAddressA, Name: "A"}
 	programA2Loc := common.AddressLocation{Address: cAddressA, Name: "A2"}
 	programA := &derived.Program{
@@ -38,7 +38,7 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 	}
 
 	addressB := flow.HexToAddress("0xb")
-	cAddressB := common.MustBytesToAddress(addressB.Bytes())
+	cAddressB := common.Address(addressB)
 	programBLoc := common.AddressLocation{Address: cAddressB, Name: "B"}
 	programBDep := derived.NewProgramDependencies()
 	programBDep.Add(programALoc)
@@ -51,7 +51,7 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 	}
 
 	addressD := flow.HexToAddress("0xd")
-	cAddressD := common.MustBytesToAddress(addressD.Bytes())
+	cAddressD := common.Address(addressD)
 	programDLoc := common.AddressLocation{Address: cAddressD, Name: "D"}
 	programD := &derived.Program{
 		Program: nil,
@@ -60,7 +60,7 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 	}
 
 	addressC := flow.HexToAddress("0xc")
-	cAddressC := common.MustBytesToAddress(addressC.Bytes())
+	cAddressC := common.Address(addressC)
 	programCLoc := common.AddressLocation{Address: cAddressC, Name: "C"}
 	programC := &derived.Program{
 		Program: nil,

--- a/fvm/environment/event_emitter_test.go
+++ b/fvm/environment/event_emitter_test.go
@@ -30,8 +30,7 @@ func Test_IsServiceEvent(t *testing.T) {
 			event := cadence.Event{
 				EventType: &cadence.EventType{
 					Location: common.AddressLocation{
-						Address: common.MustBytesToAddress(
-							event.Address.Bytes()),
+						Address: common.Address(event.Address),
 					},
 					QualifiedIdentifier: event.QualifiedIdentifier(),
 				},
@@ -47,8 +46,7 @@ func Test_IsServiceEvent(t *testing.T) {
 		event := cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
-					Address: common.MustBytesToAddress(
-						flow.Testnet.Chain().ServiceAddress().Bytes()),
+					Address: common.Address(flow.Testnet.Chain().ServiceAddress()),
 				},
 				QualifiedIdentifier: events.EpochCommit.QualifiedIdentifier(),
 			},
@@ -63,8 +61,7 @@ func Test_IsServiceEvent(t *testing.T) {
 		event := cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
-					Address: common.MustBytesToAddress(
-						chain.Chain().ServiceAddress().Bytes()),
+					Address: common.Address(chain.Chain().ServiceAddress()),
 				},
 				QualifiedIdentifier: "SomeContract.SomeEvent",
 			},

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -25,21 +25,21 @@ var (
 	addressC = flow.HexToAddress("0c")
 
 	contractALocation = common.AddressLocation{
-		Address: common.MustBytesToAddress(addressA.Bytes()),
+		Address: common.Address(addressA),
 		Name:    "A",
 	}
 	contractA2Location = common.AddressLocation{
-		Address: common.MustBytesToAddress(addressA.Bytes()),
+		Address: common.Address(addressA),
 		Name:    "A2",
 	}
 
 	contractBLocation = common.AddressLocation{
-		Address: common.MustBytesToAddress(addressB.Bytes()),
+		Address: common.Address(addressB),
 		Name:    "B",
 	}
 
 	contractCLocation = common.AddressLocation{
-		Address: common.MustBytesToAddress(addressC.Bytes()),
+		Address: common.Address(addressC),
 		Name:    "C",
 	}
 

--- a/fvm/environment/system_contracts.go
+++ b/fvm/environment/system_contracts.go
@@ -44,9 +44,8 @@ func (sys *SystemContracts) Invoke(
 	error,
 ) {
 	contractLocation := common.AddressLocation{
-		Address: common.MustBytesToAddress(
-			spec.AddressFromChain(sys.chain).Bytes()),
-		Name: spec.LocationName,
+		Address: common.Address(spec.AddressFromChain(sys.chain)),
+		Name:    spec.LocationName,
 	}
 
 	span := sys.tracer.StartChildSpan(trace.FVMInvokeContractFunction)

--- a/fvm/environment/transaction_info.go
+++ b/fvm/environment/transaction_info.go
@@ -122,7 +122,7 @@ func NewTransactionInfo(
 	for _, auth := range params.TxBody.Authorizers {
 		runtimeAddresses = append(
 			runtimeAddresses,
-			common.MustBytesToAddress(auth.Bytes()))
+			common.Address(auth))
 		if auth == serviceAccount {
 			isServiceAccountAuthorizer = true
 		}

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/onflow/flow-go/module/trace"
 )
 
-var flowTokenAddress = common.MustBytesToAddress(systemcontracts.SystemContractsForChain(flow.Emulator).FlowToken.Address.Bytes())
+var flowTokenAddress = common.Address(systemcontracts.SystemContractsForChain(flow.Emulator).FlowToken.Address)
 var randomBeaconAddress = systemcontracts.SystemContractsForChain(flow.Emulator).RandomBeaconHistory.Address
 
 const defaultChainID = flow.Testnet

--- a/fvm/evm/testutils/handler.go
+++ b/fvm/evm/testutils/handler.go
@@ -19,7 +19,7 @@ func SetupHandler(
 	return handler.NewContractHandler(
 		chainID,
 		rootAddr,
-		common.MustBytesToAddress(systemcontracts.SystemContractsForChain(chainID).FlowToken.Address.Bytes()),
+		common.Address(systemcontracts.SystemContractsForChain(chainID).FlowToken.Address),
 		rootAddr,
 		handler.NewBlockStore(chainID, backend, rootAddr),
 		handler.NewAddressAllocator(),

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -237,7 +237,7 @@ func GetAccountBalance(
 ) {
 	env, _ := getScriptEnvironment(ctx, storageSnapshot)
 
-	accountBalance, err := env.GetAccountBalance(common.MustBytesToAddress(address.Bytes()))
+	accountBalance, err := env.GetAccountBalance(common.Address(address))
 
 	if err != nil {
 		return 0, fmt.Errorf("cannot get account balance: %w", err)
@@ -256,7 +256,7 @@ func GetAccountAvailableBalance(
 ) {
 	env, _ := getScriptEnvironment(ctx, storageSnapshot)
 
-	accountBalance, err := env.GetAccountAvailableBalance(common.MustBytesToAddress(address.Bytes()))
+	accountBalance, err := env.GetAccountAvailableBalance(common.Address(address))
 
 	if err != nil {
 		return 0, fmt.Errorf("cannot get account balance: %w", err)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -356,7 +356,7 @@ func (b *BasicBlockExecutor) SetupAccounts(tb testing.TB, privateKeys []flow.Acc
 					stdlib.AccountEventAddressParameter.Identifier,
 				).(cadence.Address)
 
-				addr = flow.ConvertAddress(address)
+				addr = flow.Address(address)
 				break
 			}
 		}

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1700,7 +1700,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 		data, err := ccf.Decode(nil, accountCreatedEvents[0].Payload)
 		require.NoError(t, err)
 
-		address := flow.ConvertAddress(
+		address := flow.Address(
 			cadence.SearchFieldByName(
 				data.(cadence.Event),
 				stdlib.AccountEventAddressParameter.Identifier,
@@ -1895,7 +1895,7 @@ func TestBlockContext_ExecuteTransaction_CreateAccount_WithMonotonicAddresses(t 
 	data, err := ccf.Decode(nil, accountCreatedEvents[0].Payload)
 	require.NoError(t, err)
 
-	address := flow.ConvertAddress(
+	address := flow.Address(
 		cadence.SearchFieldByName(
 			data.(cadence.Event),
 			stdlib.AccountEventAddressParameter.Identifier,

--- a/fvm/fvm_fuzz_test.go
+++ b/fvm/fvm_fuzz_test.go
@@ -308,7 +308,7 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 		data, err := ccf.Decode(nil, accountCreatedEvents[0].Payload)
 		require.NoError(tb, err)
 
-		address = flow.ConvertAddress(
+		address = flow.Address(
 			cadence.SearchFieldByName(
 				data.(cadence.Event),
 				stdlib.AccountEventAddressParameter.Identifier,

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -991,7 +991,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			data, err := ccf.Decode(nil, accountCreatedEvents[0].Payload)
 			require.NoError(t, err)
 
-			address := flow.ConvertAddress(
+			address := flow.Address(
 				cadence.SearchFieldByName(
 					data.(cadence.Event),
 					cadenceStdlib.AccountEventAddressParameter.Identifier,
@@ -2432,7 +2432,7 @@ func TestInteractionLimit(t *testing.T) {
 				return snapshotTree, err
 			}
 
-			address = flow.ConvertAddress(
+			address = flow.Address(
 				cadence.SearchFieldByName(
 					data.(cadence.Event),
 					cadenceStdlib.AccountEventAddressParameter.Identifier,

--- a/fvm/storage/derived/derived_chain_data_test.go
+++ b/fvm/storage/derived/derived_chain_data_test.go
@@ -21,7 +21,7 @@ func TestDerivedChainData(t *testing.T) {
 
 	testLocation := func(hex string) common.AddressLocation {
 		return common.AddressLocation{
-			Address: common.MustBytesToAddress(flow.HexToAddress(hex).Bytes()),
+			Address: common.Address(flow.HexToAddress(hex)),
 			Name:    hex,
 		}
 	}

--- a/integration/benchmark/load/load_type_test.go
+++ b/integration/benchmark/load/load_type_test.go
@@ -311,7 +311,7 @@ func (t *TestAccountLoader) Load(
 	t.snapshot.Lock()
 	defer t.snapshot.Unlock()
 
-	acc, err := fvm.GetAccount(t.ctx, flow.ConvertAddress(address), t.snapshot)
+	acc, err := fvm.GetAccount(t.ctx, flow.Address(address), t.snapshot)
 	if err != nil {
 		return nil, wrapErr(err)
 	}

--- a/integration/benchmark/load/token_transfer_load.go
+++ b/integration/benchmark/load/token_transfer_load.go
@@ -54,7 +54,7 @@ func (l *TokenTransferLoad) Load(log zerolog.Logger, lc LoadContext) error {
 				// if no accounts are available, just send to the service account
 				destinationAddress = sc.FlowServiceAccount.Address
 			} else {
-				destinationAddress = flow.ConvertAddress(acc2.Address)
+				destinationAddress = flow.Address(acc2.Address)
 				lc.ReturnAvailableAccount(acc2)
 			}
 

--- a/integration/benchmark/load/token_transfer_multiple_load.go
+++ b/integration/benchmark/load/token_transfer_multiple_load.go
@@ -65,7 +65,7 @@ func (l *TokenTransferMultiLoad) Load(log zerolog.Logger, lc LoadContext) error 
 				l.destinationAddresses = apply(
 					destinationSDKAddresses,
 					func(a flowsdk.Address) flow.Address {
-						return flow.ConvertAddress(a)
+						return flow.Address(a)
 					})
 			})
 			// get another account to send tokens to

--- a/model/flow/address.go
+++ b/model/flow/address.go
@@ -17,10 +17,6 @@ type Address [AddressLength]byte
 // EmptyAddress is the default value of a variable of type Address
 var EmptyAddress = BytesToAddress(nil)
 
-func ConvertAddress(b [AddressLength]byte) Address {
-	return Address(b)
-}
-
 // HexToAddress converts a hex string to an Address.
 func HexToAddress(h string) Address {
 	addr, _ := StringToAddress(h)

--- a/model/flow/address_test.go
+++ b/model/flow/address_test.go
@@ -23,8 +23,8 @@ func TestConvertAddress(t *testing.T) {
 
 	assert.NotEqual(t, cadenceAddress, runtimeAddress)
 
-	assert.Equal(t, expected, ConvertAddress(cadenceAddress))
-	assert.Equal(t, expected, ConvertAddress(runtimeAddress))
+	assert.Equal(t, expected, Address(cadenceAddress))
+	assert.Equal(t, expected, Address(runtimeAddress))
 }
 
 func TestBytesToAddress(t *testing.T) {

--- a/module/execution/scripts_test.go
+++ b/module/execution/scripts_test.go
@@ -277,7 +277,7 @@ func (s *scriptTestSuite) createAccount() flow.Address {
 	data, err := ccf.Decode(nil, accountCreatedEvents[0].Payload)
 	s.Require().NoError(err)
 
-	return flow.ConvertAddress(
+	return flow.Address(
 		cadence.SearchFieldByName(
 			data.(cadence.Event),
 			stdlib.AccountEventAddressParameter.Identifier,


### PR DESCRIPTION
Go arrays can be converted directly.

- Remove unnecessary conversion from Cadence address (Go array) to Go byte slice, then Go byte slice to Flow address (Go array)
- Remove unnecessary `flow.ConvertAddress` function and type convert directly