### PR TITLE
Improve debug logs for mismatching events

### DIFF
--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -308,7 +308,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 				Str("event_tx_id", event.TransactionID.String()).
 				Uint32("event_tx_index", event.TransactionIndex).
 				Uint32("event_index", event.EventIndex).
-				Bytes("event_payload", event.Payload).
+				Hex("event_payload", event.Payload).
 				Str("block_id", chunk.BlockID.String()).
 				Str("collection_id", collectionID).
 				Str("result_id", result.ID().String()).


### PR DESCRIPTION
When verification of events fails, the logs include the event payload. 

Currently it is logged as a string, where parts are omitted because they are invalid (Unicode replacement character), e.g.  `"\u0601��آ�@x9A.1d7e57aa55817448.NonFungibleToken.NFT.ResourceDestroyed��bid؉\x0f�duuid؉\x0f�؈@�\x1b\x03V��\x00\x01\x00\x01\x1b\x00\x00\x13\x00\x00&�\x10"`

Instead, given the data is CBOR and not e.g. JSON, log the data as hex, like `d8818281d8a28340782a412e663233336463656538386665306162652e46756e6769626c65546f6b656e2e4465706f736974656486826474797065d889018266616d6f756e74d889178262746fd88ad889038266746f55554944d8890f826d6465706f736974656455554944d8890f826c62616c616e63654166746572d8891782d88840867822412e313635343635333339393034306136312e466c6f77546f6b656e2e5661756c741a0002d69048f919ee77447b7497001b000067000026d3271b00000047c20bdae1`, so it can be debugged in tools like https://cbor.me

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved debug logging for event verification by enhancing log data representation format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->