### PR TITLE
[FVM] Remove unused ExecutedCollectionConsumer

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -11,7 +11,6 @@ import (
 	otelTrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/onflow/flow-go/engine/execution"
-	"github.com/onflow/flow-go/engine/execution/computation/result"
 	"github.com/onflow/flow-go/engine/execution/utils"
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/fvm/blueprints"
@@ -125,7 +124,6 @@ type blockComputer struct {
 	signer                module.Local
 	spockHasher           hash.Hasher
 	receiptHasher         hash.Hasher
-	colResCons            []result.ExecutedCollectionConsumer
 	protocolState         protocol.SnapshotExecutionSubsetProvider
 	maxConcurrency        int
 }
@@ -169,7 +167,6 @@ func NewBlockComputer(
 	committer ViewCommitter,
 	signer module.Local,
 	executionDataProvider provider.Provider,
-	colResCons []result.ExecutedCollectionConsumer,
 	state protocol.SnapshotExecutionSubsetProvider,
 	maxConcurrency int,
 ) (BlockComputer, error) {
@@ -213,7 +210,6 @@ func NewBlockComputer(
 		signer:                signer,
 		spockHasher:           utils.NewSPOCKHasher(),
 		receiptHasher:         utils.NewExecutionReceiptHasher(),
-		colResCons:            colResCons,
 		protocolState:         state,
 		maxConcurrency:        maxConcurrency,
 	}, nil
@@ -403,7 +399,6 @@ func (e *blockComputer) executeBlock(
 		block,
 		// Add buffer just in case result collection becomes slower than the execution
 		e.maxConcurrency*2,
-		e.colResCons,
 		baseSnapshot,
 	)
 	defer collector.Stop()

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -201,7 +201,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer,
 			me,
 			prov,
-			nil,
 			testutil.ProtocolStateWithSourceFixture(nil),
 			testMaxConcurrency)
 		require.NoError(t, err)
@@ -340,7 +339,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer,
 			me,
 			prov,
-			nil,
 			testutil.ProtocolStateWithSourceFixture(nil),
 			testMaxConcurrency)
 		require.NoError(t, err)
@@ -442,7 +440,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			comm,
 			me,
 			prov,
-			nil,
 			testutil.ProtocolStateWithSourceFixture(nil),
 			testMaxConcurrency)
 		require.NoError(t, err)
@@ -507,7 +504,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer,
 			me,
 			prov,
-			nil,
 			testutil.ProtocolStateWithSourceFixture(nil),
 			testMaxConcurrency)
 		require.NoError(t, err)
@@ -733,7 +729,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 				committer.NewNoopViewCommitter(),
 				me,
 				prov,
-				nil,
 				testutil.ProtocolStateWithSourceFixture(nil),
 				testMaxConcurrency)
 			require.NoError(t, err)
@@ -845,7 +840,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer.NewNoopViewCommitter(),
 			me,
 			prov,
-			nil,
 			testutil.ProtocolStateWithSourceFixture(nil),
 			testMaxConcurrency)
 		require.NoError(t, err)
@@ -959,7 +953,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer.NewNoopViewCommitter(),
 			me,
 			prov,
-			nil,
 			testutil.ProtocolStateWithSourceFixture(nil),
 			testMaxConcurrency)
 		require.NoError(t, err)
@@ -1004,7 +997,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer,
 			me,
 			prov,
-			nil,
 			testutil.ProtocolStateWithSourceFixture(nil),
 			testMaxConcurrency)
 		require.NoError(t, err)
@@ -1343,7 +1335,6 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 		committer,
 		me,
 		prov,
-		nil,
 		testutil.ProtocolStateWithSourceFixture(constRandomSource),
 		testMaxConcurrency)
 	require.NoError(t, err)
@@ -1590,7 +1581,6 @@ func testScheduledTransactionsWithError(
 		committer,
 		me,
 		prov,
-		nil,
 		testutil.ProtocolStateWithSourceFixture(nil),
 		testMaxConcurrency)
 	require.NoError(t, err)

--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -817,7 +817,6 @@ func executeBlockAndVerifyWithParameters(t *testing.T,
 		ledgerCommiter,
 		me,
 		prov,
-		nil,
 		stateForRandomSource,
 		testVerifyMaxConcurrency)
 	require.NoError(t, err)

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -118,7 +118,6 @@ func New(
 		committer,
 		me,
 		executionDataProvider,
-		nil, // TODO(ramtin): update me with proper consumers
 		protoState,
 		params.MaxConcurrency,
 	)

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -203,7 +203,6 @@ func benchmarkComputeBlock(
 		committer.NewNoopViewCommitter(),
 		me,
 		prov,
-		nil,
 		testutil.ProtocolStateWithSourceFixture(nil),
 		maxConcurrency)
 	require.NoError(b, err)

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -149,7 +149,6 @@ func TestComputeBlockWithStorage(t *testing.T) {
 		committer.NewNoopViewCommitter(),
 		me,
 		prov,
-		nil,
 		testutil.ProtocolStateWithSourceFixture(nil),
 		testMaxConcurrency)
 	require.NoError(t, err)
@@ -858,7 +857,6 @@ func Test_EventEncodingFailsOnlyTxAndCarriesOn(t *testing.T) {
 		committer.NewNoopViewCommitter(),
 		me,
 		prov,
-		nil,
 		testutil.ProtocolStateWithSourceFixture(nil),
 		testMaxConcurrency)
 	require.NoError(t, err)

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -151,7 +151,6 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 		committer.NewNoopViewCommitter(),
 		me,
 		prov,
-		nil,
 		testutil.ProtocolStateWithSourceFixture(nil),
 		testMaxConcurrency)
 	require.NoError(t, err)
@@ -264,7 +263,6 @@ func TestPrograms_TestBlockForks(t *testing.T) {
 		committer.NewNoopViewCommitter(),
 		me,
 		prov,
-		nil,
 		testutil.ProtocolStateWithSourceFixture(nil),
 		testMaxConcurrency)
 	require.NoError(t, err)

--- a/engine/execution/computation/result/consumer.go
+++ b/engine/execution/computation/result/consumer.go
@@ -39,12 +39,6 @@ type ExecutedCollection interface {
 	ExecutionSnapshot() *snapshot.ExecutionSnapshot
 }
 
-// ExecutedCollectionConsumer consumes ExecutedCollections
-type ExecutedCollectionConsumer interface {
-	module.ReadyDoneAware
-	OnExecutedCollection(res ExecutedCollection) error
-}
-
 // AttestedCollection holds results of a collection attestation
 type AttestedCollection interface {
 	ExecutedCollection

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -308,7 +308,6 @@ func ExecutionResultFixture(t *testing.T,
 			committer,
 			me,
 			prov,
-			nil,
 			protocolState,
 			testMaxConcurrency)
 		require.NoError(t, err)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -236,7 +236,6 @@ func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logge
 		ledgerCommitter,
 		me,
 		prov,
-		nil,
 		testutil.ProtocolStateWithSourceFixture(nil),
 		1) // We're interested in fvm's serial execution time
 	require.NoError(tb, err)


### PR DESCRIPTION
pre-spring clean up.

ExecutedCollectionConsumer was not used.
Looks like a good idea we had in the past, but we never finished it up. If we need it again in the future we can revert this PR, but for now we can reduce complexity of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal result collection mechanism by removing unused consumer notification logic and streamlining constructor interfaces across computation components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->