### PR TITLE
Add EVM function to reclaim ERC20 tokens from attacker's EOA addresses

### DIFF
--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -1044,6 +1044,22 @@ access(all) contract EVM {
         ) as! Result
     }
 
+    /// This is only a temporary measure and will be removed immediately
+    /// after the remediation of the illicit tokens
+    // in the Dec 2025 security incident is complete.
+    /// This function can only be called from the `FlowServiceAccount` contract,
+    /// and only from the holder of `FlowServiceAccount.Administrator` resource.
+    access(account)
+    fun reclaimERC20FromAttackerEOAs(from: String, to: String, data: [UInt8]): Result {
+        return InternalEVM.call(
+            from: EVM.addressFromString(from).bytes,
+            to: EVM.addressFromString(to).bytes,
+            data: data,
+            gasLimit: 16_000_000,
+            value: UInt(0)
+        ) as! Result
+    }
+
     init() {
         self.setupHeartbeat()
     }


### PR DESCRIPTION
Depends on: https://github.com/onflow/flow-core-contracts/pull/573

Necessary change to reclaim ERC20 tokens from the attacker's EOA addresses:
- https://evm.flowscan.io/address/0x9D9247F5C3F3B78F7EE2C480B9CDaB91393Bf4D6?tab=tokens
- https://evm.flowscan.io/address/0x00000000000000000000000235aE95896583818d?tab=tokens

After we perform this last reclamation process, we can revert all changes to `EVM` & `FlowServiceAccount` contracts.
