### PR TITLE
[FVM] Unexport reusable runtime

### DIFF
--- a/fvm/executionParameters_test.go
+++ b/fvm/executionParameters_test.go
@@ -22,140 +22,34 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func TestGetExecutionMemoryWeights(t *testing.T) {
-	address := common.Address{}
-
-	setupEnvMock := func(readStored func(
-		address common.Address,
-		path cadence.Path,
-		context runtime.Context,
-	) (cadence.Value, error)) environment.Environment {
-		envMock := &fvmmock.Environment{}
-		envMock.On("BorrowCadenceRuntime", mock.Anything).Return(
-			reusableRuntime.ReusableCadenceTransactionRuntime{
-				ReusableCadenceRuntime: reusableRuntime.NewReusableCadenceRuntime(
-					&testutil.TestRuntime{
-						ReadStoredFunc: readStored,
-					},
-					flow.Mainnet.Chain(),
-					runtime.Config{},
-				),
+func TestGetWeights(t *testing.T) {
+	t.Run("memory", func(t *testing.T) {
+		runTests[common.MemoryKind](
+			t,
+			func(env environment.Environment, service common.Address) (map[common.MemoryKind]uint64, error) {
+				return fvm.GetExecutionMemoryWeights(env, service)
 			},
+			blueprints.TransactionFeesExecutionMemoryWeightsPath,
+			meter.DefaultMemoryWeights,
 		)
-		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
-		return envMock
-	}
-
-	t.Run("return error if nothing is stored",
-		func(t *testing.T) {
-			envMock := setupEnvMock(
-				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
-					return nil, nil
-				})
-			_, err := fvm.GetExecutionMemoryWeights(envMock, address)
-			require.Error(t, err)
-			require.EqualError(t, err, errors.NewCouldNotGetExecutionParameterFromStateError(
-				address.Hex(),
-				blueprints.TransactionFeesExecutionMemoryWeightsPath.String()).Error())
-		},
-	)
-	t.Run("return error if can't parse stored",
-		func(t *testing.T) {
-			envMock := setupEnvMock(
-				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
-					return cadence.NewBool(false), nil
-				})
-			_, err := fvm.GetExecutionMemoryWeights(envMock, address)
-			require.Error(t, err)
-			require.EqualError(t, err, errors.NewCouldNotGetExecutionParameterFromStateError(
-				address.Hex(),
-				blueprints.TransactionFeesExecutionMemoryWeightsPath.String()).Error())
-		},
-	)
-	t.Run("return error if get stored returns error",
-		func(t *testing.T) {
-			someErr := fmt.Errorf("some error")
-			envMock := setupEnvMock(
-				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
-					return nil, someErr
-				})
-			_, err := fvm.GetExecutionMemoryWeights(envMock, address)
-			require.Error(t, err)
-			require.EqualError(t, err, someErr.Error())
-		},
-	)
-	t.Run("return error if get stored returns error",
-		func(t *testing.T) {
-			someErr := fmt.Errorf("some error")
-			envMock := setupEnvMock(
-				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
-					return nil, someErr
-				})
-			_, err := fvm.GetExecutionMemoryWeights(envMock, address)
-			require.Error(t, err)
-			require.EqualError(t, err, someErr.Error())
-		},
-	)
-	t.Run("no error if a dictionary is stored",
-		func(t *testing.T) {
-			envMock := setupEnvMock(
-				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
-					return cadence.NewDictionary([]cadence.KeyValuePair{}), nil
-				})
-			_, err := fvm.GetExecutionMemoryWeights(envMock, address)
-			require.NoError(t, err)
-		},
-	)
-	t.Run("return defaults if empty dict is stored",
-		func(t *testing.T) {
-			envMock := setupEnvMock(
-				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
-					return cadence.NewDictionary([]cadence.KeyValuePair{}), nil
-				})
-			weights, err := fvm.GetExecutionMemoryWeights(envMock, address)
-			require.NoError(t, err)
-			require.InDeltaMapValues(t, meter.DefaultMemoryWeights, weights, 0)
-		},
-	)
-	t.Run("return merged if some dict is stored",
-		func(t *testing.T) {
-			expectedWeights := meter.ExecutionMemoryWeights{}
-			var existingWeightKey common.MemoryKind
-			var existingWeightValue uint64
-			for k, v := range meter.DefaultMemoryWeights {
-				expectedWeights[k] = v
-			}
-			// change one existing value
-			for kind, u := range meter.DefaultMemoryWeights {
-				existingWeightKey = kind
-				existingWeightValue = u
-				expectedWeights[kind] = u + 1
-				break
-			}
-			expectedWeights[0] = 0
-
-			envMock := setupEnvMock(
-				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
-					return cadence.NewDictionary([]cadence.KeyValuePair{
-						{
-							Value: cadence.UInt64(0),
-							Key:   cadence.UInt64(0),
-						}, // a new key
-						{
-							Value: cadence.UInt64(existingWeightValue + 1),
-							Key:   cadence.UInt64(existingWeightKey),
-						}, // existing key with new value
-					}), nil
-				})
-
-			weights, err := fvm.GetExecutionMemoryWeights(envMock, address)
-			require.NoError(t, err)
-			require.InDeltaMapValues(t, expectedWeights, weights, 0)
-		},
-	)
+	})
+	t.Run("execution effort", func(t *testing.T) {
+		runTests[common.ComputationKind](
+			t,
+			func(env environment.Environment, service common.Address) (map[common.ComputationKind]uint64, error) {
+				return fvm.GetExecutionEffortWeights(env, service)
+			},
+			blueprints.TransactionFeesExecutionEffortWeightsPath,
+			meter.DefaultComputationWeights,
+		)
+	})
 }
 
-func TestGetExecutionEffortWeights(t *testing.T) {
+func runTests[T common.ComputationKind | common.MemoryKind](
+	t *testing.T,
+	f func(env environment.Environment, service common.Address) (map[T]uint64, error),
+	path cadence.Path,
+	defaultWeights map[T]uint64) {
 	address := common.Address{}
 
 	setupEnvMock := func(readStored func(
@@ -163,17 +57,20 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 		path cadence.Path,
 		context runtime.Context,
 	) (cadence.Value, error)) environment.Environment {
+		pool := reusableRuntime.NewCustomReusableCadenceRuntimePool(
+			0,
+			flow.Mainnet.Chain(),
+			runtime.Config{},
+			func(config runtime.Config) runtime.Runtime {
+				return &testutil.TestRuntime{
+					ReadStoredFunc: readStored,
+				}
+			},
+		)
+
 		envMock := &fvmmock.Environment{}
 		envMock.On("BorrowCadenceRuntime", mock.Anything).Return(
-			reusableRuntime.ReusableCadenceTransactionRuntime{
-				ReusableCadenceRuntime: reusableRuntime.NewReusableCadenceRuntime(
-					&testutil.TestRuntime{
-						ReadStoredFunc: readStored,
-					},
-					flow.Mainnet.Chain(),
-					runtime.Config{},
-				),
-			},
+			pool.Borrow(envMock, environment.CadenceTransactionRuntime),
 		)
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
@@ -185,11 +82,11 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
 					return nil, nil
 				})
-			_, err := fvm.GetExecutionEffortWeights(envMock, address)
+			_, err := f(envMock, address)
 			require.Error(t, err)
 			require.EqualError(t, err, errors.NewCouldNotGetExecutionParameterFromStateError(
 				address.Hex(),
-				blueprints.TransactionFeesExecutionEffortWeightsPath.String()).Error())
+				path.String()).Error())
 		},
 	)
 	t.Run("return error if can't parse stored",
@@ -198,11 +95,11 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
 					return cadence.NewBool(false), nil
 				})
-			_, err := fvm.GetExecutionEffortWeights(envMock, address)
+			_, err := f(envMock, address)
 			require.Error(t, err)
 			require.EqualError(t, err, errors.NewCouldNotGetExecutionParameterFromStateError(
 				address.Hex(),
-				blueprints.TransactionFeesExecutionEffortWeightsPath.String()).Error())
+				path.String()).Error())
 		},
 	)
 	t.Run("return error if get stored returns error",
@@ -212,9 +109,9 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
 					return nil, someErr
 				})
-			_, err := fvm.GetExecutionEffortWeights(envMock, address)
+			_, err := f(envMock, address)
 			require.Error(t, err)
-			require.EqualError(t, err, someErr.Error())
+			require.ErrorContains(t, err, someErr.Error())
 		},
 	)
 	t.Run("return error if get stored returns error",
@@ -224,9 +121,9 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
 					return nil, someErr
 				})
-			_, err := fvm.GetExecutionEffortWeights(envMock, address)
+			_, err := f(envMock, address)
 			require.Error(t, err)
-			require.EqualError(t, err, someErr.Error())
+			require.ErrorContains(t, err, someErr.Error())
 		},
 	)
 	t.Run("no error if a dictionary is stored",
@@ -235,7 +132,7 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
 					return cadence.NewDictionary([]cadence.KeyValuePair{}), nil
 				})
-			_, err := fvm.GetExecutionEffortWeights(envMock, address)
+			_, err := f(envMock, address)
 			require.NoError(t, err)
 		},
 	)
@@ -245,26 +142,27 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 				func(address common.Address, path cadence.Path, context runtime.Context) (cadence.Value, error) {
 					return cadence.NewDictionary([]cadence.KeyValuePair{}), nil
 				})
-			weights, err := fvm.GetExecutionEffortWeights(envMock, address)
+			weights, err := f(envMock, address)
 			require.NoError(t, err)
-			require.InDeltaMapValues(t, meter.DefaultComputationWeights, weights, 0)
+			require.InDeltaMapValues(t, defaultWeights, weights, 0)
 		},
 	)
 	t.Run("return merged if some dict is stored",
 		func(t *testing.T) {
-			expectedWeights := meter.ExecutionEffortWeights{}
-			var existingWeightKey common.ComputationKind
+			expectedWeights := make(map[T]uint64)
+			var existingWeightKey T
 			var existingWeightValue uint64
-			for k, v := range meter.DefaultComputationWeights {
+			for k, v := range defaultWeights {
 				expectedWeights[k] = v
 			}
 			// change one existing value
-			for kind, u := range meter.DefaultComputationWeights {
+			for kind, u := range defaultWeights {
 				existingWeightKey = kind
 				existingWeightValue = u
 				expectedWeights[kind] = u + 1
 				break
 			}
+
 			expectedWeights[0] = 0
 
 			envMock := setupEnvMock(
@@ -281,7 +179,7 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 					}), nil
 				})
 
-			weights, err := fvm.GetExecutionEffortWeights(envMock, address)
+			weights, err := f(envMock, address)
 			require.NoError(t, err)
 			require.InDeltaMapValues(t, expectedWeights, weights, 0)
 		},

--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -15,7 +15,7 @@ import (
 // TODO(JanezP): unexport all types in this file
 // They are just used by some test
 
-// ReusableCadenceRuntime is a wrapper around cadence Runtime and cadence Environment
+// reusableCadenceRuntime is a wrapper around cadence Runtime and cadence Environment
 // with pre-injected cadence context for: EVM, getTransactionIndex, ...
 // it can be reused by changing the fvmEnv. The reuse happens accross blocks and between scripts and transactions
 //
@@ -26,9 +26,9 @@ import (
 // - evm emulator (and related objects)
 //
 // because the cadence environment differs between scripts and transactions there are 2
-// wrapper structs for ReusableCadenceRuntime that change what env ReadStored
+// wrapper structs for reusableCadenceRuntime that change what env ReadStored
 // and InvokeContractFunction use.
-type ReusableCadenceRuntime struct {
+type reusableCadenceRuntime struct {
 	runtime.Runtime
 
 	chain flow.Chain
@@ -45,12 +45,12 @@ type SwappableEnvironment struct {
 	environment.Environment
 }
 
-func NewReusableCadenceRuntime(
+func newReusableCadenceRuntime(
 	rt runtime.Runtime,
 	chain flow.Chain,
 	config runtime.Config,
-) *ReusableCadenceRuntime {
-	reusable := &ReusableCadenceRuntime{
+) *reusableCadenceRuntime {
+	reusable := &reusableCadenceRuntime{
 		Runtime:          rt,
 		chain:            chain,
 		TxRuntimeEnv:     runtime.NewBaseInterpreterEnvironment(config),
@@ -63,7 +63,7 @@ func NewReusableCadenceRuntime(
 	return reusable
 }
 
-func (reusable *ReusableCadenceRuntime) declareStandardLibraryFunctions() {
+func (reusable *reusableCadenceRuntime) declareStandardLibraryFunctions() {
 	// random source for transactions
 	declaration := BlockRandomSourceDeclaration(reusable.fvmEnv)
 	reusable.TxRuntimeEnv.DeclareValue(declaration, nil)
@@ -89,19 +89,19 @@ func (reusable *ReusableCadenceRuntime) declareStandardLibraryFunctions() {
 	)
 }
 
-func (reusable *ReusableCadenceRuntime) SetFvmEnvironment(fvmEnv environment.Environment) {
+func (reusable *reusableCadenceRuntime) SetFvmEnvironment(fvmEnv environment.Environment) {
 	reusable.fvmEnv.Environment = fvmEnv
 }
 
-func (reusable *ReusableCadenceRuntime) CadenceTXEnv() runtime.Environment {
+func (reusable *reusableCadenceRuntime) CadenceTXEnv() runtime.Environment {
 	return reusable.TxRuntimeEnv
 }
 
-func (reusable *ReusableCadenceRuntime) CadenceScriptEnv() runtime.Environment {
+func (reusable *reusableCadenceRuntime) CadenceScriptEnv() runtime.Environment {
 	return reusable.ScriptRuntimeEnv
 }
 
-func (reusable *ReusableCadenceRuntime) NewTransactionExecutor(
+func (reusable *reusableCadenceRuntime) NewTransactionExecutor(
 	script runtime.Script,
 	location common.Location,
 ) runtime.Executor {
@@ -117,7 +117,7 @@ func (reusable *ReusableCadenceRuntime) NewTransactionExecutor(
 	)
 }
 
-func (reusable *ReusableCadenceRuntime) ExecuteScript(
+func (reusable *reusableCadenceRuntime) ExecuteScript(
 	script runtime.Script,
 	location common.Location,
 ) (
@@ -136,16 +136,16 @@ func (reusable *ReusableCadenceRuntime) ExecuteScript(
 	)
 }
 
-// ReusableCadenceTransactionRuntime is a wrapper around ReusableCadenceRuntime
+// reusableCadenceTransactionRuntime is a wrapper around reusableCadenceRuntime
 // that is meant to be used in transactions.
-// see: ReusableCadenceRuntime
-type ReusableCadenceTransactionRuntime struct {
-	*ReusableCadenceRuntime
+// see: reusableCadenceRuntime
+type reusableCadenceTransactionRuntime struct {
+	*reusableCadenceRuntime
 }
 
-var _ environment.ReusableCadenceRuntime = ReusableCadenceTransactionRuntime{}
+var _ environment.ReusableCadenceRuntime = reusableCadenceTransactionRuntime{}
 
-func (reusable ReusableCadenceTransactionRuntime) ReadStored(
+func (reusable reusableCadenceTransactionRuntime) ReadStored(
 	address common.Address,
 	path cadence.Path,
 ) (
@@ -164,7 +164,7 @@ func (reusable ReusableCadenceTransactionRuntime) ReadStored(
 	)
 }
 
-func (reusable ReusableCadenceTransactionRuntime) InvokeContractFunction(
+func (reusable reusableCadenceTransactionRuntime) InvokeContractFunction(
 	contractLocation common.AddressLocation,
 	functionName string,
 	arguments []cadence.Value,
@@ -187,16 +187,16 @@ func (reusable ReusableCadenceTransactionRuntime) InvokeContractFunction(
 	)
 }
 
-// ReusableCadenceScriptRuntime is a wrapper around ReusableCadenceRuntime
+// reusableCadenceScriptRuntime is a wrapper around reusableCadenceRuntime
 // that is meant to be used in scripts.
-// see: ReusableCadenceRuntime
-type ReusableCadenceScriptRuntime struct {
-	*ReusableCadenceRuntime
+// see: reusableCadenceRuntime
+type reusableCadenceScriptRuntime struct {
+	*reusableCadenceRuntime
 }
 
-var _ environment.ReusableCadenceRuntime = ReusableCadenceScriptRuntime{}
+var _ environment.ReusableCadenceRuntime = reusableCadenceScriptRuntime{}
 
-func (reusable ReusableCadenceScriptRuntime) ReadStored(
+func (reusable reusableCadenceScriptRuntime) ReadStored(
 	address common.Address,
 	path cadence.Path,
 ) (
@@ -215,7 +215,7 @@ func (reusable ReusableCadenceScriptRuntime) ReadStored(
 	)
 }
 
-func (reusable ReusableCadenceScriptRuntime) InvokeContractFunction(
+func (reusable reusableCadenceScriptRuntime) InvokeContractFunction(
 	contractLocation common.AddressLocation,
 	functionName string,
 	arguments []cadence.Value,

--- a/fvm/runtime/reusable_cadence_runtime_pool.go
+++ b/fvm/runtime/reusable_cadence_runtime_pool.go
@@ -10,7 +10,7 @@ import (
 type CadenceRuntimeConstructor func(config runtime.Config) runtime.Runtime
 
 type ReusableCadenceRuntimePool struct {
-	pool chan *ReusableCadenceRuntime
+	pool chan *reusableCadenceRuntime
 
 	runtimeConfig runtime.Config
 
@@ -36,9 +36,9 @@ func newReusableCadenceRuntimePool(
 	config runtime.Config,
 	newCustomRuntime CadenceRuntimeConstructor,
 ) ReusableCadenceRuntimePool {
-	var pool chan *ReusableCadenceRuntime
+	var pool chan *reusableCadenceRuntime
 	if poolSize > 0 {
-		pool = make(chan *ReusableCadenceRuntime, poolSize)
+		pool = make(chan *reusableCadenceRuntime, poolSize)
 	}
 
 	return ReusableCadenceRuntimePool{
@@ -87,12 +87,12 @@ func (pool ReusableCadenceRuntimePool) Borrow(
 	fvmEnv environment.Environment,
 	runtimeType environment.CadenceRuntimeType,
 ) environment.ReusableCadenceRuntime {
-	var reusable *ReusableCadenceRuntime
+	var reusable *reusableCadenceRuntime
 	select {
 	case reusable = <-pool.pool:
 		// Do nothing.
 	default:
-		reusable = NewReusableCadenceRuntime(
+		reusable = newReusableCadenceRuntime(
 			WrappedCadenceRuntime{
 				pool.newRuntime(),
 			},
@@ -105,12 +105,12 @@ func (pool ReusableCadenceRuntimePool) Borrow(
 
 	switch runtimeType {
 	case environment.CadenceScriptRuntime:
-		return ReusableCadenceScriptRuntime{
-			ReusableCadenceRuntime: reusable,
+		return reusableCadenceScriptRuntime{
+			reusableCadenceRuntime: reusable,
 		}
 	case environment.CadenceTransactionRuntime:
-		return ReusableCadenceTransactionRuntime{
-			ReusableCadenceRuntime: reusable,
+		return reusableCadenceTransactionRuntime{
+			reusableCadenceRuntime: reusable,
 		}
 	default:
 		panic("unreachable")
@@ -121,12 +121,12 @@ func (pool ReusableCadenceRuntimePool) Borrow(
 func (pool ReusableCadenceRuntimePool) Return(
 	reusable environment.ReusableCadenceRuntime,
 ) {
-	var inner *ReusableCadenceRuntime
+	var inner *reusableCadenceRuntime
 	switch v := reusable.(type) {
-	case ReusableCadenceScriptRuntime:
-		inner = v.ReusableCadenceRuntime
-	case ReusableCadenceTransactionRuntime:
-		inner = v.ReusableCadenceRuntime
+	case reusableCadenceScriptRuntime:
+		inner = v.reusableCadenceRuntime
+	case reusableCadenceTransactionRuntime:
+		inner = v.reusableCadenceRuntime
 	default:
 		panic("unreachable")
 	}

--- a/fvm/runtime/reusable_cadence_runtime_test.go
+++ b/fvm/runtime/reusable_cadence_runtime_test.go
@@ -15,15 +15,15 @@ func TestReusableCadenceRuntimePoolUnbuffered(t *testing.T) {
 	pool := NewReusableCadenceRuntimePool(0, flow.Mainnet.Chain(), runtime.Config{})
 	require.Nil(t, pool.pool)
 
-	entry := pool.Borrow(nil, environment.CadenceTransactionRuntime).(ReusableCadenceTransactionRuntime)
+	entry := pool.Borrow(nil, environment.CadenceTransactionRuntime).(reusableCadenceTransactionRuntime)
 	require.NotNil(t, entry)
 
 	pool.Return(entry)
 
-	entry2 := pool.Borrow(nil, environment.CadenceTransactionRuntime).(ReusableCadenceTransactionRuntime)
+	entry2 := pool.Borrow(nil, environment.CadenceTransactionRuntime).(reusableCadenceTransactionRuntime)
 	require.NotNil(t, entry2)
 
-	require.NotSame(t, entry.ReusableCadenceRuntime, entry2.ReusableCadenceRuntime)
+	require.NotSame(t, entry.reusableCadenceRuntime, entry2.reusableCadenceRuntime)
 }
 
 func TestReusableCadenceRuntimePoolBuffered(t *testing.T) {
@@ -36,7 +36,7 @@ func TestReusableCadenceRuntimePoolBuffered(t *testing.T) {
 	default:
 	}
 
-	entry := pool.Borrow(nil, environment.CadenceTransactionRuntime).(ReusableCadenceTransactionRuntime)
+	entry := pool.Borrow(nil, environment.CadenceTransactionRuntime).(reusableCadenceTransactionRuntime)
 	require.NotNil(t, entry)
 
 	select {
@@ -47,10 +47,10 @@ func TestReusableCadenceRuntimePoolBuffered(t *testing.T) {
 
 	pool.Return(entry)
 
-	entry2 := pool.Borrow(nil, environment.CadenceTransactionRuntime).(ReusableCadenceTransactionRuntime)
+	entry2 := pool.Borrow(nil, environment.CadenceTransactionRuntime).(reusableCadenceTransactionRuntime)
 	require.NotNil(t, entry2)
 
-	require.Same(t, entry.ReusableCadenceRuntime, entry2.ReusableCadenceRuntime)
+	require.Same(t, entry.reusableCadenceRuntime, entry2.reusableCadenceRuntime)
 }
 
 func TestReusableCadenceRuntimePoolSharing(t *testing.T) {
@@ -65,7 +65,7 @@ func TestReusableCadenceRuntimePoolSharing(t *testing.T) {
 
 	var otherPool = pool
 
-	entry := otherPool.Borrow(nil, environment.CadenceTransactionRuntime).(ReusableCadenceTransactionRuntime)
+	entry := otherPool.Borrow(nil, environment.CadenceTransactionRuntime).(reusableCadenceTransactionRuntime)
 	require.NotNil(t, entry)
 
 	select {
@@ -76,8 +76,8 @@ func TestReusableCadenceRuntimePoolSharing(t *testing.T) {
 
 	otherPool.Return(entry)
 
-	entry2 := pool.Borrow(nil, environment.CadenceTransactionRuntime).(ReusableCadenceTransactionRuntime)
+	entry2 := pool.Borrow(nil, environment.CadenceTransactionRuntime).(reusableCadenceTransactionRuntime)
 	require.NotNil(t, entry2)
 
-	require.Same(t, entry.ReusableCadenceRuntime, entry2.ReusableCadenceRuntime)
+	require.Same(t, entry.reusableCadenceRuntime, entry2.reusableCadenceRuntime)
 }


### PR DESCRIPTION
This is just a refactor and a cleanup. 

I also noticed that the `GetExecutionMemoryWeights` and `GetExecutionEffortWeights` tests were exactly the same besides the function called, so I extracted that with generics and shortened the test code by 50%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal runtime implementations made non-public and reorganized; pooling and borrowing behavior updated for runtime reuse.
* **Tests**
  * Test suites consolidated into a generic, parametric helper with subtests for different weight kinds.
  * Error assertions standardized for clearer, more robust messages.
* **Chores**
  * Removed an obsolete, now-redundant test suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->