### PR TITLE
add back quotes for DISABLE_ADX flag

### DIFF
--- a/crypto_adx_flag.mk
+++ b/crypto_adx_flag.mk
@@ -17,7 +17,7 @@ else
 endif
 
 # Flags to disable ADX instructions for older CPUs
-DISABLE_ADX := -O2 -D__BLST_PORTABLE__
+DISABLE_ADX := "-O2 -D__BLST_PORTABLE__"
 
 # Then, set `CRYPTO_FLAG`
 # the crypto package uses BLST source files underneath which may use ADX instructions.


### PR DESCRIPTION
fixing removal of quotes in crypto_adx_flag.mk in https://github.com/onflow/flow-go/pull/8355 - the build fails with:
```
unknown shorthand flag: '_' in -__BLST_PORTABLE__
```

port of: https://github.com/onflow/flow-go-internal/pull/7145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build configuration for cryptographic library compilation flags to improve flag processing and propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->