### PR TITLE
Improve logging

### DIFF
--- a/engine/access/rest/common/middleware/logging.go
+++ b/engine/access/rest/common/middleware/logging.go
@@ -12,24 +12,34 @@ import (
 )
 
 // LoggingMiddleware creates a middleware which adds a logger interceptor to each request to log the request method, uri,
-// duration and response code
+// duration and response code. It logs at DEBUG level when the request starts and at INFO level when it finishes.
 func LoggingMiddleware(logger zerolog.Logger) mux.MiddlewareFunc {
 	return func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			// record star time
+			// Log at start of request for debugging and tracing
+			logger.Debug().
+				Str("method", req.Method).
+				Str("uri", req.RequestURI).
+				Str("client_ip", req.RemoteAddr).
+				Str("user_agent", req.UserAgent()).
+				Msg("started REST request")
+
+			// record start time
 			start := time.Now()
 			// modify the writer
 			respWriter := newResponseWriter(w)
 			// continue to the next handler
 			inner.ServeHTTP(respWriter, req)
-			log := logger.Info()
-			log.Str("method", req.Method).
+
+			// Log at end of request with response details
+			logger.Info().
+				Str("method", req.Method).
 				Str("uri", req.RequestURI).
 				Str("client_ip", req.RemoteAddr).
 				Str("user_agent", req.UserAgent()).
 				Dur("duration", time.Since(start)).
 				Int("response_code", respWriter.statusCode).
-				Msg("api")
+				Msg("finished REST request")
 		})
 	}
 }

--- a/engine/access/rest/common/middleware/logging.go
+++ b/engine/access/rest/common/middleware/logging.go
@@ -13,6 +13,10 @@ import (
 
 // LoggingMiddleware creates a middleware which adds a logger interceptor to each request to log the request method, uri,
 // duration and response code. It logs at DEBUG level when the request starts and at INFO level when it finishes.
+//
+// Example log messages for searching:
+//   - Start:  DBG "started REST request" method=GET uri=/v1/blocks client_ip=... user_agent=...
+//   - Finish: INF "finished REST request" method=GET uri=/v1/blocks client_ip=... user_agent=... duration=... response_code=200
 func LoggingMiddleware(logger zerolog.Logger) mux.MiddlewareFunc {
 	return func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/engine/access/rest/common/middleware/logging.go
+++ b/engine/access/rest/common/middleware/logging.go
@@ -12,21 +12,23 @@ import (
 )
 
 // LoggingMiddleware creates a middleware which adds a logger interceptor to each request to log the request method, uri,
-// duration and response code. It logs at DEBUG level when the request starts and at INFO level when it finishes.
+// duration and response code. Both start and finish logs are at DEBUG level.
 //
 // Example log messages for searching:
 //   - Start:  DBG "started REST request" method=GET uri=/v1/blocks client_ip=... user_agent=...
-//   - Finish: INF "finished REST request" method=GET uri=/v1/blocks client_ip=... user_agent=... duration=... response_code=200
+//   - Finish: DBG "finished REST request" method=GET uri=/v1/blocks client_ip=... user_agent=... duration=... response_code=200
 func LoggingMiddleware(logger zerolog.Logger) mux.MiddlewareFunc {
 	return func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			// Log at start of request for debugging and tracing
-			logger.Debug().
+			lg := logger.With().
 				Str("method", req.Method).
 				Str("uri", req.RequestURI).
 				Str("client_ip", req.RemoteAddr).
 				Str("user_agent", req.UserAgent()).
-				Msg("started REST request")
+				Logger()
+
+			// Log at start of request for debugging and tracing
+			lg.Debug().Msg("started REST request")
 
 			// record start time
 			start := time.Now()
@@ -36,11 +38,7 @@ func LoggingMiddleware(logger zerolog.Logger) mux.MiddlewareFunc {
 			inner.ServeHTTP(respWriter, req)
 
 			// Log at end of request with response details
-			logger.Info().
-				Str("method", req.Method).
-				Str("uri", req.RequestURI).
-				Str("client_ip", req.RemoteAddr).
-				Str("user_agent", req.UserAgent()).
+			lg.Debug().
 				Dur("duration", time.Since(start)).
 				Int("response_code", respWriter.statusCode).
 				Msg("finished REST request")

--- a/engine/collection/rpc/engine.go
+++ b/engine/collection/rpc/engine.go
@@ -82,7 +82,7 @@ func New(
 	}
 
 	// Note: logging interceptor should be last (innermost) to capture all messages.
-	// This adds debug level logs for both start and finish of each gRPC request.
+	// Both start and finish logs are at debug level.
 	// Example log messages for searching:
 	//   - Start:  DBG "started call" grpc.method=SendTransaction grpc.service=flow.access.AccessAPI peer.address=...
 	//   - Finish: DBG "finished call" grpc.method=SendTransaction grpc.service=flow.access.AccessAPI peer.address=... grpc.code=OK grpc.time_ms=...

--- a/engine/collection/rpc/engine.go
+++ b/engine/collection/rpc/engine.go
@@ -81,6 +81,10 @@ func New(
 		interceptors = append(interceptors, rateLimitInterceptor)
 	}
 
+	// Note: logging interceptor should be last (innermost) to capture all messages.
+	// This adds debug level logs for both start and finish of each gRPC request.
+	interceptors = append(interceptors, grpcserver.LoggingInterceptor(log))
+
 	// create a chained unary interceptor
 	chainedInterceptors := grpc.ChainUnaryInterceptor(interceptors...)
 	grpcOpts = append(grpcOpts, chainedInterceptors)

--- a/engine/collection/rpc/engine.go
+++ b/engine/collection/rpc/engine.go
@@ -83,6 +83,9 @@ func New(
 
 	// Note: logging interceptor should be last (innermost) to capture all messages.
 	// This adds debug level logs for both start and finish of each gRPC request.
+	// Example log messages for searching:
+	//   - Start:  DBG "started call" grpc.method=SendTransaction grpc.service=flow.access.AccessAPI peer.address=...
+	//   - Finish: DBG "finished call" grpc.method=SendTransaction grpc.service=flow.access.AccessAPI peer.address=... grpc.code=OK grpc.time_ms=...
 	interceptors = append(interceptors, grpcserver.LoggingInterceptor(log))
 
 	// create a chained unary interceptor

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -96,6 +96,10 @@ func New(
 		interceptors = append(interceptors, rateLimitInterceptor)
 	}
 
+	// Note: logging interceptor should be last (innermost) to capture all messages.
+	// This adds debug level logs for both start and finish of each gRPC request.
+	interceptors = append(interceptors, grpcserver.LoggingInterceptor(log))
+
 	// create a chained unary interceptor
 	chainedInterceptors := grpc.ChainUnaryInterceptor(interceptors...)
 	serverOptions = append(serverOptions, chainedInterceptors)

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -98,6 +98,9 @@ func New(
 
 	// Note: logging interceptor should be last (innermost) to capture all messages.
 	// This adds debug level logs for both start and finish of each gRPC request.
+	// Example log messages for searching:
+	//   - Start:  DBG "started call" grpc.method=ExecuteScriptAtBlockID grpc.service=flow.execution.ExecutionAPI peer.address=...
+	//   - Finish: DBG "finished call" grpc.method=ExecuteScriptAtBlockID grpc.service=flow.execution.ExecutionAPI peer.address=... grpc.code=OK grpc.time_ms=...
 	interceptors = append(interceptors, grpcserver.LoggingInterceptor(log))
 
 	// create a chained unary interceptor

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -97,7 +97,7 @@ func New(
 	}
 
 	// Note: logging interceptor should be last (innermost) to capture all messages.
-	// This adds debug level logs for both start and finish of each gRPC request.
+	// Both start and finish logs are at debug level.
 	// Example log messages for searching:
 	//   - Start:  DBG "started call" grpc.method=ExecuteScriptAtBlockID grpc.service=flow.execution.ExecutionAPI peer.address=...
 	//   - Finish: DBG "finished call" grpc.method=ExecuteScriptAtBlockID grpc.service=flow.execution.ExecutionAPI peer.address=... grpc.code=OK grpc.time_ms=...

--- a/module/grpcserver/interceptor_logging.go
+++ b/module/grpcserver/interceptor_logging.go
@@ -14,6 +14,10 @@ import (
 // LoggingInterceptor returns a grpc.UnaryServerInterceptor that logs incoming GRPC request and response.
 // It extracts the requester's peer address from the gRPC context and includes it in log entries.
 // Logs are emitted at the start and finish of each call for debugging and tracing purposes.
+//
+// Example log messages for searching:
+//   - Start:  DBG "started call" grpc.method=Ping grpc.service=flow.access.AccessAPI peer.address=...
+//   - Finish: DBG "finished call" grpc.method=Ping grpc.service=flow.access.AccessAPI peer.address=... grpc.code=OK grpc.time_ms=...
 func LoggingInterceptor(log zerolog.Logger) grpc.UnaryServerInterceptor {
 	return logging.UnaryServerInterceptor(
 		InterceptorLogger(log),
@@ -26,6 +30,10 @@ func LoggingInterceptor(log zerolog.Logger) grpc.UnaryServerInterceptor {
 // StreamLoggingInterceptor returns a grpc.StreamServerInterceptor that logs incoming streaming GRPC requests.
 // It extracts the requester's peer address from the gRPC context and includes it in log entries.
 // Logs are emitted at the start and finish of each streaming call for debugging and tracing purposes.
+//
+// Example log messages for searching:
+//   - Start:  DBG "started call" grpc.method=SubscribeEvents grpc.service=flow.executiondata.ExecutionDataAPI peer.address=...
+//   - Finish: DBG "finished call" grpc.method=SubscribeEvents grpc.service=flow.executiondata.ExecutionDataAPI peer.address=... grpc.code=OK grpc.time_ms=...
 func StreamLoggingInterceptor(log zerolog.Logger) grpc.StreamServerInterceptor {
 	return logging.StreamServerInterceptor(
 		InterceptorLogger(log),

--- a/module/grpcserver/interceptor_logging.go
+++ b/module/grpcserver/interceptor_logging.go
@@ -14,6 +14,7 @@ import (
 // LoggingInterceptor returns a grpc.UnaryServerInterceptor that logs incoming GRPC request and response.
 // It extracts the requester's peer address from the gRPC context and includes it in log entries.
 // Logs are emitted at the start and finish of each call for debugging and tracing purposes.
+// Both start and finish logs are at debug level.
 //
 // Example log messages for searching:
 //   - Start:  DBG "started call" grpc.method=Ping grpc.service=flow.access.AccessAPI peer.address=...
@@ -30,6 +31,7 @@ func LoggingInterceptor(log zerolog.Logger) grpc.UnaryServerInterceptor {
 // StreamLoggingInterceptor returns a grpc.StreamServerInterceptor that logs incoming streaming GRPC requests.
 // It extracts the requester's peer address from the gRPC context and includes it in log entries.
 // Logs are emitted at the start and finish of each streaming call for debugging and tracing purposes.
+// Both start and finish logs are at debug level.
 //
 // Example log messages for searching:
 //   - Start:  DBG "started call" grpc.method=SubscribeEvents grpc.service=flow.executiondata.ExecutionDataAPI peer.address=...
@@ -73,16 +75,8 @@ func InterceptorLogger(l zerolog.Logger) logging.Logger {
 	})
 }
 
-// statusCodeToLogLevel converts a grpc status.Code to the appropriate logging.Level
-func statusCodeToLogLevel(c codes.Code) logging.Level {
-	switch c {
-	case codes.OK:
-		// log successful returns as Debug to avoid excessive logging in info mode
-		return logging.LevelDebug
-	case codes.DeadlineExceeded, codes.ResourceExhausted, codes.OutOfRange:
-		// these are common, map to info
-		return logging.LevelInfo
-	default:
-		return logging.DefaultServerCodeToLevel(c)
-	}
+// statusCodeToLogLevel converts a grpc status.Code to the appropriate logging.Level.
+// All status codes are logged at debug level to avoid excessive logging.
+func statusCodeToLogLevel(_ codes.Code) logging.Level {
+	return logging.LevelDebug
 }

--- a/module/grpcserver/interceptor_logging.go
+++ b/module/grpcserver/interceptor_logging.go
@@ -8,14 +8,40 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
 )
 
-// LoggingInterceptor returns a grpc.UnaryServerInterceptor that logs incoming GRPC request and response
+// LoggingInterceptor returns a grpc.UnaryServerInterceptor that logs incoming GRPC request and response.
+// It extracts the requester's peer address from the gRPC context and includes it in log entries.
+// Logs are emitted at the start and finish of each call for debugging and tracing purposes.
 func LoggingInterceptor(log zerolog.Logger) grpc.UnaryServerInterceptor {
 	return logging.UnaryServerInterceptor(
 		InterceptorLogger(log),
 		logging.WithLevels(statusCodeToLogLevel),
+		logging.WithFieldsFromContext(extractPeerFields),
+		logging.WithLogOnEvents(logging.StartCall, logging.FinishCall),
 	)
+}
+
+// StreamLoggingInterceptor returns a grpc.StreamServerInterceptor that logs incoming streaming GRPC requests.
+// It extracts the requester's peer address from the gRPC context and includes it in log entries.
+// Logs are emitted at the start and finish of each streaming call for debugging and tracing purposes.
+func StreamLoggingInterceptor(log zerolog.Logger) grpc.StreamServerInterceptor {
+	return logging.StreamServerInterceptor(
+		InterceptorLogger(log),
+		logging.WithLevels(statusCodeToLogLevel),
+		logging.WithFieldsFromContext(extractPeerFields),
+		logging.WithLogOnEvents(logging.StartCall, logging.FinishCall),
+	)
+}
+
+// extractPeerFields extracts peer information from the gRPC context and returns it as logging fields.
+// This includes the client's remote address for request tracing and debugging.
+func extractPeerFields(ctx context.Context) logging.Fields {
+	if p, ok := peer.FromContext(ctx); ok {
+		return logging.Fields{"peer.address", p.Addr.String()}
+	}
+	return nil
 }
 
 // InterceptorLogger adapts a zerolog.Logger to interceptor's logging.Logger

--- a/module/grpcserver/server_builder.go
+++ b/module/grpcserver/server_builder.go
@@ -102,6 +102,7 @@ func NewGrpcServerBuilder(
 
 	// Note: make sure logging interceptor is innermost wrapper to capture all messages
 	unaryInterceptors = append(unaryInterceptors, LoggingInterceptor(log))
+	streamInterceptors = append(streamInterceptors, StreamLoggingInterceptor(log))
 
 	grpcOpts = append(grpcOpts, grpc.ChainUnaryInterceptor(unaryInterceptors...))
 	if len(streamInterceptors) > 0 {


### PR DESCRIPTION
Add log to track start and finish of each request, useful for debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST requests now emit structured start and finish debug logs, including method, URI, client IP, user agent, duration, and response code for better tracing.
  * gRPC now emits start/finish debug logs for unary and streaming calls, includes peer address and timing, and ensures logging runs at the point closest to actual handler execution for more accurate observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->