### PR TITLE
[Breaking Change] Normalize nil payload value encoding to empty slice

### DIFF
--- a/ledger/trie_encoder_test.go
+++ b/ledger/trie_encoder_test.go
@@ -640,7 +640,7 @@ func TestTrieUpdateNilVsEmptySlice(t *testing.T) {
 	}
 
 	// Step 1: Verify original distinction
-	require.NotNil(t, tu.Payloads[0].Value(), "Payload 0 should have non-nil value after normalized")
+	require.Nil(t, tu.Payloads[0].Value(), "Payload 0 should have nil value (we don't normalize at creation time, only encoding time)")
 	require.NotNil(t, tu.Payloads[1].Value(), "Payload 1 should have non-nil value")
 	require.Equal(t, 0, len(tu.Payloads[0].Value()), "Payload 0 should have 0 length")
 	require.Equal(t, 0, len(tu.Payloads[1].Value()), "Payload 1 should have 0 length")

--- a/ledger/trie_test.go
+++ b/ledger/trie_test.go
@@ -421,6 +421,11 @@ func TestPayloadJSONSerialization(t *testing.T) {
 
 		v2 := p2.Value()
 		require.True(t, v2.Equals(Value{}))
+
+		// after decoding, the value will be normalized to []byte{}
+		// which will be different from the original format
+		require.True(t, p.value == nil)
+		require.True(t, p2.value != nil)
 	})
 
 	t.Run("empty key", func(t *testing.T) {
@@ -543,6 +548,7 @@ func TestPayloadCBORSerialization(t *testing.T) {
 		var p Payload
 		b, err := cbor.Marshal(p)
 		require.NoError(t, err)
+		require.True(t, p.value == nil)
 		require.Equal(t, encoded, b)
 
 		var p2 Payload
@@ -562,6 +568,11 @@ func TestPayloadCBORSerialization(t *testing.T) {
 
 		v2 := p2.Value()
 		require.True(t, v2.Equals(Value{}))
+
+		// after decoding, the value will be normalized to []byte{}
+		// which will be different from the original format
+		require.True(t, p.value == nil)
+		require.True(t, p2.value != nil)
 	})
 
 	t.Run("empty key", func(t *testing.T) {


### PR DESCRIPTION
Working towards  https://github.com/onflow/flow-go/issues/8308

## Background
When working on a proof of concept for https://github.com/onflow/flow-go/issues/8308, I found a non-determinism issue causing a result_id mismatch. The root cause was an ambiguity in [EncodeTrieUpdate](https://github.com/onflow/flow-go/blob/master/ledger/trie_encoder.go#L555) and [DecodeTrieUpdate](https://github.com/onflow/flow-go/blob/master/ledger/trie_encoder.go#L604), which do not distinguish between `nil` and `[]byte{}` (empty slice) payload values; both are decoded as `[]byte{}`. I have the test case `TestTrieUpdateNilVsEmptySlice` (included in the PR) to reproduce it. 

This became problematic because block execution sometimes produces a mix of both types. When these values were passed through the remote service’s gRPC/binary boundary, the distinction was lost. However, the [CBOR serialization for ChunkExecutionData ](https://github.com/onflow/flow-go/blob/master/module/executiondatasync/provider/provider.go#L291)is sensitive to this difference, resulting in a hash mismatch in execution data id and an incorrect result_id.

## Solution
This PR fixes the issue by adding a normalization step in NewPayload to convert nil values to empty slices ([]byte{}). This works because:

- Existing code treats them as equal: The existing implementation of [`ValueEquals`](https://github.com/onflow/flow-go/blob/master/ledger/trie.go#L409) already treats `nil` and empty payloads as equivalent by using `IsEmpty()`, the codebase already considers them semantically equivalent.
- Consistency across serialization formats: By normalizing at payload creation time, we ensure all code paths produce consistent encoded data regardless of whether the original value was nil or []byte{}. This eliminates the distinction that was causing hash mismatches in execution data serialization.


## Note
This is a breaking change that requires HCU to deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize nil and empty payload values so they consistently serialize as empty byte strings across JSON and CBOR, avoiding mismatches between nil vs empty representations.

* **Tests**
  * Added and updated tests to verify nil and empty payload values normalize and remain equivalent after encode/decode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->