### PR TITLE
Update to Cadence v1.10.2

### DIFF
--- a/fvm/evm/emulator/state/collection.go
+++ b/fvm/evm/emulator/state/collection.go
@@ -268,12 +268,13 @@ func (v ByteStringValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 }
 
 func (v ByteStringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
-	if v.ByteSize() <= maxInlineSize {
+	byteSize := v.ByteSize()
+	if byteSize <= maxInlineSize {
 		return v, nil
 	}
 
 	// Create StorableSlab
-	return atree.NewStorableSlab(storage, address, v)
+	return atree.NewStorableSlab(storage, address, v, byteSize)
 }
 
 func (v ByteStringValue) Encode(enc *atree.Encoder) error {

--- a/fvm/meter/memory_meter.go
+++ b/fvm/meter/memory_meter.go
@@ -41,6 +41,7 @@ var (
 		common.MemoryKindWrappedFunctionValue:             25,
 		common.MemoryKindBigInt:                           50,
 		common.MemoryKindVoidExpression:                   1,
+		common.MemoryKindStringBuilder:                    138,
 
 		// Atree
 
@@ -185,6 +186,7 @@ var (
 		common.MemoryKindSwitchStatement:     41,
 		common.MemoryKindWhileStatement:      25,
 		common.MemoryKindRemoveStatement:     33,
+		common.MemoryKindGuardStatement:      25,
 
 		common.MemoryKindBooleanExpression:        9,
 		common.MemoryKindNilExpression:            1,

--- a/go.mod
+++ b/go.mod
@@ -46,13 +46,13 @@ require (
 	github.com/multiformats/go-multiaddr v0.14.0
 	github.com/multiformats/go-multiaddr-dns v0.4.1
 	github.com/multiformats/go-multihash v0.2.3
-	github.com/onflow/atree v0.15.0
-	github.com/onflow/cadence v1.10.1
+	github.com/onflow/atree v0.16.0
+	github.com/onflow/cadence v1.10.2
 	github.com/onflow/crypto v0.25.4
 	github.com/onflow/flow v0.4.20-0.20260303141511-b7c99b4fb01b
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.9.3
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.9.3
-	github.com/onflow/flow-go-sdk v1.10.1
+	github.com/onflow/flow-go-sdk v1.10.2
 	github.com/onflow/flow/protobuf/go/flow v0.4.20
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -938,12 +938,12 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/onflow/atree v0.15.0 h1:wIDhQBWlmTj4KD40lTdjIcog7UIUr5iHjIMjIOhuYGU=
-github.com/onflow/atree v0.15.0/go.mod h1:hiOT/vKK/Zyw34Ru9OFbfEemC5NnQ7SHFB43bN9/4qI=
+github.com/onflow/atree v0.16.0 h1:b+f/suzcnnr1Lx1KdJEjpn2CX+AKSAz1yIB30NQDutU=
+github.com/onflow/atree v0.16.0/go.mod h1:hiOT/vKK/Zyw34Ru9OFbfEemC5NnQ7SHFB43bN9/4qI=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
-github.com/onflow/cadence v1.10.1 h1:wKr/JdBM7lHqVZgY3HA6KcjE1b7vES/1p902v4CT2ME=
-github.com/onflow/cadence v1.10.1/go.mod h1:WcBEohOspFyZ3unRlL/Zd5q0yZSCveWJq3me/FtoVRg=
+github.com/onflow/cadence v1.10.2 h1:wa0olSOUNgcxAxjJHbMU+zsvxzFXkm+FNANQTsfpdr8=
+github.com/onflow/cadence v1.10.2/go.mod h1:tyUNaYlAgeQVgfR2C38MI1dtFFjKay+yGGPMrCRc068=
 github.com/onflow/crypto v0.25.4 h1:R615PWPdSoA5RATNb/j3cYaloBIZlSXVNgS7BjwHiwM=
 github.com/onflow/crypto v0.25.4/go.mod h1:DlkW/1SPUvLHYvUcjWa9PkLIRgSBKR4EDc3i+ATQKW4=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=
@@ -960,8 +960,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go-sdk v1.10.1 h1:Ix2R+ITT4z0D6Jj4uVxnZF0sbP42WtkYt6Law3KZHZ0=
-github.com/onflow/flow-go-sdk v1.10.1/go.mod h1:s3EWgDnrvOYV8MTa5tmOCP3CcypoMTytW7JRQ1tZ38s=
+github.com/onflow/flow-go-sdk v1.10.2 h1:wkP65lmMtfUrhkt27JdtV+uh2qNZgiGJEfCe80VO+/U=
+github.com/onflow/flow-go-sdk v1.10.2/go.mod h1:cNecrpIt1TWYBZC50+NztxWiZT+X3jl6ykrSBHgPctE=
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0 h1:DmNop+O0EMyicZvhgdWboFG57xz5t9Qp81FKlfKyqJc=
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0/go.mod h1:eZ9VMMNfCq0ho6kV25xJn1kXeCfxnkhj3MwF3ed08gY=
 github.com/onflow/flow-nft/lib/go/templates v1.3.0 h1:uGIBy4GEY6Z9hKP7sm5nA5kwvbvLWW4nWx5NN9Wg0II=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -215,15 +215,15 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.15.0 // indirect
-	github.com/onflow/cadence v1.10.1 // indirect
+	github.com/onflow/atree v0.16.0 // indirect
+	github.com/onflow/cadence v1.10.2 // indirect
 	github.com/onflow/fixed-point v0.1.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.9.3 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.9.3 // indirect
 	github.com/onflow/flow-evm-bridge v0.1.0 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.1 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.1 // indirect
-	github.com/onflow/flow-go-sdk v1.10.1 // indirect
+	github.com/onflow/flow-go-sdk v1.10.2 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.3.0 // indirect
 	github.com/onflow/flow-nft/lib/go/templates v1.3.0 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.4.20 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -888,12 +888,12 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/onflow/atree v0.15.0 h1:wIDhQBWlmTj4KD40lTdjIcog7UIUr5iHjIMjIOhuYGU=
-github.com/onflow/atree v0.15.0/go.mod h1:hiOT/vKK/Zyw34Ru9OFbfEemC5NnQ7SHFB43bN9/4qI=
+github.com/onflow/atree v0.16.0 h1:b+f/suzcnnr1Lx1KdJEjpn2CX+AKSAz1yIB30NQDutU=
+github.com/onflow/atree v0.16.0/go.mod h1:hiOT/vKK/Zyw34Ru9OFbfEemC5NnQ7SHFB43bN9/4qI=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
-github.com/onflow/cadence v1.10.1 h1:wKr/JdBM7lHqVZgY3HA6KcjE1b7vES/1p902v4CT2ME=
-github.com/onflow/cadence v1.10.1/go.mod h1:WcBEohOspFyZ3unRlL/Zd5q0yZSCveWJq3me/FtoVRg=
+github.com/onflow/cadence v1.10.2 h1:wa0olSOUNgcxAxjJHbMU+zsvxzFXkm+FNANQTsfpdr8=
+github.com/onflow/cadence v1.10.2/go.mod h1:tyUNaYlAgeQVgfR2C38MI1dtFFjKay+yGGPMrCRc068=
 github.com/onflow/crypto v0.25.4 h1:R615PWPdSoA5RATNb/j3cYaloBIZlSXVNgS7BjwHiwM=
 github.com/onflow/crypto v0.25.4/go.mod h1:DlkW/1SPUvLHYvUcjWa9PkLIRgSBKR4EDc3i+ATQKW4=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=
@@ -908,8 +908,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go-sdk v1.10.1 h1:Ix2R+ITT4z0D6Jj4uVxnZF0sbP42WtkYt6Law3KZHZ0=
-github.com/onflow/flow-go-sdk v1.10.1/go.mod h1:s3EWgDnrvOYV8MTa5tmOCP3CcypoMTytW7JRQ1tZ38s=
+github.com/onflow/flow-go-sdk v1.10.2 h1:wkP65lmMtfUrhkt27JdtV+uh2qNZgiGJEfCe80VO+/U=
+github.com/onflow/flow-go-sdk v1.10.2/go.mod h1:cNecrpIt1TWYBZC50+NztxWiZT+X3jl6ykrSBHgPctE=
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0 h1:DmNop+O0EMyicZvhgdWboFG57xz5t9Qp81FKlfKyqJc=
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0/go.mod h1:eZ9VMMNfCq0ho6kV25xJn1kXeCfxnkhj3MwF3ed08gY=
 github.com/onflow/flow-nft/lib/go/templates v1.3.0 h1:uGIBy4GEY6Z9hKP7sm5nA5kwvbvLWW4nWx5NN9Wg0II=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -20,14 +20,14 @@ require (
 	github.com/ipfs/go-datastore v0.8.2
 	github.com/ipfs/go-ds-pebble v0.5.0
 	github.com/libp2p/go-libp2p v0.38.2
-	github.com/onflow/cadence v1.10.1
+	github.com/onflow/cadence v1.10.2
 	github.com/onflow/crypto v0.25.4
 	github.com/onflow/flow v0.4.20-0.20260303141511-b7c99b4fb01b
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.9.3
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.9.3
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.1
 	github.com/onflow/flow-go v0.38.0-preview.0.0.20241021221952-af9cd6e99de1
-	github.com/onflow/flow-go-sdk v1.10.1
+	github.com/onflow/flow-go-sdk v1.10.2
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow-nft/lib/go/contracts v1.3.0
 	github.com/onflow/flow/protobuf/go/flow v0.4.20
@@ -267,7 +267,7 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.15.0 // indirect
+	github.com/onflow/atree v0.16.0 // indirect
 	github.com/onflow/fixed-point v0.1.1 // indirect
 	github.com/onflow/flow-evm-bridge v0.1.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.1 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -748,12 +748,12 @@ github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JX
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/onflow/atree v0.15.0 h1:wIDhQBWlmTj4KD40lTdjIcog7UIUr5iHjIMjIOhuYGU=
-github.com/onflow/atree v0.15.0/go.mod h1:hiOT/vKK/Zyw34Ru9OFbfEemC5NnQ7SHFB43bN9/4qI=
+github.com/onflow/atree v0.16.0 h1:b+f/suzcnnr1Lx1KdJEjpn2CX+AKSAz1yIB30NQDutU=
+github.com/onflow/atree v0.16.0/go.mod h1:hiOT/vKK/Zyw34Ru9OFbfEemC5NnQ7SHFB43bN9/4qI=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
-github.com/onflow/cadence v1.10.1 h1:wKr/JdBM7lHqVZgY3HA6KcjE1b7vES/1p902v4CT2ME=
-github.com/onflow/cadence v1.10.1/go.mod h1:WcBEohOspFyZ3unRlL/Zd5q0yZSCveWJq3me/FtoVRg=
+github.com/onflow/cadence v1.10.2 h1:wa0olSOUNgcxAxjJHbMU+zsvxzFXkm+FNANQTsfpdr8=
+github.com/onflow/cadence v1.10.2/go.mod h1:tyUNaYlAgeQVgfR2C38MI1dtFFjKay+yGGPMrCRc068=
 github.com/onflow/crypto v0.25.4 h1:R615PWPdSoA5RATNb/j3cYaloBIZlSXVNgS7BjwHiwM=
 github.com/onflow/crypto v0.25.4/go.mod h1:DlkW/1SPUvLHYvUcjWa9PkLIRgSBKR4EDc3i+ATQKW4=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=
@@ -770,8 +770,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go-sdk v1.10.1 h1:Ix2R+ITT4z0D6Jj4uVxnZF0sbP42WtkYt6Law3KZHZ0=
-github.com/onflow/flow-go-sdk v1.10.1/go.mod h1:s3EWgDnrvOYV8MTa5tmOCP3CcypoMTytW7JRQ1tZ38s=
+github.com/onflow/flow-go-sdk v1.10.2 h1:wkP65lmMtfUrhkt27JdtV+uh2qNZgiGJEfCe80VO+/U=
+github.com/onflow/flow-go-sdk v1.10.2/go.mod h1:cNecrpIt1TWYBZC50+NztxWiZT+X3jl6ykrSBHgPctE=
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0 h1:DmNop+O0EMyicZvhgdWboFG57xz5t9Qp81FKlfKyqJc=
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0/go.mod h1:eZ9VMMNfCq0ho6kV25xJn1kXeCfxnkhj3MwF3ed08gY=
 github.com/onflow/flow-nft/lib/go/templates v1.3.0 h1:uGIBy4GEY6Z9hKP7sm5nA5kwvbvLWW4nWx5NN9Wg0II=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/flow-go-sdk v1.10.2](https://github.com/onflow/flow-go-sdk/releases/tag/v1.10.2)
- [onflow/cadence v1.10.2](https://github.com/onflow/cadence/releases/tag/v1.10.2)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core framework dependencies across modules: atree → v0.16.0, cadence → v1.10.2, flow-go-sdk → v1.10.2.
* **Performance**
  * Minor storage optimization to avoid redundant size computations, reducing overhead in certain data operations.
  * Adjusted memory accounting weights to better reflect string-builder and guard-statement usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->