### PR TITLE
go fix: remove obsolete +build directives

### DIFF
--- a/admin/tools.go
+++ b/admin/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package tools
 

--- a/ledger/common/hash/copy_generic.go
+++ b/ledger/common/hash/copy_generic.go
@@ -29,7 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //go:build (!amd64 && !386 && !ppc64le) || purego
-// +build !amd64,!386,!ppc64le purego
 
 package hash
 

--- a/ledger/common/hash/copy_unaligned.go
+++ b/ledger/common/hash/copy_unaligned.go
@@ -29,8 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //go:build (amd64 || 386 || ppc64le) && !purego
-// +build amd64 386 ppc64le
-// +build !purego
 
 package hash
 

--- a/ledger/common/hash/keccak.go
+++ b/ledger/common/hash/keccak.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64 && !purego && gc
-// +build amd64,!purego,gc
 
 package hash
 

--- a/ledger/common/hash/keccakf.go
+++ b/ledger/common/hash/keccakf.go
@@ -29,7 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //go:build !amd64 || purego || !gc
-// +build !amd64 purego !gc
 
 package hash
 

--- a/ledger/complete/wal/fadvise.go
+++ b/ledger/complete/wal/fadvise.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package wal
 

--- a/ledger/complete/wal/fadvise_linux.go
+++ b/ledger/complete/wal/fadvise_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package wal
 


### PR DESCRIPTION
Run of `go1.26.0 fix ./...` on the flow-go repository.
Removes `//+build` directives, which have been deprecated since Go 1.18 (replaced by `//go:build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal build configuration directives across multiple modules to use modern syntax. No changes to product functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->