### PR TITLE
Backport fix for access scripts to experimental-cadence-v1.8.7

### DIFF
--- a/fvm/script.go
+++ b/fvm/script.go
@@ -202,35 +202,33 @@ func (executor *scriptExecutor) executeScript() error {
 
 	chainID := executor.ctx.Chain.ChainID()
 
-	if executor.ctx.EVMEnabled {
-		// Setup InternalEVM in both environments because:
-		// - Scripts execute in ScriptRuntimeEnv
-		// - But system contract invocations (e.g., getAccount().balance) use TxRuntimeEnv
+	// Setup InternalEVM in both environments because:
+	// - Scripts execute in ScriptRuntimeEnv
+	// - But system contract invocations (e.g., getAccount().balance) use TxRuntimeEnv
 
-		// Setup InternalEVM in ScriptRuntimeEnv (for script execution)
-		err := evm.SetupEnvironment(
-			chainID,
-			executor.env,
-			rt.ScriptRuntimeEnv,
-		)
-		if err != nil {
-			return err
-		}
+	// Setup InternalEVM in ScriptRuntimeEnv (for script execution)
+	err := evm.SetupEnvironment(
+		chainID,
+		executor.env,
+		rt.ScriptRuntimeEnv,
+	)
+	if err != nil {
+		return err
+	}
 
-		// Setup InternalEVM in TxRuntimeEnv (for system contract invocations)
-		// This solves the problem where FlowServiceAccount (which imports EVM) needs
-		// InternalEVM to be available during dependency checking when invoked via
-		// system contracts (e.g., getAccount().balance). Without this, type checking
-		// fails with "cannot find variable in this scope: `InternalEVM`" because
-		// system contract invocations use TxRuntimeEnv, not ScriptRuntimeEnv.
-		err = evm.SetupEnvironment(
-			chainID,
-			executor.env,
-			rt.TxRuntimeEnv,
-		)
-		if err != nil {
-			return err
-		}
+	// Setup InternalEVM in TxRuntimeEnv (for system contract invocations)
+	// This solves the problem where FlowServiceAccount (which imports EVM) needs
+	// InternalEVM to be available during dependency checking when invoked via
+	// system contracts (e.g., getAccount().balance). Without this, type checking
+	// fails with "cannot find variable in this scope: `InternalEVM`" because
+	// system contract invocations use TxRuntimeEnv, not ScriptRuntimeEnv.
+	err = evm.SetupEnvironment(
+		chainID,
+		executor.env,
+		rt.TxRuntimeEnv,
+	)
+	if err != nil {
+		return err
 	}
 
 	value, err := rt.ExecuteScript(


### PR DESCRIPTION
Backports https://github.com/onflow/flow-go/pull/8290/commits/ee6c8e9efd49638c6fc602dc8327324323e22fca to `[v0.45.0-experimental-cadence-v1.8.7](https://github.com/onflow/flow-go/releases/tag/v0.45.0-experimental-cadence-v1.8.7)` for use by the emulator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable script execution and system-contract invocations by ensuring the runtime environment is fully initialized before use.
  * Reduced setup-related errors during dependency checks, improving stability when running scripts and automated validations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->