### PR TITLE
[Access] Fix `ParseAddress()` by only removing prefix "0x"

### DIFF
--- a/engine/access/rest/common/parser/address.go
+++ b/engine/access/rest/common/parser/address.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ParseAddress(raw string, chain flow.Chain) (flow.Address, error) {
-	raw = strings.ReplaceAll(raw, "0x", "") // remove 0x prefix
+	raw = strings.TrimPrefix(raw, "0x") // remove 0x prefix
 
 	valid, _ := regexp.MatchString(`^[0-9a-fA-F]{16}$`, raw)
 	if !valid {

--- a/engine/access/rest/common/parser/address_test.go
+++ b/engine/access/rest/common/parser/address_test.go
@@ -19,6 +19,7 @@ func TestAddress_InvalidParse(t *testing.T) {
 		"foo",
 		"1",
 		"@",
+		"0x0x0b807ae5da6210df",
 		"ead892083b3e2c61222", // too long
 	}
 


### PR DESCRIPTION
Currently, `ParseAddress()` removes all instances of "0x" in the address input, instead of just the "0x" prefix.

This bug can cause an invalid input address containing a non-prefix "0x" to be treated as valid.

This PR:
- only removes "0x" only if it is a prefix
- returns an error if "0x" is present as a non-prefix
- adds a test case for this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address parsing normalization to remove only a single leading "0x" prefix instead of stripping all occurrences. This ensures more robust handling of address inputs with unusual formatting and enhances validation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->