### PR TITLE
[Access] Include computation used passed from execution nodes

### DIFF
--- a/engine/access/rpc/backend/transactions/provider/execution_node.go
+++ b/engine/access/rpc/backend/transactions/provider/execution_node.go
@@ -117,14 +117,15 @@ func (e *ENTransactionProvider) TransactionResult(
 	}
 
 	return &accessmodel.TransactionResult{
-		TransactionID: transactionID,
-		Status:        txStatus,
-		StatusCode:    uint(resp.GetStatusCode()),
-		Events:        events,
-		ErrorMessage:  resp.GetErrorMessage(),
-		BlockID:       blockID,
-		BlockHeight:   block.Height,
-		CollectionID:  collectionID,
+		TransactionID:   transactionID,
+		Status:          txStatus,
+		StatusCode:      uint(resp.GetStatusCode()),
+		Events:          events,
+		ErrorMessage:    resp.GetErrorMessage(),
+		BlockID:         blockID,
+		BlockHeight:     block.Height,
+		CollectionID:    collectionID,
+		ComputationUsed: resp.GetComputationUsage(),
 	}, nil
 }
 
@@ -216,14 +217,15 @@ func (e *ENTransactionProvider) TransactionResultByIndex(
 
 	// convert to response, cache and return
 	return &accessmodel.TransactionResult{
-		Status:        txStatus,
-		StatusCode:    uint(resp.GetStatusCode()),
-		Events:        events,
-		ErrorMessage:  resp.GetErrorMessage(),
-		BlockID:       blockID,
-		BlockHeight:   block.Height,
-		TransactionID: txID,
-		CollectionID:  collectionID,
+		Status:          txStatus,
+		StatusCode:      uint(resp.GetStatusCode()),
+		Events:          events,
+		ErrorMessage:    resp.GetErrorMessage(),
+		BlockID:         blockID,
+		BlockHeight:     block.Height,
+		TransactionID:   txID,
+		CollectionID:    collectionID,
+		ComputationUsed: resp.GetComputationUsage(),
 	}, nil
 }
 
@@ -368,14 +370,15 @@ func (e *ENTransactionProvider) userTransactionResults(
 			}
 
 			results = append(results, &accessmodel.TransactionResult{
-				Status:        txStatus,
-				StatusCode:    uint(txResult.GetStatusCode()),
-				Events:        events,
-				ErrorMessage:  txResult.GetErrorMessage(),
-				BlockID:       blockID,
-				TransactionID: txID,
-				CollectionID:  guarantee.CollectionID,
-				BlockHeight:   block.Height,
+				Status:          txStatus,
+				StatusCode:      uint(txResult.GetStatusCode()),
+				Events:          events,
+				ErrorMessage:    txResult.GetErrorMessage(),
+				BlockID:         blockID,
+				TransactionID:   txID,
+				CollectionID:    guarantee.CollectionID,
+				BlockHeight:     block.Height,
+				ComputationUsed: txResult.GetComputationUsage(),
 			})
 
 			i++
@@ -419,14 +422,15 @@ func (e *ENTransactionProvider) systemTransactionResults(
 		}
 
 		results = append(results, &accessmodel.TransactionResult{
-			Status:        txStatus,
-			StatusCode:    uint(systemTxResult.GetStatusCode()),
-			Events:        events,
-			ErrorMessage:  systemTxResult.GetErrorMessage(),
-			BlockID:       blockID,
-			TransactionID: systemTxIDs[i],
-			CollectionID:  flow.ZeroID,
-			BlockHeight:   block.Height,
+			Status:          txStatus,
+			StatusCode:      uint(systemTxResult.GetStatusCode()),
+			Events:          events,
+			ErrorMessage:    systemTxResult.GetErrorMessage(),
+			BlockID:         blockID,
+			TransactionID:   systemTxIDs[i],
+			CollectionID:    flow.ZeroID,
+			BlockHeight:     block.Height,
+			ComputationUsed: systemTxResult.GetComputationUsage(),
 		})
 	}
 

--- a/engine/access/rpc/backend/transactions/transactions_functional_test.go
+++ b/engine/access/rpc/backend/transactions/transactions_functional_test.go
@@ -598,10 +598,9 @@ func (s *TransactionsFunctionalSuite) TestTransactionResult_ExecutionNode() {
 		ErrorMessage:         accessResponse.ErrorMessage,
 		Events:               accessResponse.Events,
 		EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
+		ComputationUsage:     accessResponse.ComputationUsage,
 	}
-	// The EN gRPC response does not include per-transaction ComputationUsed.
 	expectedResult := s.expectedResultForIndex(1, entities.EventEncodingVersion_JSON_CDC_V0)
-	expectedResult.ComputationUsed = 0
 
 	expectedRequest := &execproto.GetTransactionResultRequest{
 		BlockId:       blockID[:],
@@ -630,10 +629,9 @@ func (s *TransactionsFunctionalSuite) TestTransactionResultByIndex_ExecutionNode
 		ErrorMessage:         accessResponse.ErrorMessage,
 		Events:               accessResponse.Events,
 		EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
+		ComputationUsage:     accessResponse.ComputationUsage,
 	}
-	// The EN gRPC response does not include per-transaction ComputationUsed.
 	expectedResult := s.expectedResultForIndex(1, entities.EventEncodingVersion_JSON_CDC_V0)
-	expectedResult.ComputationUsed = 0
 
 	expectedRequest := &execproto.GetTransactionByIndexRequest{
 		BlockId: blockID[:],
@@ -688,13 +686,12 @@ func (s *TransactionsFunctionalSuite) TestTransactionResultsByBlockID_ExecutionN
 	for i := range s.tf.ExpectedResults {
 		accessResponse := convert.TransactionResultToMessage(s.expectedResultForIndex(i, entities.EventEncodingVersion_CCF_V0))
 		nodeResults[i] = &execproto.GetTransactionResultResponse{
-			StatusCode:   accessResponse.StatusCode,
-			ErrorMessage: accessResponse.ErrorMessage,
-			Events:       accessResponse.Events,
+			StatusCode:       accessResponse.StatusCode,
+			ErrorMessage:     accessResponse.ErrorMessage,
+			Events:           accessResponse.Events,
+			ComputationUsage: accessResponse.ComputationUsage,
 		}
-		// The EN gRPC response does not include per-transaction ComputationUsed.
 		expectedResults[i] = s.expectedResultForIndex(i, entities.EventEncodingVersion_JSON_CDC_V0)
-		expectedResults[i].ComputationUsed = 0
 	}
 
 	nodeResponse := &execproto.GetTransactionResultsResponse{


### PR DESCRIPTION
https://github.com/onflow/flow-go/pull/8451 added support for returning computation used.
https://github.com/onflow/flow-go/pull/8458 updates ENs to include it in their response.

This PR hooks populates computation used when getting transaction results from execution nodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction results now include a new field that exposes computation resource usage metrics from execution node responses, allowing clients to see computation consumption for each transaction.

* **Tests**
  * Updated test expectations to verify computation usage is properly propagated in transaction result responses across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->