### PR TITLE
[Access] Don't require stateStreamBackend in access bootstrap

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -2264,7 +2264,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				utils.NotNil(builder.nodeBackend),
 				utils.NotNil(builder.secureGrpcServer),
 				utils.NotNil(builder.unsecureGrpcServer),
-				utils.NotNil(builder.stateStreamBackend),
+				builder.stateStreamBackend, // might be nil
 				builder.stateStreamConf,
 				indexReporter,
 				builder.FollowerDistributor,


### PR DESCRIPTION
This is causing ANs with the state stream API disabled to crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal initialization flexibility for the state stream backend component by allowing conditional nil handling in downstream logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->