### PR TITLE
[Access] Allow disabling bitswap reproviding on public network

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -846,6 +846,10 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 				blob.WithParentBlobService(bs),
 			}
 
+			if !builder.BitswapReprovideEnabled {
+				opts = append(opts, blob.WithReprovideInterval(-1))
+			}
+
 			net := builder.AccessNodeConfig.PublicNetworkConfig.Network
 
 			var err error


### PR DESCRIPTION
Bitswap reproviding isn't required, so allow disabling it.

This logic was added to the staked network bitswap setup, but never ported to the public network setup.
https://github.com/onflow/flow-go/blob/ff9b45e9465d3ddf680adf58f3e00277c897eeb7/cmd/access/node_builder/access_node_builder.go#L677-L679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blob service configuration to properly handle bitswap reprovide settings across execution data services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->