### PR TITLE
[FVM] Refactor cadence declarations in FVM

### DIFF
--- a/fvm/evm/backends/wrappedEnv.go
+++ b/fvm/evm/backends/wrappedEnv.go
@@ -30,12 +30,6 @@ func NewWrappedEnvironment(env environment.Environment) *WrappedEnvironment {
 
 var _ types.Backend = &WrappedEnvironment{}
 
-// SetEnv allows replacing the underlying environment.Environment and reusing
-// the WrappedEnvironment object.
-func (we *WrappedEnvironment) SetEnv(env environment.Environment) {
-	we.env = env
-}
-
 // GetValue gets a value from the storage for the given owner and key pair,
 // if value not found empty slice and no error is returned.
 func (we *WrappedEnvironment) GetValue(owner, key []byte) ([]byte, error) {

--- a/fvm/runtime/cadence_function_declarations.go
+++ b/fvm/runtime/cadence_function_declarations.go
@@ -6,7 +6,14 @@ import (
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 
-	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/evm"
+	"github.com/onflow/flow-go/fvm/evm/backends"
+	"github.com/onflow/flow-go/fvm/evm/emulator"
+	"github.com/onflow/flow-go/fvm/evm/handler"
+	"github.com/onflow/flow-go/fvm/evm/impl"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 // randomSourceFunctionType is the type of the `randomSource` function.
@@ -15,7 +22,9 @@ var randomSourceFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
 }
 
-func blockRandomSourceDeclaration(renv *ReusableCadenceRuntime) stdlib.StandardLibraryValue {
+// BlockRandomSourceDeclaration returns a declaration for the `randomSource` function.
+// if the environment is a SwappableEnvironment the underlying environment can be swapped without causing issues.
+func BlockRandomSourceDeclaration(fvmEnv environment.Environment) stdlib.StandardLibraryValue {
 	// Declare the `randomSourceHistory` function. This function is **only** used by the
 	// System transaction, to fill the `RandomBeaconHistory` contract via the heartbeat
 	// resource. This allows the `RandomBeaconHistory` contract to be a standard contract,
@@ -31,14 +40,7 @@ func blockRandomSourceDeclaration(renv *ReusableCadenceRuntime) stdlib.StandardL
 		Value: interpreter.NewUnmeteredStaticHostFunctionValue(
 			randomSourceFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
-				var err error
-				var source []byte
-				env := renv.fvmEnv
-				if env != nil {
-					source, err = env.RandomSourceHistory()
-				} else {
-					err = errors.NewOperationNotSupportedError("randomSourceHistory")
-				}
+				source, err := fvmEnv.RandomSourceHistory()
 
 				if err != nil {
 					panic(err)
@@ -58,7 +60,9 @@ var transactionIndexFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UInt32Type),
 }
 
-func transactionIndexDeclaration(renv *ReusableCadenceRuntime) stdlib.StandardLibraryValue {
+// TransactionIndexDeclaration returns a declaration for the `getTransactionIndex` function.
+// if the environment is a SwappableEnvironment the underlying environment can be swapped without causing issues.
+func TransactionIndexDeclaration(fvmEnv environment.Environment) stdlib.StandardLibraryValue {
 	return stdlib.StandardLibraryValue{
 		Name:      "getTransactionIndex",
 		DocString: `Returns the transaction index in the current block, i.e. first transaction in a block has index of 0, second has index of 1...`,
@@ -70,13 +74,44 @@ func transactionIndexDeclaration(renv *ReusableCadenceRuntime) stdlib.StandardLi
 				return interpreter.NewUInt32Value(
 					invocation.InvocationContext,
 					func() uint32 {
-						env := renv.fvmEnv
-						if env == nil {
-							panic(errors.NewOperationNotSupportedError("transactionIndex"))
-						}
-						return env.TxIndex()
+						return fvmEnv.TxIndex()
 					})
 			},
 		),
 	}
+}
+
+// EVMInternalEVMContractValue creates an internal EVM contract value based on the specified ChainID and environment.
+// if the environment is a SwappableEnvironment the underlying environment can be swapped without causing issues.
+func EVMInternalEVMContractValue(chainID flow.ChainID, fvmEnv environment.Environment) *interpreter.SimpleCompositeValue {
+	if fvmEnv == nil {
+		return nil
+	}
+	sc := systemcontracts.SystemContractsForChain(chainID)
+	randomBeaconAddress := sc.RandomBeaconHistory.Address
+	flowTokenAddress := sc.FlowToken.Address
+
+	evmBackend := backends.NewWrappedEnvironment(fvmEnv)
+	evmEmulator := emulator.NewEmulator(evmBackend, evm.StorageAccountAddress(chainID))
+	blockStore := handler.NewBlockStore(chainID, evmBackend, evm.StorageAccountAddress(chainID))
+	addressAllocator := handler.NewAddressAllocator()
+
+	evmContractAddress := evm.ContractAccountAddress(chainID)
+
+	contractHandler := handler.NewContractHandler(
+		chainID,
+		evmContractAddress,
+		common.Address(flowTokenAddress),
+		randomBeaconAddress,
+		blockStore,
+		addressAllocator,
+		evmBackend,
+		evmEmulator,
+	)
+
+	return impl.NewInternalEVMContractValue(
+		nil,
+		contractHandler,
+		evmContractAddress,
+	)
 }

--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -8,12 +8,7 @@ import (
 
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/evm"
-	"github.com/onflow/flow-go/fvm/evm/backends"
-	"github.com/onflow/flow-go/fvm/evm/emulator"
-	"github.com/onflow/flow-go/fvm/evm/handler"
-	"github.com/onflow/flow-go/fvm/evm/impl"
 	"github.com/onflow/flow-go/fvm/evm/stdlib"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -41,8 +36,13 @@ type ReusableCadenceRuntime struct {
 	TxRuntimeEnv     runtime.Environment
 	ScriptRuntimeEnv runtime.Environment
 
-	fvmEnv     environment.Environment
-	evmBackend *backends.WrappedEnvironment
+	fvmEnv *SwappableEnvironment
+}
+
+// SwappableEnvironment is a wrapper type that extends the functionality of environment.Environment.
+// It is designed to allow dynamic replacement of the underlying environment implementation.
+type SwappableEnvironment struct {
+	environment.Environment
 }
 
 func NewReusableCadenceRuntime(
@@ -55,6 +55,7 @@ func NewReusableCadenceRuntime(
 		chain:            chain,
 		TxRuntimeEnv:     runtime.NewBaseInterpreterEnvironment(config),
 		ScriptRuntimeEnv: runtime.NewScriptInterpreterEnvironment(config),
+		fvmEnv:           &SwappableEnvironment{},
 	}
 
 	reusable.declareStandardLibraryFunctions()
@@ -64,62 +65,32 @@ func NewReusableCadenceRuntime(
 
 func (reusable *ReusableCadenceRuntime) declareStandardLibraryFunctions() {
 	// random source for transactions
-	reusable.TxRuntimeEnv.DeclareValue(blockRandomSourceDeclaration(reusable), nil)
+	declaration := BlockRandomSourceDeclaration(reusable.fvmEnv)
+	reusable.TxRuntimeEnv.DeclareValue(declaration, nil)
 
 	// transaction index
-	declaration := transactionIndexDeclaration(reusable)
+	declaration = TransactionIndexDeclaration(reusable.fvmEnv)
 	reusable.TxRuntimeEnv.DeclareValue(declaration, nil)
 	reusable.ScriptRuntimeEnv.DeclareValue(declaration, nil)
 
-	reusable.declareEVM()
-}
-
-func (reusable *ReusableCadenceRuntime) declareEVM() {
-	chainID := reusable.chain.ChainID()
-	sc := systemcontracts.SystemContractsForChain(chainID)
-	randomBeaconAddress := sc.RandomBeaconHistory.Address
-	flowTokenAddress := sc.FlowToken.Address
-
-	reusable.evmBackend = backends.NewWrappedEnvironment(reusable.fvmEnv)
-	evmEmulator := emulator.NewEmulator(reusable.evmBackend, evm.StorageAccountAddress(chainID))
-	blockStore := handler.NewBlockStore(chainID, reusable.evmBackend, evm.StorageAccountAddress(chainID))
-	addressAllocator := handler.NewAddressAllocator()
-
-	evmContractAddress := evm.ContractAccountAddress(chainID)
-
-	contractHandler := handler.NewContractHandler(
-		chainID,
-		evmContractAddress,
-		common.Address(flowTokenAddress),
-		randomBeaconAddress,
-		blockStore,
-		addressAllocator,
-		reusable.evmBackend,
-		evmEmulator,
-	)
-
-	internalEVMContractValue := impl.NewInternalEVMContractValue(
-		nil,
-		contractHandler,
-		evmContractAddress,
-	)
+	evmInternalContractValue := EVMInternalEVMContractValue(reusable.chain.ChainID(), reusable.fvmEnv)
+	evmContractAddress := evm.ContractAccountAddress(reusable.chain.ChainID())
 
 	stdlib.SetupEnvironment(
 		reusable.TxRuntimeEnv,
-		internalEVMContractValue,
+		evmInternalContractValue,
 		evmContractAddress,
 	)
 
 	stdlib.SetupEnvironment(
 		reusable.ScriptRuntimeEnv,
-		internalEVMContractValue,
+		evmInternalContractValue,
 		evmContractAddress,
 	)
 }
 
 func (reusable *ReusableCadenceRuntime) SetFvmEnvironment(fvmEnv environment.Environment) {
-	reusable.fvmEnv = fvmEnv
-	reusable.evmBackend.SetEnv(fvmEnv)
+	reusable.fvmEnv.Environment = fvmEnv
 }
 
 func (reusable *ReusableCadenceRuntime) CadenceTXEnv() runtime.Environment {


### PR DESCRIPTION
I found (what I think is) a better way to handle swapping FVM Environment under the hood. 

This allowed me to do some nice cleanup and to expose the creation of declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how the FVM runtime manages and passes execution environments internally, improving code organization.
  * Removed the ability to dynamically swap the underlying environment instance at runtime, simplifying environment management.
  * Reorganized EVM contract value initialization and integration flow.
  * Updated function signatures for random source and transaction index declarations to accept environment parameters directly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->