### PR TITLE
[FVM] Remove unused error

### DIFF
--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -70,7 +70,8 @@ const (
 	ErrCodeAccountAuthorizationError   ErrorCode = 1055
 	ErrCodeOperationAuthorizationError ErrorCode = 1056
 	ErrCodeOperationNotSupportedError  ErrorCode = 1057
-	ErrCodeBlockHeightOutOfRangeError  ErrorCode = 1058
+	// Deprecated: No longer used.
+	ErrCodeBlockHeightOutOfRangeError ErrorCode = 1058
 
 	// execution errors 1100 - 1200
 	// Deprecated: No longer used.

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -248,17 +248,6 @@ func IsOperationNotSupportedError(err error) bool {
 	return HasErrorCode(err, ErrCodeOperationNotSupportedError)
 }
 
-func NewBlockHeightOutOfRangeError(height uint64) CodedError {
-	return NewCodedError(
-		ErrCodeBlockHeightOutOfRangeError,
-		"block height (%v) is out of queriable range",
-		height)
-}
-
-func IsBlockHeightOutOfRangeError(err error) bool {
-	return HasErrorCode(err, ErrCodeBlockHeightOutOfRangeError)
-}
-
 // NewScriptExecutionCancelledError construct a new CodedError which indicates
 // that Cadence Script execution has been cancelled (e.g. request connection
 // has been droped)


### PR DESCRIPTION
:broom: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Utilities for constructing and detecting block-height out-of-range errors have been removed. Integrations relying on those helpers will need updates to handle this error case differently.

* **Deprecations**
  * The block-height out-of-range error code is now marked deprecated and should not be used going forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->