### PR TITLE
[FVM] Fix concurent execution metrics

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -638,7 +638,7 @@ func (e *blockComputer) executeProcessCallback(
 
 	txnIndex++
 
-	txn, err := e.executeTransactionInternal(blockSpan, database, request, 0)
+	txn, err := e.executeTransactionInternal(blockSpan, database, request, 1)
 	if err != nil {
 		snapshotTime := logical.Time(0)
 		if txn != nil {

--- a/engine/execution/computation/computer/transaction_coordinator.go
+++ b/engine/execution/computation/computer/transaction_coordinator.go
@@ -124,7 +124,7 @@ func (coordinator *transactionCoordinator) NewTransaction(
 	return &transaction{
 		request:            request,
 		coordinator:        coordinator,
-		numConflictRetries: attempt,
+		numConflictRetries: attempt - 1,
 		startedAt:          time.Now(),
 		Transaction:        txn,
 		ProcedureExecutor: coordinator.vm.NewExecutor(


### PR DESCRIPTION
transactions were being reported as retried even though there was only 1 attempt.