### PR TITLE
[Flow EVM] Optimize EVMEncodeABI by removing an ArrayValue iteration

### DIFF
--- a/fvm/evm/impl/abi.go
+++ b/fvm/evm/impl/abi.go
@@ -262,21 +262,6 @@ func newInternalEVMTypeEncodeABIFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			reportArrayABIEncodingComputation(
-				context,
-				valuesArray,
-				evmSpecialTypeIDs,
-				func(intensity uint64) {
-					common.UseComputation(
-						context,
-						common.ComputationUsage{
-							Kind:      environment.ComputationKindEVMEncodeABI,
-							Intensity: intensity,
-						},
-					)
-				},
-			)
-
 			size := valuesArray.Count()
 
 			values := make([]any, 0, size)
@@ -285,6 +270,22 @@ func newInternalEVMTypeEncodeABIFunction(
 			valuesArray.Iterate(
 				context,
 				func(element interpreter.Value) (resume bool) {
+
+					reportABIEncodingComputation(
+						context,
+						element,
+						evmSpecialTypeIDs,
+						func(intensity uint64) {
+							common.UseComputation(
+								context,
+								common.ComputationUsage{
+									Kind:      environment.ComputationKindEVMEncodeABI,
+									Intensity: intensity,
+								},
+							)
+						},
+					)
+
 					value, ty, err := encodeABI(
 						context,
 						element,


### PR DESCRIPTION
Updates #8401

Currently, `EVMEncodeABI` iterates valuesArray (ArrayValue) twice. The first iteration is used to report ABI computation, and the second iteration is used to encode values.

This optimization combines ABI computation reporting and value encoding into one ArrayValue iteration.

### Details

The optimization checks limits before each computation inside the loop.  So the loop starts and it will exit early to prevent limits being exceeded during the loop.

- The happy path (entire loop is within limits) is optimized by looping once instead of twice.

- The unhappy path (entire loop doesn't fit within limits) is potentially less efficient because it is detected during the loop. So computations that are within limits are allowed during the loop, and the loop is exited early if the next computation won't fit within limits.

### Caveats

The current code (without this PR) is not metering empty `valuesArray`, so that aspect is unaffected by this PR.

Elements are metered regardless of type and value, so an element that is an empty `valuesArray` would still be metered. This aspect is also unaffected by this PR.

### Context

I found this quick hit, while looking for [other (larger) cross-vm optimizations](https://flow-foundation.slack.com/archives/C07NFGGAGHM/p1770402654200019).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

~~## Summary by CodeRabbit~~

~~* **Refactor**~~
  ~~* Enhanced computation intensity reporting for encoding operations to provide more granular, per-element metrics, enabling more detailed performance tracking and visibility.~~

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

EDIT: added Details and added Caveats.