### PR TITLE
Enforce global stream limit per WebSocket subscription

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1763,6 +1763,10 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			return errors.New("execution-data-indexing-enabled must be set if store-tx-result-error-messages is enabled")
 		}
 
+		if builder.stateStreamConf.MaxGlobalStreams == 0 {
+			return errors.New("state-stream-global-max-streams must be greater than 0")
+		}
+
 		return nil
 	})
 }

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -945,6 +945,10 @@ func (builder *ObserverServiceBuilder) extraFlags() {
 			return errors.New("rest-max-request-size must be greater than 0")
 		}
 
+		if builder.stateStreamConf.MaxGlobalStreams == 0 {
+			return errors.New("state-stream-global-max-streams must be greater than 0")
+		}
+
 		return nil
 	})
 }

--- a/engine/access/rest/router/router.go
+++ b/engine/access/rest/router/router.go
@@ -108,15 +108,14 @@ func (b *RouterBuilder) AddWebsocketsRoute(
 	maxRequestSize int64,
 	maxResponseSize int64,
 	dataProviderFactory dp.DataProviderFactory,
-	limiter *limiters.ConcurrencyLimiter,
+	streamLimiter *limiters.ConcurrencyLimiter,
 ) *RouterBuilder {
-	h := websockets.NewWebSocketHandler(ctx, b.logger, config, chain, maxRequestSize, maxResponseSize, dataProviderFactory)
-	handler := websockets.NewConnectionLimitedHandler(b.logger, h.HttpHandler, h, limiter)
+	h := websockets.NewWebSocketHandler(ctx, b.logger, config, chain, maxRequestSize, maxResponseSize, dataProviderFactory, streamLimiter)
 	b.v1SubRouter.
 		Methods(http.MethodGet).
 		Path("/ws").
 		Name("ws").
-		Handler(handler)
+		Handler(h)
 
 	return b
 }

--- a/engine/access/rest/server.go
+++ b/engine/access/rest/server.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -55,6 +56,10 @@ func NewServer(
 	extendedBackend extended.API,
 	limiter *limiters.ConcurrencyLimiter,
 ) (*http.Server, error) {
+	if limiter == nil && (stateStreamApi != nil || enableNewWebsocketsStreamAPI) {
+		return nil, errors.New("stream limiter is required when websocket routes are enabled")
+	}
+
 	builder := router.NewRouterBuilder(logger, restCollector).AddRestRoutes(serverAPI, chain, config.MaxRequestSize, config.MaxResponseSize)
 	if stateStreamApi != nil {
 		builder.AddLegacyWebsocketsRoutes(stateStreamApi, chain, stateStreamConfig, config.MaxRequestSize, config.MaxResponseSize, limiter)

--- a/engine/access/rest/websockets/controller.go
+++ b/engine/access/rest/websockets/controller.go
@@ -148,7 +148,11 @@ func NewWebSocketController(
 	conn WebsocketConnection,
 	dataProviderFactory dp.DataProviderFactory,
 	streamLimiter *limiters.ConcurrencyLimiter,
-) *Controller {
+) (*Controller, error) {
+	if streamLimiter == nil {
+		return nil, errors.New("stream limiter is required")
+	}
+
 	var rateLimiter *rate.Limiter
 	if config.MaxResponsesPerSecond > 0 {
 		rateLimiter = rate.NewLimiter(rate.Limit(config.MaxResponsesPerSecond), 1)
@@ -165,7 +169,7 @@ func NewWebSocketController(
 		rateLimiter:         rateLimiter,
 		streamLimiter:       streamLimiter,
 		keepaliveConfig:     DefaultKeepaliveConfig(),
-	}
+	}, nil
 }
 
 // HandleConnection manages the lifecycle of a WebSocket connection,

--- a/engine/access/rest/websockets/controller.go
+++ b/engine/access/rest/websockets/controller.go
@@ -89,6 +89,7 @@ import (
 
 	dp "github.com/onflow/flow-go/engine/access/rest/websockets/data_providers"
 	"github.com/onflow/flow-go/engine/access/rest/websockets/models"
+	"github.com/onflow/flow-go/module/limiters"
 	"github.com/onflow/flow-go/utils/concurrentmap"
 )
 
@@ -135,7 +136,8 @@ type Controller struct {
 	dataProviders       *concurrentmap.Map[SubscriptionID, dp.DataProvider]
 	dataProviderFactory dp.DataProviderFactory
 	dataProvidersGroup  *sync.WaitGroup
-	limiter             *rate.Limiter
+	rateLimiter         *rate.Limiter
+	streamLimiter       *limiters.ConcurrencyLimiter
 
 	keepaliveConfig KeepaliveConfig
 }
@@ -145,10 +147,11 @@ func NewWebSocketController(
 	config Config,
 	conn WebsocketConnection,
 	dataProviderFactory dp.DataProviderFactory,
+	streamLimiter *limiters.ConcurrencyLimiter,
 ) *Controller {
-	var limiter *rate.Limiter
+	var rateLimiter *rate.Limiter
 	if config.MaxResponsesPerSecond > 0 {
-		limiter = rate.NewLimiter(rate.Limit(config.MaxResponsesPerSecond), 1)
+		rateLimiter = rate.NewLimiter(rate.Limit(config.MaxResponsesPerSecond), 1)
 	}
 
 	return &Controller{
@@ -159,7 +162,8 @@ func NewWebSocketController(
 		dataProviders:       concurrentmap.New[SubscriptionID, dp.DataProvider](),
 		dataProviderFactory: dataProviderFactory,
 		dataProvidersGroup:  &sync.WaitGroup{},
-		limiter:             limiter,
+		rateLimiter:         rateLimiter,
+		streamLimiter:       streamLimiter,
 		keepaliveConfig:     DefaultKeepaliveConfig(),
 	}
 }
@@ -442,8 +446,20 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 		return
 	}
 
+	// Check if the global stream limit has been reached.
+	if !c.streamLimiter.Acquire() {
+		err := fmt.Errorf("error creating new subscription: maximum number of streams reached")
+		c.writeErrorResponse(
+			ctx,
+			err,
+			wrapErrorMessage(http.StatusTooManyRequests, err.Error(), models.SubscribeAction, msg.SubscriptionID),
+		)
+		return
+	}
+
 	subscriptionID, err := c.parseOrCreateSubscriptionID(msg.SubscriptionID)
 	if err != nil {
+		c.streamLimiter.Release()
 		err = fmt.Errorf("error parsing subscription id: %w", err)
 		c.writeErrorResponse(
 			ctx,
@@ -456,6 +472,7 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 	// register new provider
 	provider, err := c.dataProviderFactory.NewDataProvider(ctx, subscriptionID.String(), msg.Topic, msg.Arguments, c.multiplexedStream)
 	if err != nil {
+		c.streamLimiter.Release()
 		err = fmt.Errorf("error creating data provider: %w", err)
 		c.writeErrorResponse(
 			ctx,
@@ -478,6 +495,8 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 	// run provider
 	c.dataProvidersGroup.Add(1)
 	go func() {
+		defer c.streamLimiter.Release()
+
 		err = provider.Run()
 		if err != nil {
 			err = fmt.Errorf("internal error: %w", err)
@@ -604,9 +623,9 @@ func (c *Controller) parseOrCreateSubscriptionID(id string) (SubscriptionID, err
 // An error is returned if the context is canceled or the expected wait time exceeds the context's
 // deadline.
 func (c *Controller) checkRateLimit(ctx context.Context) error {
-	if c.limiter == nil {
+	if c.rateLimiter == nil {
 		return nil
 	}
 
-	return c.limiter.WaitN(ctx, 1)
+	return c.rateLimiter.WaitN(ctx, 1)
 }

--- a/engine/access/rest/websockets/controller_test.go
+++ b/engine/access/rest/websockets/controller_test.go
@@ -23,6 +23,7 @@ import (
 	connmock "github.com/onflow/flow-go/engine/access/rest/websockets/mock"
 	"github.com/onflow/flow-go/engine/access/rest/websockets/models"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/limiters"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -30,8 +31,9 @@ import (
 type WsControllerSuite struct {
 	suite.Suite
 
-	logger   zerolog.Logger
-	wsConfig Config
+	logger        zerolog.Logger
+	wsConfig      Config
+	streamLimiter *limiters.ConcurrencyLimiter
 }
 
 func TestControllerSuite(t *testing.T) {
@@ -42,6 +44,10 @@ func TestControllerSuite(t *testing.T) {
 func (s *WsControllerSuite) SetupTest() {
 	s.logger = unittest.Logger()
 	s.wsConfig = NewDefaultWebsocketConfig()
+
+	var err error
+	s.streamLimiter, err = limiters.NewConcurrencyLimiter(1000)
+	s.Require().NoError(err)
 }
 
 // TestSubscribeRequest tests the subscribe to topic flow.
@@ -51,7 +57,7 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -115,7 +121,7 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, _ := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		type Request struct {
 			Action string `json:"action"`
@@ -164,7 +170,7 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, _ := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -201,7 +207,7 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		// data provider might finish on its own or controller will close it via Close()
 		dataProvider.On("Close").Return(nil).Maybe()
@@ -245,12 +251,152 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 	})
 }
 
+// TestGlobalStreamLimiter verifies that the global stream limiter correctly
+// controls subscription creation and releases slots on completion or error.
+func (s *WsControllerSuite) TestGlobalStreamLimiter() {
+	s.T().Run("Rejects subscription when global limit reached", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a limiter with capacity 1 and exhaust it.
+		streamLimiter, err := limiters.NewConcurrencyLimiter(1)
+		require.NoError(t, err)
+		require.True(t, streamLimiter.Acquire()) // exhaust the single slot
+
+		conn, dataProviderFactory, _ := newControllerMocks(t)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+
+		done := make(chan struct{})
+		subscriptionID := "dummy-id"
+		s.expectSubscribeRequest(t, conn, subscriptionID)
+
+		conn.
+			On("WriteJSON", mock.Anything).
+			Return(func(msg interface{}) error {
+				defer close(done)
+
+				response, ok := msg.(models.BaseMessageResponse)
+				require.True(t, ok)
+				require.NotEmpty(t, response.Error)
+				require.Equal(t, http.StatusTooManyRequests, response.Error.Code)
+				require.Contains(t, response.Error.Message, "maximum number of streams reached")
+
+				return &websocket.CloseError{Code: websocket.CloseNormalClosure}
+			})
+
+		s.expectCloseConnection(conn, done)
+
+		controller.HandleConnection(context.Background())
+
+		conn.AssertExpectations(t)
+		// Factory should never be called — rejected before provider creation.
+		dataProviderFactory.AssertExpectations(t)
+
+		// The externally acquired slot must still be held.
+		require.False(t, streamLimiter.Acquire(), "externally acquired slot should still be held")
+		streamLimiter.Release()
+	})
+
+	s.T().Run("Releases slot when provider creation fails", func(t *testing.T) {
+		t.Parallel()
+
+		streamLimiter, err := limiters.NewConcurrencyLimiter(1)
+		require.NoError(t, err)
+
+		conn, dataProviderFactory, _ := newControllerMocks(t)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+
+		dataProviderFactory.
+			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("invalid topic")).
+			Once()
+
+		done := make(chan struct{})
+		subscriptionID := "dummy-id"
+		s.expectSubscribeRequest(t, conn, subscriptionID)
+
+		conn.
+			On("WriteJSON", mock.Anything).
+			Return(func(msg interface{}) error {
+				defer close(done)
+
+				response, ok := msg.(models.BaseMessageResponse)
+				require.True(t, ok)
+				require.NotEmpty(t, response.Error)
+				require.Equal(t, http.StatusBadRequest, response.Error.Code)
+
+				return &websocket.CloseError{Code: websocket.CloseNormalClosure}
+			})
+
+		s.expectCloseConnection(conn, done)
+
+		controller.HandleConnection(context.Background())
+
+		// Slot must have been released despite the error.
+		require.True(t, streamLimiter.Acquire(), "slot should be released after provider creation failure")
+		streamLimiter.Release()
+
+		conn.AssertExpectations(t)
+		dataProviderFactory.AssertExpectations(t)
+	})
+
+	s.T().Run("Releases slot when provider completes", func(t *testing.T) {
+		t.Parallel()
+
+		streamLimiter, err := limiters.NewConcurrencyLimiter(1)
+		require.NoError(t, err)
+
+		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+
+		dataProvider.On("Close").Return(nil).Maybe()
+		dataProvider.
+			On("Run", mock.Anything).
+			Return(nil).
+			Once()
+
+		dataProviderFactory.
+			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(dataProvider, nil).
+			Once()
+
+		done := make(chan struct{})
+		subscriptionID := "dummy-id"
+		s.expectSubscribeRequest(t, conn, subscriptionID)
+
+		// When the subscribe OK response is written, close done to trigger
+		// connection shutdown. The provider runs and completes immediately
+		// (Run returns nil), so no further writes are expected.
+		conn.
+			On("WriteJSON", mock.Anything).
+			Run(func(args mock.Arguments) {
+				response, ok := args.Get(0).(models.SubscribeMessageResponse)
+				require.True(t, ok)
+				require.Equal(t, subscriptionID, response.SubscriptionID)
+				close(done)
+			}).
+			Return(nil).
+			Once()
+
+		s.expectCloseConnection(conn, done)
+
+		controller.HandleConnection(context.Background())
+
+		// Slot must have been released after provider completed.
+		require.True(t, streamLimiter.Acquire(), "slot should be released after provider completes")
+		streamLimiter.Release()
+
+		conn.AssertExpectations(t)
+		dataProviderFactory.AssertExpectations(t)
+		dataProvider.AssertExpectations(t)
+	})
+}
+
 func (s *WsControllerSuite) TestUnsubscribeRequest() {
 	s.T().Run("Happy path", func(t *testing.T) {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -318,7 +464,7 @@ func (s *WsControllerSuite) TestUnsubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -388,7 +534,7 @@ func (s *WsControllerSuite) TestUnsubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -461,7 +607,7 @@ func (s *WsControllerSuite) TestListSubscriptions() {
 	s.T().Run("Happy path", func(t *testing.T) {
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -543,7 +689,7 @@ func (s *WsControllerSuite) TestSubscribeBlocks() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -597,7 +743,7 @@ func (s *WsControllerSuite) TestSubscribeBlocks() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -682,7 +828,7 @@ func (s *WsControllerSuite) TestRateLimiter() {
 	config := NewDefaultWebsocketConfig()
 	config.MaxResponsesPerSecond = 2
 
-	controller := NewWebSocketController(s.logger, config, conn, nil)
+	controller := NewWebSocketController(s.logger, config, conn, nil, s.streamLimiter)
 
 	// Step 3: Simulate sending messages to the controller's `multiplexedStream`.
 	go func() {
@@ -733,7 +879,7 @@ func (s *WsControllerSuite) TestConfigureKeepaliveConnection() {
 		conn.On("SetReadDeadline", mock.Anything).Return(nil)
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
 
 		err := controller.configureKeepalive()
 		s.Require().NoError(err, "configureKeepalive should not return an error")
@@ -752,7 +898,7 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		conn.On("SetPongHandler", mock.AnythingOfType("func(string) error")).Return(nil).Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
 
 		// Mock keepalive to return an error
 		done := make(chan struct{}, 1)
@@ -786,7 +932,7 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		conn.On("SetPongHandler", mock.AnythingOfType("func(string) error")).Return(nil).Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
 
 		conn.
 			On("ReadJSON", mock.Anything).
@@ -803,7 +949,7 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -852,7 +998,7 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		conn.On("SetPongHandler", mock.AnythingOfType("func(string) error")).Return(nil).Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
 
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -875,7 +1021,7 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		wsConfig := s.wsConfig
 
 		wsConfig.InactivityTimeout = 50 * time.Millisecond
-		controller := NewWebSocketController(s.logger, wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, wsConfig, conn, factory, s.streamLimiter)
 
 		conn.
 			On("ReadJSON", mock.Anything).
@@ -927,7 +1073,7 @@ func (s *WsControllerSuite) TestKeepaliveRoutine() {
 		})
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
 		controller.keepaliveConfig = keepaliveConfig
 
 		controller.HandleConnection(context.Background())
@@ -942,7 +1088,7 @@ func (s *WsControllerSuite) TestKeepaliveRoutine() {
 			Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
 		controller.keepaliveConfig = keepaliveConfig
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -961,7 +1107,7 @@ func (s *WsControllerSuite) TestKeepaliveRoutine() {
 			Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
 		controller.keepaliveConfig = keepaliveConfig
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -975,7 +1121,7 @@ func (s *WsControllerSuite) TestKeepaliveRoutine() {
 	s.T().Run("Context cancelled", func(t *testing.T) {
 		conn := connmock.NewWebsocketConnection(t)
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory)
+		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
 		controller.keepaliveConfig = keepaliveConfig
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/engine/access/rest/websockets/controller_test.go
+++ b/engine/access/rest/websockets/controller_test.go
@@ -57,7 +57,8 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -121,7 +122,8 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, _ := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		type Request struct {
 			Action string `json:"action"`
@@ -170,7 +172,8 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, _ := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -207,7 +210,8 @@ func (s *WsControllerSuite) TestSubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		// data provider might finish on its own or controller will close it via Close()
 		dataProvider.On("Close").Return(nil).Maybe()
@@ -263,7 +267,8 @@ func (s *WsControllerSuite) TestGlobalStreamLimiter() {
 		require.True(t, streamLimiter.Acquire()) // exhaust the single slot
 
 		conn, dataProviderFactory, _ := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+		require.NoError(t, err)
 
 		done := make(chan struct{})
 		subscriptionID := "dummy-id"
@@ -303,7 +308,8 @@ func (s *WsControllerSuite) TestGlobalStreamLimiter() {
 		require.NoError(t, err)
 
 		conn, dataProviderFactory, _ := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -346,7 +352,8 @@ func (s *WsControllerSuite) TestGlobalStreamLimiter() {
 		require.NoError(t, err)
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, streamLimiter)
+		require.NoError(t, err)
 
 		dataProvider.On("Close").Return(nil).Maybe()
 		dataProvider.
@@ -396,7 +403,8 @@ func (s *WsControllerSuite) TestUnsubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -464,7 +472,8 @@ func (s *WsControllerSuite) TestUnsubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -534,7 +543,8 @@ func (s *WsControllerSuite) TestUnsubscribeRequest() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -607,7 +617,8 @@ func (s *WsControllerSuite) TestListSubscriptions() {
 	s.T().Run("Happy path", func(t *testing.T) {
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -689,7 +700,8 @@ func (s *WsControllerSuite) TestSubscribeBlocks() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -743,7 +755,8 @@ func (s *WsControllerSuite) TestSubscribeBlocks() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -828,7 +841,8 @@ func (s *WsControllerSuite) TestRateLimiter() {
 	config := NewDefaultWebsocketConfig()
 	config.MaxResponsesPerSecond = 2
 
-	controller := NewWebSocketController(s.logger, config, conn, nil, s.streamLimiter)
+	controller, err := NewWebSocketController(s.logger, config, conn, nil, s.streamLimiter)
+	require.NoError(s.T(), err)
 
 	// Step 3: Simulate sending messages to the controller's `multiplexedStream`.
 	go func() {
@@ -879,9 +893,10 @@ func (s *WsControllerSuite) TestConfigureKeepaliveConnection() {
 		conn.On("SetReadDeadline", mock.Anything).Return(nil)
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 
-		err := controller.configureKeepalive()
+		err = controller.configureKeepalive()
 		s.Require().NoError(err, "configureKeepalive should not return an error")
 
 		conn.AssertExpectations(t)
@@ -898,7 +913,8 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		conn.On("SetPongHandler", mock.AnythingOfType("func(string) error")).Return(nil).Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 
 		// Mock keepalive to return an error
 		done := make(chan struct{}, 1)
@@ -932,7 +948,8 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		conn.On("SetPongHandler", mock.AnythingOfType("func(string) error")).Return(nil).Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 
 		conn.
 			On("ReadJSON", mock.Anything).
@@ -949,7 +966,8 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		t.Parallel()
 
 		conn, dataProviderFactory, dataProvider := newControllerMocks(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, dataProviderFactory, s.streamLimiter)
+		require.NoError(t, err)
 
 		dataProviderFactory.
 			On("NewDataProvider", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -998,7 +1016,8 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		conn.On("SetPongHandler", mock.AnythingOfType("func(string) error")).Return(nil).Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -1021,7 +1040,8 @@ func (s *WsControllerSuite) TestControllerShutdown() {
 		wsConfig := s.wsConfig
 
 		wsConfig.InactivityTimeout = 50 * time.Millisecond
-		controller := NewWebSocketController(s.logger, wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 
 		conn.
 			On("ReadJSON", mock.Anything).
@@ -1073,7 +1093,8 @@ func (s *WsControllerSuite) TestKeepaliveRoutine() {
 		})
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 		controller.keepaliveConfig = keepaliveConfig
 
 		controller.HandleConnection(context.Background())
@@ -1088,13 +1109,14 @@ func (s *WsControllerSuite) TestKeepaliveRoutine() {
 			Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 		controller.keepaliveConfig = keepaliveConfig
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		err := controller.keepalive(ctx)
+		err = controller.keepalive(ctx)
 		s.Require().Error(err)
 		s.Require().ErrorIs(expectedError, err)
 	})
@@ -1107,13 +1129,14 @@ func (s *WsControllerSuite) TestKeepaliveRoutine() {
 			Once()
 
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 		controller.keepaliveConfig = keepaliveConfig
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		err := controller.keepalive(ctx)
+		err = controller.keepalive(ctx)
 		s.Require().Error(err)
 		s.Require().ErrorContains(err, "error sending ping")
 	})
@@ -1121,14 +1144,15 @@ func (s *WsControllerSuite) TestKeepaliveRoutine() {
 	s.T().Run("Context cancelled", func(t *testing.T) {
 		conn := connmock.NewWebsocketConnection(t)
 		factory := dpmock.NewDataProviderFactory(t)
-		controller := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		controller, err := NewWebSocketController(s.logger, s.wsConfig, conn, factory, s.streamLimiter)
+		require.NoError(t, err)
 		controller.keepaliveConfig = keepaliveConfig
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Immediately cancel the context
 
 		// Start the keepalive process with the context canceled
-		err := controller.keepalive(ctx)
+		err = controller.keepalive(ctx)
 		s.Require().NoError(err)
 	})
 }

--- a/engine/access/rest/websockets/handler.go
+++ b/engine/access/rest/websockets/handler.go
@@ -10,6 +10,7 @@ import (
 	dp "github.com/onflow/flow-go/engine/access/rest/websockets/data_providers"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/module/limiters"
 )
 
 type Handler struct {
@@ -24,6 +25,7 @@ type Handler struct {
 	logger              zerolog.Logger
 	websocketConfig     Config
 	dataProviderFactory dp.DataProviderFactory
+	streamLimiter       *limiters.ConcurrencyLimiter
 }
 
 var _ http.Handler = (*Handler)(nil)
@@ -36,6 +38,7 @@ func NewWebSocketHandler(
 	maxRequestSize int64,
 	maxResponseSize int64,
 	dataProviderFactory dp.DataProviderFactory,
+	streamLimiter *limiters.ConcurrencyLimiter,
 ) *Handler {
 	return &Handler{
 		ctx:                 ctx,
@@ -43,6 +46,7 @@ func NewWebSocketHandler(
 		websocketConfig:     config,
 		logger:              logger,
 		dataProviderFactory: dataProviderFactory,
+		streamLimiter:       streamLimiter,
 	}
 }
 
@@ -69,6 +73,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	controller := NewWebSocketController(logger, h.websocketConfig, NewWebsocketConnection(conn), h.dataProviderFactory)
+	controller := NewWebSocketController(logger, h.websocketConfig, NewWebsocketConnection(conn), h.dataProviderFactory, h.streamLimiter)
 	controller.HandleConnection(h.ctx)
 }

--- a/engine/access/rest/websockets/handler.go
+++ b/engine/access/rest/websockets/handler.go
@@ -73,6 +73,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	controller := NewWebSocketController(logger, h.websocketConfig, NewWebsocketConnection(conn), h.dataProviderFactory, h.streamLimiter)
+	controller, err := NewWebSocketController(logger, h.websocketConfig, NewWebsocketConnection(conn), h.dataProviderFactory, h.streamLimiter)
+	if err != nil {
+		h.HttpHandler.ErrorHandler(w, common.NewRestError(http.StatusInternalServerError, "could not create websocket controller: ", err), logger)
+		return
+	}
 	controller.HandleConnection(h.ctx)
 }

--- a/module/limiters/concurrency_limiter.go
+++ b/module/limiters/concurrency_limiter.go
@@ -26,23 +26,36 @@ func NewConcurrencyLimiter(maxConcurrent uint32) (*ConcurrencyLimiter, error) {
 	}, nil
 }
 
-// Allow executes fn if the number of concurrent operations is below the configured limit.
-// Returns true if fn was executed, false if the limit was reached and fn was not called.
-// The concurrency counter is decremented when fn returns, including on panic.
-func (h *ConcurrencyLimiter) Allow(fn func()) bool {
+// Acquire atomically increments the concurrency counter if it is below the configured limit.
+// Returns true if the slot was acquired, false if the limit was reached.
+// The caller MUST call [Release] exactly once after a successful Acquire.
+func (h *ConcurrencyLimiter) Acquire() bool {
 	for {
 		current := h.totalConcurrent.Load()
 		if current >= h.maxConcurrent {
 			return false
 		}
 		if h.totalConcurrent.CompareAndSwap(current, current+1) {
-			break
+			return true
 		}
 	}
+}
+
+// Release decrements the concurrency counter, freeing a slot previously obtained via [Acquire].
+// Must be called exactly once for every successful [Acquire] call.
+func (h *ConcurrencyLimiter) Release() {
+	h.totalConcurrent.Sub(1)
+}
+
+// Allow executes fn if the number of concurrent operations is below the configured limit.
+// Returns true if fn was executed, false if the limit was reached and fn was not called.
+// The concurrency counter is decremented when fn returns, including on panic.
+func (h *ConcurrencyLimiter) Allow(fn func()) bool {
+	if !h.Acquire() {
+		return false
+	}
 	// decrement within a defer to support usecases where panics are handled gracefully by the caller
-	defer func() {
-		h.totalConcurrent.Sub(1)
-	}()
+	defer h.Release()
 
 	fn()
 	return true

--- a/module/limiters/concurrency_limiter.go
+++ b/module/limiters/concurrency_limiter.go
@@ -43,8 +43,17 @@ func (h *ConcurrencyLimiter) Acquire() bool {
 
 // Release decrements the concurrency counter, freeing a slot previously obtained via [Acquire].
 // Must be called exactly once for every successful [Acquire] call.
+// Panics if called without a matching [Acquire] (counter underflow).
 func (h *ConcurrencyLimiter) Release() {
-	h.totalConcurrent.Sub(1)
+	for {
+		current := h.totalConcurrent.Load()
+		if current == 0 {
+			panic("concurrency limiter release without matching acquire")
+		}
+		if h.totalConcurrent.CompareAndSwap(current, current-1) {
+			return
+		}
+	}
 }
 
 // Allow executes fn if the number of concurrent operations is below the configured limit.

--- a/module/limiters/concurrency_limiter_test.go
+++ b/module/limiters/concurrency_limiter_test.go
@@ -90,6 +90,78 @@ func TestConcurrencyLimiter_NewZeroLimit(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestConcurrencyLimiter_Acquire_WithinLimit verifies that Acquire returns true
+// when below the concurrency limit.
+func TestConcurrencyLimiter_Acquire_WithinLimit(t *testing.T) {
+	limiter, err := NewConcurrencyLimiter(2)
+	require.NoError(t, err)
+
+	assert.True(t, limiter.Acquire())
+	assert.True(t, limiter.Acquire())
+
+	limiter.Release()
+	limiter.Release()
+}
+
+// TestConcurrencyLimiter_Acquire_AtLimit verifies that Acquire returns false
+// when the concurrency limit is reached, and succeeds again after Release.
+func TestConcurrencyLimiter_Acquire_AtLimit(t *testing.T) {
+	limiter, err := NewConcurrencyLimiter(1)
+	require.NoError(t, err)
+
+	assert.True(t, limiter.Acquire())
+	assert.False(t, limiter.Acquire(), "second Acquire must fail at limit")
+
+	limiter.Release()
+	assert.True(t, limiter.Acquire(), "Acquire must succeed after Release")
+
+	limiter.Release()
+}
+
+// TestConcurrencyLimiter_Acquire_ConcurrentCalls verifies that at most maxConcurrent
+// slots can be acquired simultaneously across concurrent goroutines.
+func TestConcurrencyLimiter_Acquire_ConcurrentCalls(t *testing.T) {
+	const maxConcurrent = 5
+	const totalGoroutines = 50
+
+	limiter, err := NewConcurrencyLimiter(maxConcurrent)
+	require.NoError(t, err)
+
+	var (
+		peak    atomic.Int32
+		current atomic.Int32
+		wg      sync.WaitGroup
+	)
+
+	start := make(chan struct{})
+
+	for i := 0; i < totalGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if limiter.Acquire() {
+				n := current.Add(1)
+				for {
+					old := peak.Load()
+					if n <= old || peak.CompareAndSwap(old, n) {
+						break
+					}
+				}
+				time.Sleep(time.Millisecond)
+				current.Add(-1)
+				limiter.Release()
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.LessOrEqual(t, peak.Load(), int32(maxConcurrent),
+		"peak concurrent acquisitions must not exceed maxConcurrent")
+}
+
 // TestConcurrencyLimiter_Allow_ConcurrentCalls verifies that at most maxConcurrent
 // goroutines execute fn simultaneously across a burst of concurrent callers.
 func TestConcurrencyLimiter_Allow_ConcurrentCalls(t *testing.T) {

--- a/module/limiters/concurrency_limiter_test.go
+++ b/module/limiters/concurrency_limiter_test.go
@@ -162,6 +162,17 @@ func TestConcurrencyLimiter_Acquire_ConcurrentCalls(t *testing.T) {
 		"peak concurrent acquisitions must not exceed maxConcurrent")
 }
 
+// TestConcurrencyLimiter_Release_Underflow verifies that Release panics when called
+// without a matching Acquire (counter at zero).
+func TestConcurrencyLimiter_Release_Underflow(t *testing.T) {
+	limiter, err := NewConcurrencyLimiter(1)
+	require.NoError(t, err)
+
+	assert.PanicsWithValue(t, "concurrency limiter release without matching acquire", func() {
+		limiter.Release()
+	})
+}
+
 // TestConcurrencyLimiter_Allow_ConcurrentCalls verifies that at most maxConcurrent
 // goroutines execute fn simultaneously across a burst of concurrent callers.
 func TestConcurrencyLimiter_Allow_ConcurrentCalls(t *testing.T) {


### PR DESCRIPTION
## Summary

- Moves the global stream limiter from the WebSocket connection level to the subscription level
- The `/ws` endpoint multiplexes many subscriptions over a single connection, so the previous connection-level enforcement was incorrect: one connection could bypass `MaxGlobalStreams`, while idle connections consumed the budget
- Adds `Acquire()`/`Release()` methods to `ConcurrencyLimiter` for lifecycle-scoped slot management
- The limiter is now passed into the WebSocket controller and acquired/released per subscription in `handleSubscribe`

## Test plan

- [x] `ConcurrencyLimiter` tests for `Acquire`/`Release` (within limit, at limit, concurrent)
- [x] Controller test: subscription rejected with 429 when global limit exhausted
- [x] Controller test: slot released when provider creation fails
- [x] Controller test: slot released when provider completes
- [x] Full websocket test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added concurrency limiting for websocket connections to prevent server overload and ensure stable stream handling.

* **Bug Fixes**
  * Added validation to enforce that state streaming maximum global stream configuration must be greater than zero, preventing invalid startup configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->