### PR TITLE
[Access & Execution] Add flag to disable bitswap bloom cache

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -681,9 +681,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 				opts = append(opts, blob.WithReprovideInterval(-1))
 			}
 
-			if !builder.BitswapBloomCacheEnabled {
-				opts = append(opts, blob.WithSkipBloomCache(true))
-			}
+			opts = append(opts, blob.WithSkipBloomCache(!builder.BitswapBloomCacheEnabled))
 
 			var err error
 			bs, err = node.EngineRegistry.RegisterBlobService(channels.ExecutionDataService, builder.ExecutionDatastoreManager.Datastore(), opts...)

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -681,7 +681,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 				opts = append(opts, blob.WithReprovideInterval(-1))
 			}
 
-			opts = append(opts, blob.WithSkipBloomCache(!builder.BitswapBloomCacheEnabled))
+			opts = append(opts, blob.WithUseBloomCache(builder.BitswapBloomCacheEnabled))
 
 			var err error
 			bs, err = node.EngineRegistry.RegisterBlobService(channels.ExecutionDataService, builder.ExecutionDatastoreManager.Datastore(), opts...)

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -681,6 +681,10 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 				opts = append(opts, blob.WithReprovideInterval(-1))
 			}
 
+			if !builder.BitswapBloomCacheEnabled {
+				opts = append(opts, blob.WithSkipBloomCache(true))
+			}
+
 			var err error
 			bs, err = node.EngineRegistry.RegisterBlobService(channels.ExecutionDataService, builder.ExecutionDatastoreManager.Datastore(), opts...)
 			if err != nil {

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -432,7 +432,7 @@ func (exeNode *ExecutionNode) LoadBlobService(
 		opts = append(opts, blob.WithReprovideInterval(-1))
 	}
 
-	opts = append(opts, blob.WithSkipBloomCache(!node.BitswapBloomCacheEnabled))
+	opts = append(opts, blob.WithUseBloomCache(node.BitswapBloomCacheEnabled))
 
 	if exeNode.exeConf.blobstoreRateLimit > 0 && exeNode.exeConf.blobstoreBurstLimit > 0 {
 		opts = append(opts, blob.WithRateLimit(float64(exeNode.exeConf.blobstoreRateLimit), exeNode.exeConf.blobstoreBurstLimit))

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -432,9 +432,7 @@ func (exeNode *ExecutionNode) LoadBlobService(
 		opts = append(opts, blob.WithReprovideInterval(-1))
 	}
 
-	if !node.BitswapBloomCacheEnabled {
-		opts = append(opts, blob.WithSkipBloomCache(true))
-	}
+	opts = append(opts, blob.WithSkipBloomCache(!node.BitswapBloomCacheEnabled))
 
 	if exeNode.exeConf.blobstoreRateLimit > 0 && exeNode.exeConf.blobstoreBurstLimit > 0 {
 		opts = append(opts, blob.WithRateLimit(float64(exeNode.exeConf.blobstoreRateLimit), exeNode.exeConf.blobstoreBurstLimit))

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -432,6 +432,10 @@ func (exeNode *ExecutionNode) LoadBlobService(
 		opts = append(opts, blob.WithReprovideInterval(-1))
 	}
 
+	if !node.BitswapBloomCacheEnabled {
+		opts = append(opts, blob.WithSkipBloomCache(true))
+	}
+
 	if exeNode.exeConf.blobstoreRateLimit > 0 && exeNode.exeConf.blobstoreBurstLimit > 0 {
 		opts = append(opts, blob.WithRateLimit(float64(exeNode.exeConf.blobstoreRateLimit), exeNode.exeConf.blobstoreBurstLimit))
 	}

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -309,7 +309,7 @@ func DefaultBaseConfig() *BaseConfig {
 		ComplianceConfig:         compliance.DefaultConfig(),
 		DhtSystemEnabled:         true,
 		BitswapReprovideEnabled:  true,
-		BitswapBloomCacheEnabled: true, // default: use cached blockstore
+		BitswapBloomCacheEnabled: true, // default: use cached blockstore TODO leo: change default to false
 	}
 }
 

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -303,12 +303,12 @@ func DefaultBaseConfig() *BaseConfig {
 			Duration: 10 * time.Second,
 		},
 
-		HeroCacheMetricsEnable:  false,
-		SyncCoreConfig:          chainsync.DefaultConfig(),
-		CodecFactory:            codecFactory,
-		ComplianceConfig:        compliance.DefaultConfig(),
-		DhtSystemEnabled:        true,
-		BitswapReprovideEnabled: true,
+		HeroCacheMetricsEnable:   false,
+		SyncCoreConfig:           chainsync.DefaultConfig(),
+		CodecFactory:             codecFactory,
+		ComplianceConfig:         compliance.DefaultConfig(),
+		DhtSystemEnabled:         true,
+		BitswapReprovideEnabled:  true,
 		BitswapBloomCacheEnabled: true, // default: use cached blockstore
 	}
 }

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -185,6 +185,13 @@ type BaseConfig struct {
 	// This is only meaningful to Access and Execution nodes.
 	BitswapReprovideEnabled bool
 
+	// BitswapBloomCacheEnabled configures whether the Bitswap bloom cache is enabled.
+	// When disabled, uses a plain blockstore instead of cached blockstore, avoiding
+	// the CPU cost of building the bloom filter on startup. Pebble's built-in bloom
+	// filters (persisted in SSTables) are still used for efficient lookups.
+	// This is only meaningful to Access and Execution nodes.
+	BitswapBloomCacheEnabled bool
+
 	TransactionFeesDisabled bool
 }
 
@@ -302,6 +309,7 @@ func DefaultBaseConfig() *BaseConfig {
 		ComplianceConfig:        compliance.DefaultConfig(),
 		DhtSystemEnabled:        true,
 		BitswapReprovideEnabled: true,
+		BitswapBloomCacheEnabled: true, // default: use cached blockstore
 	}
 }
 

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -1251,9 +1251,7 @@ func (builder *ObserverServiceBuilder) BuildExecutionSyncComponents() *ObserverS
 				),
 			}
 
-			if !builder.BitswapBloomCacheEnabled {
-				opts = append(opts, blob.WithSkipBloomCache(true))
-			}
+			opts = append(opts, blob.WithUseBloomCache(builder.BitswapBloomCacheEnabled))
 
 			var err error
 			bs, err = node.EngineRegistry.RegisterBlobService(channels.PublicExecutionDataService, ds, opts...)

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -1251,6 +1251,10 @@ func (builder *ObserverServiceBuilder) BuildExecutionSyncComponents() *ObserverS
 				),
 			}
 
+			if !builder.BitswapBloomCacheEnabled {
+				opts = append(opts, blob.WithSkipBloomCache(true))
+			}
+
 			var err error
 			bs, err = node.EngineRegistry.RegisterBlobService(channels.PublicExecutionDataService, ds, opts...)
 			if err != nil {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -214,6 +214,10 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 		"bitswap-reprovide-enabled",
 		defaultConfig.BitswapReprovideEnabled,
 		"[experimental] whether to enable bitswap reproviding. This is an experimental feature. Use with caution.")
+	fnb.flags.BoolVar(&fnb.BaseConfig.BitswapBloomCacheEnabled,
+		"bitswap-bloom-cache-enabled",
+		defaultConfig.BitswapBloomCacheEnabled,
+		"[experimental] whether to enable bitswap bloom cache. When disabled, uses a plain blockstore instead of cached blockstore, avoiding the CPU cost of building the bloom filter on startup. Pebble's built-in bloom filters (persisted in SSTables) are still used. This is an experimental feature. Use with caution.")
 
 	// dynamic node startup flags
 	fnb.flags.StringVar(&fnb.BaseConfig.DynamicStartupANPubkey,

--- a/integration/tests/access/cohort3/execution_state_sync_test.go
+++ b/integration/tests/access/cohort3/execution_state_sync_test.go
@@ -196,12 +196,24 @@ func (s *ExecutionStateSyncSuite) executionDataForHeight(ctx context.Context, no
 			BlockId:              header.ID[:],
 			EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
 		})
+
 		if err != nil {
+			s.log.Info().
+				Uint64("height", height).
+				Hex("block_id", header.ID[:]).
+				Err(err).
+				Msg("failed to get execution data")
 			return err
 		}
 
 		blockED, err = convert.MessageToBlockExecutionData(ed.GetBlockExecutionData(), flow.Localnet.Chain())
 		s.Require().NoError(err, "could not convert execution data")
+
+		s.log.Info().
+			Uint64("height", height).
+			Hex("block_id", header.ID[:]).
+			Int("chunks", len(blockED.ChunkExecutionDatas)).
+			Msg("successfully retrieved execution data")
 
 		return err
 	}), "could not get execution data for block %d", height)

--- a/network/p2p/blob/blob_service.go
+++ b/network/p2p/blob/blob_service.go
@@ -126,7 +126,7 @@ func NewBlobService(
 		prefix: prefix,
 		config: &BlobServiceConfig{
 			ReprovideInterval: DefaultReprovideInterval,
-			SkipBloomCache:    false, // default: use cached blockstore
+			SkipBloomCache:    false, // default: use bloom cache
 		},
 		blockStore: blockStore,
 	}

--- a/network/p2p/blob/blob_service.go
+++ b/network/p2p/blob/blob_service.go
@@ -136,7 +136,7 @@ func NewBlobService(
 		opt(bs)
 	}
 
-	if bs.config.SkipBloomCache {
+	if !bs.config.SkipBloomCache {
 		cachedBlockStore, err := blockstore.CachedBlockstore(
 			context.Background(),
 			blockStore,


### PR DESCRIPTION
Add an experimental `bitswap-bloom-cache-enabled flag` (default: true) that controls whether the Bitswap bloom cache is used for Access/Execution/Observer nodes. When disabled, the blob service uses a new WithSkipBloomCache option to skip the cached blockstore and instead use a plain Pebble-backed blockstore, avoiding the CPU cost of building bloom filters at startup while still relying on Pebble’s SSTable bloom filters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental, configurable Bloom-cache support for Bitswap/blob retrieval via `--bitswap-bloom-cache-enabled` (enabled by default).
  * The blob service now conditionally uses a cached blockstore based on the flag.

* **Chores**
  * Improved debug/informational logging during execution data synchronization (adds height/block identifiers on success and failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->