### PR TITLE
Fix unicast authorizer for observer node

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -56,6 +56,7 @@ import (
 	netcache "github.com/onflow/flow-go/network/cache"
 	"github.com/onflow/flow-go/network/channels"
 	"github.com/onflow/flow-go/network/converter"
+	"github.com/onflow/flow-go/network/message"
 	"github.com/onflow/flow-go/network/p2p"
 	p2pbuilder "github.com/onflow/flow-go/network/p2p/builder"
 	p2pbuilderconfig "github.com/onflow/flow-go/network/p2p/builder/config"
@@ -691,6 +692,13 @@ func (fnb *FlowNodeBuilder) InitFlowNetworkWithConduitFactory(
 		SlashingViolationConsumerFactory: func(adapter network.ConduitAdapter) network.ViolationsConsumer {
 			return slashing.NewSlashingViolationsConsumer(fnb.Logger, fnb.Metrics.Network, adapter)
 		},
+		UnicastStreamAuthorizer: func() func(flow.Role, flow.Role) bool {
+			if fnb.ObserverMode {
+				// observer mode uses public network where peers are not authorized based on role
+				return message.AlwaysAuthorizedUnicastSenderRole
+			}
+			return nil // use default (IsAuthorizedUnicastSenderRole)
+		}(),
 	}, networkOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize network: %w", err)


### PR DESCRIPTION
[The changes from this PR ](https://github.com/onflow/flow-go/pull/8533/changes) breaks for the observer node receiving block responses from access node. 

This PR fix is by allowing messages to be sent to observer node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network authorization configuration with conditional logic for observer mode. Authorization behavior for network communication streams has been adjusted based on operational mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->