### PR TITLE
Fix lint warning

### DIFF
--- a/engine/access/rpc/backend/accounts/accounts_test.go
+++ b/engine/access/rpc/backend/accounts/accounts_test.go
@@ -632,7 +632,7 @@ func (s *AccountsSuite) setupExecutionNodes(block *flow.Block) {
 
 	// this line causes a S1021 lint error because receipts is explicitly declared. this is required
 	// to ensure the mock library handles the response type correctly
-	var receipts flow.ExecutionReceiptList //nolint:gosimple
+	var receipts flow.ExecutionReceiptList //nolint:staticcheck
 	receipts = unittest.ReceiptsForBlockFixture(block, s.executionNodes.NodeIDs())
 	s.receipts.On("ByBlockID", block.ID()).Return(receipts, nil)
 

--- a/engine/access/rpc/backend/events/events_test.go
+++ b/engine/access/rpc/backend/events/events_test.go
@@ -472,7 +472,7 @@ func (s *EventsSuite) setupExecutionNodes(block *flow.Block) {
 
 	// this line causes a S1021 lint error because receipts is explicitly declared. this is required
 	// to ensure the mock library handles the response type correctly
-	var receipts flow.ExecutionReceiptList //nolint:gosimple
+	var receipts flow.ExecutionReceiptList //nolint:staticcheck
 	receipts = unittest.ReceiptsForBlockFixture(block, s.executionNodes.NodeIDs())
 	s.receipts.On("ByBlockID", block.ID()).Return(receipts, nil)
 

--- a/engine/access/rpc/backend/scripts/scripts_test.go
+++ b/engine/access/rpc/backend/scripts/scripts_test.go
@@ -133,7 +133,7 @@ func (s *BackendScriptsSuite) setupExecutionNodes(block *flow.Block) {
 
 	// this line causes a S1021 lint error because receipts is explicitly declared. this is required
 	// to ensure the mock library handles the response type correctly
-	var receipts flow.ExecutionReceiptList //nolint:gosimple
+	var receipts flow.ExecutionReceiptList //nolint:staticcheck
 	receipts = unittest.ReceiptsForBlockFixture(block, s.executionNodes.NodeIDs())
 	s.receipts.On("ByBlockID", block.ID()).Return(receipts, nil)
 

--- a/engine/access/rpc/backend/transactions/stream/stream_backend_test.go
+++ b/engine/access/rpc/backend/transactions/stream/stream_backend_test.go
@@ -193,7 +193,7 @@ func (s *TransactionStreamSuite) initializeBackend() {
 
 	// this line causes a S1021 lint error because receipts is explicitly declared. this is required
 	// to ensure the mock library handles the response type correctly
-	var receipts flow.ExecutionReceiptList //nolint:gosimple
+	var receipts flow.ExecutionReceiptList //nolint:staticcheck
 	executionNodes := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
 	receipts = unittest.ReceiptsForBlockFixture(s.rootBlock, executionNodes.NodeIDs())
 	s.receipts.On("ByBlockID", mock.AnythingOfType("flow.Identifier")).Return(receipts, nil).Maybe()

--- a/model/flow/identifier_test.go
+++ b/model/flow/identifier_test.go
@@ -27,7 +27,7 @@ func TestIdentifierFormat(t *testing.T) {
 
 	// should print hex representation with %s formatting verb
 	t.Run("%s", func(t *testing.T) {
-		formatted := fmt.Sprintf("%s", id) //nolint:gosimple
+		formatted := fmt.Sprintf("%s", id) //nolint:staticcheck
 		assert.Equal(t, id.String(), formatted)
 	})
 


### PR DESCRIPTION
There was a linter warning:

 The gosimple linter was merged into staticcheck - the rules (like S1021 mentioned in the comments) are still the same, but the nolint directive needs to reference staticcheck now.

```
make lint
...
WARN [runner/nolint_filter] Found unknown linters in //nolint directives: gosimple
...
```

ref: https://github.com/golangci/golangci-lint/pull/5487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration across multiple test files to improve code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->