### PR TITLE
[Flow EVM] Handle empty RLP list in Cadence Arch `verifyCOAOwnershipProof()`

### DIFF
--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -116,6 +116,10 @@ var (
 	ErrRestrictedEOA = errors.New(
 		"this account has been restricted by the Community Governance Council in connection to malicious activity, please reach out to security@flowfoundation.com for inquiries",
 	)
+
+	// ErrEmptyRLPEncodedProof is returned when the RLP encoded COA Ownership proof is
+	// an empty list
+	ErrEmptyRLPEncodedProof = errors.New("invalid encoded proof: expected list with key indices, got empty list")
 )
 
 // StateError is a non-fatal error, returned when a state operation

--- a/fvm/evm/types/proof.go
+++ b/fvm/evm/types/proof.go
@@ -153,6 +153,12 @@ func COAOwnershipProofSignatureCountFromEncoded(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	// Ensure at least one element exists before accessing encodedItems[0]
+	if len(encodedItems) == 0 {
+		return 0, ErrEmptyRLPEncodedProof
+	}
+
 	// first encoded item is KeyIndices
 	// so reading number of elements in the key indices
 	// should return the count without the need to fully decode


### PR DESCRIPTION
Port of https://github.com/onflow/flow-go-internal/pull/7140 to `master` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for proof data to properly detect and report empty or invalid encoded proofs.

* **Tests**
  * Added test coverage for verification scenarios with empty proof inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->