### PR TITLE
Increase staking auction length for epochs tests

### DIFF
--- a/integration/tests/epochs/dynamic_epoch_transition_suite.go
+++ b/integration/tests/epochs/dynamic_epoch_transition_suite.go
@@ -53,7 +53,7 @@ func (s *DynamicEpochTransitionSuite) SetupTest() {
 	// try increasing (by 10-20 views).
 	s.StakingAuctionLen = 70
 	s.DKGPhaseLen = 50
-	s.EpochLen = 250
+	s.EpochLen = 270
 	s.FinalizationSafetyThreshold = 20
 
 	// run the generic setup, which starts up the network


### PR DESCRIPTION
Increase the staking auction to allow more time for the epochs integration tests (`TestEpochJoinAndLeaveLN`, `TestEpochJoinAndLeaveAN`) to stake and remove nodes. Necessary because CI is failing due to the epoch phase transition happening before the setup transactions finish.
Supersedes #8495