### PR TITLE
[Access] Don't require stateStreamBackend in access bootstrap

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -2264,7 +2264,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				utils.NotNil(builder.nodeBackend),
 				utils.NotNil(builder.secureGrpcServer),
 				utils.NotNil(builder.unsecureGrpcServer),
-				utils.NotNil(builder.stateStreamBackend),
+				builder.stateStreamBackend, // might be nil
 				builder.stateStreamConf,
 				indexReporter,
 				builder.FollowerDistributor,


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-go/pull/8462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated access node initialization to make the state stream backend optional, improving flexibility during node startup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->