### PR TITLE
chore: simplify logLoop select handling

### DIFF
--- a/network/p2p/tracer/gossipSubMeshTracer.go
+++ b/network/p2p/tracer/gossipSubMeshTracer.go
@@ -510,12 +510,6 @@ func (t *GossipSubMeshTracer) logLoop(ctx irrecoverable.SignalerContext) {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-		}
-
-		select {
-		case <-ctx.Done():
-			return
 		case <-ticker.C:
 			t.logPeers()
 		}


### PR DESCRIPTION
Removes redundant select block in logLoop to avoid unnecessary busy-loop and duplicate ctx.Done checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized peer-to-peer network tracing logic for improved stability and cleaner logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->