### PR TITLE
[Access] Completely disable bitswap reproviding when bitswap-reprovide-enabled=false

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -842,6 +842,10 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 				blob.WithParentBlobService(bs),
 			}
 
+			if !builder.BitswapReprovideEnabled {
+				opts = append(opts, blob.WithReprovideInterval(-1))
+			}
+
 			net := builder.AccessNodeConfig.PublicNetworkConfig.Network
 
 			var err error

--- a/network/p2p/blob/blob_service.go
+++ b/network/p2p/blob/blob_service.go
@@ -161,6 +161,11 @@ func NewBlobService(
 			}
 		}).
 		AddWorker(func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+			if bs.config.ReprovideInterval < 0 {
+				ready()
+				return
+			}
+
 			// New creates and starts the reprovider (non-blocking)
 			reprovider, err := provider.New(ds,
 				provider.Online(r),
@@ -182,7 +187,9 @@ func NewBlobService(
 
 			var err *multierror.Error
 
-			err = multierror.Append(err, bs.reprovider.Close())
+			if bs.reprovider != nil {
+				err = multierror.Append(err, bs.reprovider.Close())
+			}
 			err = multierror.Append(err, bs.blockService.Close())
 
 			if err.ErrorOrNil() != nil {
@@ -197,6 +204,9 @@ func NewBlobService(
 }
 
 func (bs *blobService) TriggerReprovide(ctx context.Context) error {
+	if bs.reprovider == nil {
+		return nil
+	}
 	return bs.reprovider.Reprovide(ctx)
 }
 


### PR DESCRIPTION
This flag currently sets the reprovide interval to -1 which disables it within the bitswap library. This avoids setting up any of the objects.