### PR TITLE
[Flow EVM] Optimize and reduce computation cost of four EVM functions

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -58,7 +58,7 @@ func newConfig(ctx types.BlockContext) *Config {
 }
 
 // NewReadOnlyBlockView constructs a new read-only block view
-func (em *Emulator) NewReadOnlyBlockView(ctx types.BlockContext) (types.ReadOnlyBlockView, error) {
+func (em *Emulator) NewReadOnlyBlockView() (types.ReadOnlyBlockView, error) {
 	execState, err := state.NewStateDB(em.ledger, em.rootAddr)
 	return &ReadOnlyBlockView{
 		state: execState,

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -38,7 +38,7 @@ func RunWithNewBlockView(t testing.TB, em *emulator.Emulator, f func(blk types.B
 }
 
 func RunWithNewReadOnlyBlockView(t testing.TB, em *emulator.Emulator, f func(blk types.ReadOnlyBlockView)) {
-	blk, err := em.NewReadOnlyBlockView(defaultCtx)
+	blk, err := em.NewReadOnlyBlockView()
 	require.NoError(t, err)
 	f(blk)
 }

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -737,16 +737,7 @@ func (a *Account) Nonce() uint64 {
 }
 
 func (a *Account) nonce() (uint64, error) {
-	bp, err := a.fch.getBlockProposal()
-	if err != nil {
-		return 0, err
-	}
-	ctx, err := a.fch.getBlockContext(bp)
-	if err != nil {
-		return 0, err
-	}
-
-	blk, err := a.fch.emulator.NewReadOnlyBlockView(ctx)
+	blk, err := a.fch.emulator.NewReadOnlyBlockView()
 	if err != nil {
 		return 0, err
 	}
@@ -765,17 +756,7 @@ func (a *Account) Balance() types.Balance {
 }
 
 func (a *Account) balance() (types.Balance, error) {
-	bp, err := a.fch.getBlockProposal()
-	if err != nil {
-		return nil, err
-	}
-
-	ctx, err := a.fch.getBlockContext(bp)
-	if err != nil {
-		return nil, err
-	}
-
-	blk, err := a.fch.emulator.NewReadOnlyBlockView(ctx)
+	blk, err := a.fch.emulator.NewReadOnlyBlockView()
 	if err != nil {
 		return nil, err
 	}
@@ -795,17 +776,7 @@ func (a *Account) Code() types.Code {
 }
 
 func (a *Account) code() (types.Code, error) {
-	bp, err := a.fch.getBlockProposal()
-	if err != nil {
-		return nil, err
-	}
-
-	ctx, err := a.fch.getBlockContext(bp)
-	if err != nil {
-		return nil, err
-	}
-
-	blk, err := a.fch.emulator.NewReadOnlyBlockView(ctx)
+	blk, err := a.fch.emulator.NewReadOnlyBlockView()
 	if err != nil {
 		return nil, err
 	}
@@ -823,17 +794,7 @@ func (a *Account) CodeHash() []byte {
 }
 
 func (a *Account) codeHash() ([]byte, error) {
-	bp, err := a.fch.getBlockProposal()
-	if err != nil {
-		return nil, err
-	}
-
-	ctx, err := a.fch.getBlockContext(bp)
-	if err != nil {
-		return nil, err
-	}
-
-	blk, err := a.fch.emulator.NewReadOnlyBlockView(ctx)
+	blk, err := a.fch.emulator.NewReadOnlyBlockView()
 	if err != nil {
 		return nil, err
 	}

--- a/fvm/evm/testutils/accounts.go
+++ b/fvm/evm/testutils/accounts.go
@@ -144,7 +144,7 @@ func FundAndGetEOATestAccount(t testing.TB, led atree.Ledger, flowEVMRootAddress
 	)
 	require.NoError(t, err)
 
-	blk2, err := e.NewReadOnlyBlockView(types.NewDefaultBlockContext(2))
+	blk2, err := e.NewReadOnlyBlockView()
 	require.NoError(t, err)
 
 	bal, err := blk2.BalanceOf(account.Address())

--- a/fvm/evm/testutils/contract.go
+++ b/fvm/evm/testutils/contract.go
@@ -84,7 +84,7 @@ func DeployContract(t testing.TB, caller types.Address, tc *TestContract, led at
 
 	ctx := types.NewDefaultBlockContext(2)
 
-	bl, err := e.NewReadOnlyBlockView(ctx)
+	bl, err := e.NewReadOnlyBlockView()
 	require.NoError(t, err)
 
 	nonce, err := bl.NonceOf(caller)

--- a/fvm/evm/testutils/emulator.go
+++ b/fvm/evm/testutils/emulator.go
@@ -29,7 +29,7 @@ func (em *TestEmulator) NewBlockView(_ types.BlockContext) (types.BlockView, err
 }
 
 // NewBlock returns a new block view
-func (em *TestEmulator) NewReadOnlyBlockView(_ types.BlockContext) (types.ReadOnlyBlockView, error) {
+func (em *TestEmulator) NewReadOnlyBlockView() (types.ReadOnlyBlockView, error) {
 	return em, nil
 }
 

--- a/fvm/evm/types/emulator.go
+++ b/fvm/evm/types/emulator.go
@@ -102,7 +102,7 @@ type BlockView interface {
 // Emulator emulates an evm-compatible chain
 type Emulator interface {
 	// constructs a new block view
-	NewReadOnlyBlockView(ctx BlockContext) (ReadOnlyBlockView, error)
+	NewReadOnlyBlockView() (ReadOnlyBlockView, error)
 
 	// constructs a new block
 	NewBlockView(ctx BlockContext) (BlockView, error)


### PR DESCRIPTION
Updates #8401

Currently, calling `NewReadOnlyBlockView()` incurs the overhead and computation cost of always reading a register from storage, and potentially also writing a register to the storage.

Specifically, `Emulator.NewReadOnlyBlockView()` receives `BlockContext` param without actually using it.  Creating `BlockContext` requires reading `BlockProposal` from storage, which incurs `GetValue` and potentially `SetValue` computation cost.

This PR removes the unnecessary `BlockContext` param in `Emulator.NewReadOnlyBlockView()`.  This optimization avoids reading a register and reduces computation cost in these EVM functions:
- `EVMAddress.balance()`
- `EVMAddress.code()`
- `EVMAddress.codeHash()`
- `EVMAddress.nonce()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the EVM Emulator's read-only block view creation method by removing the block context parameter requirement. This change simplifies the internal API while maintaining existing functionality for querying account balance, code, and nonce information. All affected call sites and test utilities have been updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->