### PR TITLE
[Network] Reduce logging for creating libp2p streams

### DIFF
--- a/network/p2p/node/libp2pNode.go
+++ b/network/p2p/node/libp2pNode.go
@@ -289,7 +289,7 @@ func (n *Node) createStream(ctx context.Context, peerID peer.ID) (libp2pnet.Stre
 		return nil, flownet.NewPeerUnreachableError(fmt.Errorf("could not create stream peer_id: %s: %w", peerID, err))
 	}
 
-	lg.Info().
+	lg.Debug().
 		Str("networking_protocol_id", string(stream.Protocol())).
 		Msg("stream successfully created to remote peer")
 	return stream, nil


### PR DESCRIPTION
This log is emitted multiple times per second on every node, and it very rarely is useful. we also have metrics that capture streams created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity for internal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->