### PR TITLE
[Flow EVM] Optimize EVM dryCall by removing RLP encoding/decoding

### DIFF
--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -467,23 +467,18 @@ func newInternalEVMTypeDryCallFunction(
 			}
 			to := callArgs.to.ToCommon()
 
-			tx := gethTypes.NewTx(&gethTypes.LegacyTx{
+			txData := &gethTypes.LegacyTx{
 				Nonce:    0,
 				To:       &to,
 				Gas:      uint64(callArgs.gasLimit),
 				Data:     callArgs.data,
 				GasPrice: big.NewInt(0),
 				Value:    callArgs.balance,
-			})
-
-			txPayload, err := tx.MarshalBinary()
-			if err != nil {
-				panic(err)
 			}
 
 			// call contract function
 
-			res := handler.DryRun(txPayload, callArgs.from)
+			res := handler.DryRunWithTxData(txData, callArgs.from)
 			return NewResultValue(handler, gauge, context, res)
 		},
 	)

--- a/fvm/evm/stdlib/contract_test.go
+++ b/fvm/evm/stdlib/contract_test.go
@@ -63,6 +63,7 @@ type testContractHandler struct {
 	batchRun             func(txs [][]byte, coinbase types.Address) []*types.ResultSummary
 	generateResourceUUID func() uint64
 	dryRun               func(tx []byte, from types.Address) *types.ResultSummary
+	dryRunWithTxData     func(txData gethTypes.TxData, from types.Address) *types.ResultSummary
 	commitBlockProposal  func()
 }
 
@@ -111,6 +112,13 @@ func (t *testContractHandler) DryRun(tx []byte, from types.Address) *types.Resul
 		panic("unexpected DryRun")
 	}
 	return t.dryRun(tx, from)
+}
+
+func (t *testContractHandler) DryRunWithTxData(txData gethTypes.TxData, from types.Address) *types.ResultSummary {
+	if t.dryRunWithTxData == nil {
+		panic("unexpected DryRunWithTxData")
+	}
+	return t.dryRunWithTxData(txData, from)
 }
 
 func (t *testContractHandler) BatchRun(txs [][]byte, coinbase types.Address) []*types.ResultSummary {
@@ -4311,12 +4319,9 @@ func TestEVMDryCall(t *testing.T) {
 	contractsAddress := flow.BytesToAddress([]byte{0x1})
 	handler := &testContractHandler{
 		evmContractAddress: common.Address(contractsAddress),
-		dryRun: func(tx []byte, from types.Address) *types.ResultSummary {
+		dryRunWithTxData: func(txData gethTypes.TxData, from types.Address) *types.ResultSummary {
 			dryCallCalled = true
-			gethTx := &gethTypes.Transaction{}
-			if err := gethTx.UnmarshalBinary(tx); err != nil {
-				require.Fail(t, err.Error())
-			}
+			gethTx := gethTypes.NewTx(txData)
 
 			require.NotNil(t, gethTx.To())
 
@@ -4821,12 +4826,9 @@ func TestCadenceOwnedAccountDryCall(t *testing.T) {
 
 	handler := &testContractHandler{
 		evmContractAddress: common.Address(contractsAddress),
-		dryRun: func(tx []byte, from types.Address) *types.ResultSummary {
+		dryRunWithTxData: func(txData gethTypes.TxData, from types.Address) *types.ResultSummary {
 			dryCallCalled = true
-			gethTx := &gethTypes.Transaction{}
-			if err := gethTx.UnmarshalBinary(tx); err != nil {
-				require.Fail(t, err.Error())
-			}
+			gethTx := gethTypes.NewTx(txData)
 
 			require.NotNil(t, gethTx.To())
 

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -120,6 +120,10 @@ var (
 	// ErrEmptyRLPEncodedProof is returned when the RLP encoded COA Ownership proof is
 	// an empty list
 	ErrEmptyRLPEncodedProof = errors.New("invalid encoded proof: expected list with key indices, got empty list")
+
+	// ErrUnexpectedEmptyTransactionData is returned when empty transaction data is received.
+	// This should never happen and is a safety error.
+	ErrUnexpectedEmptyTransactionData = errors.New("unexpected empty transaction data has been received")
 )
 
 // StateError is a non-fatal error, returned when a state operation

--- a/fvm/evm/types/handler.go
+++ b/fvm/evm/types/handler.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	gethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/onflow/cadence/common"
 )
 
@@ -42,6 +43,11 @@ type ContractHandler interface {
 	// from address is normally derived from the transaction signature.
 	// The function should not have any persisted changes made to the state.
 	DryRun(tx []byte, from Address) *ResultSummary
+
+	// DryRunWithTxData simulates execution of the provided transaction data.
+	// The from address is required since the transaction is unsigned.
+	// The function should not have any persisted changes made to the state.
+	DryRunWithTxData(txData types.TxData, from Address) *ResultSummary
 
 	// BatchRun runs transaction batch in the evm environment,
 	// collect all the gas fees and transfers the gas fees to the gasFeeCollector account.


### PR DESCRIPTION
Updates #8401

Currently, every call to EVM `dryCall()` incurs the overhead of encoding and decoding transaction data in RLP.

Specifically, EVM `dryCall()` encodes the provided transaction data to RLP, and then decodes the RLP encoding to create a transaction before executing the transaction.

This PR optimizies `dryCall()` by removing the RLP encoding and decoding steps, so the `dryCall()` executes a transaction created from the provided transaction data.

This also reduces `dryCall()` computation cost by removing `ComputationKindRLPDecoding` metering.

### Context

I found this quick hit, while looking for [other (larger) cross-vm optimizations](https://flow-foundation.slack.com/archives/C07NFGGAGHM/p1770402654200019).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public DryRunWithTxData API to simulate transactions directly from transaction-data objects (no binary payload required).
  * Dry-run flow now accepts TxData and constructs transactions for previewing execution results.

* **Tests**
  * Tests updated to use the new TxData-based dry-run path.

* **Other**
  * Introduced a new observable error for unexpected empty transaction data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->