### PR TITLE
[FVM] Remove exception for minting in token tracker

### DIFF
--- a/cmd/util/cmd/inspect-token-movements/cmd.go
+++ b/cmd/util/cmd/inspect-token-movements/cmd.go
@@ -81,7 +81,7 @@ func run(*cobra.Command, []string) {
 	}()
 
 	// Create the token changes inspector with default search tokens for this chain
-	inspector := inspection.NewTokenChangesInspector(inspection.DefaultTokenDiffSearchTokens(chain, true), chainID)
+	inspector := inspection.NewTokenChangesInspector(inspection.DefaultTokenDiffSearchTokens(chain), chainID)
 
 	var from, to uint64
 

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -244,11 +244,8 @@ func DefaultFVMOptions(chainID flow.ChainID, extensiveTracing, scheduleCallbacks
 	}
 
 	if tokenTracking {
-		// We temporarily want to log all mints/burns, so remove the minting event from the DefaultTokenDiffSearchTokens
-		withoutMintingEvent := true
-
 		options = append(options, fvm.WithInspectors([]inspection.Inspector{
-			inspection.NewTokenChangesInspector(inspection.DefaultTokenDiffSearchTokens(chainID.Chain(), withoutMintingEvent), chainID),
+			inspection.NewTokenChangesInspector(inspection.DefaultTokenDiffSearchTokens(chainID.Chain()), chainID),
 		}))
 	}
 

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -4542,7 +4542,7 @@ func TestFlowTokenChangesInspector(t *testing.T) {
 		},
 		{
 			name:             "mint with default tracking",
-			tokenDefinitions: inspection.DefaultTokenDiffSearchTokens(chain, false),
+			tokenDefinitions: inspection.DefaultTokenDiffSearchTokens(chain),
 			txBody: func(t *testing.T, chain flow.Chain, accounts []flow.Address) *flow.TransactionBody {
 				sc := systemcontracts.SystemContractsForChain(chain.ChainID())
 				env := sc.AsTemplateEnv()
@@ -4569,7 +4569,7 @@ func TestFlowTokenChangesInspector(t *testing.T) {
 			},
 		}, {
 			name:             "create account",
-			tokenDefinitions: inspection.DefaultTokenDiffSearchTokens(chain, false),
+			tokenDefinitions: inspection.DefaultTokenDiffSearchTokens(chain),
 			txBody: func(t *testing.T, chain flow.Chain, accounts []flow.Address) *flow.TransactionBody {
 				_, txBodyBuilder := testutil.CreateAccountCreationTransaction(t, chain)
 
@@ -4588,7 +4588,7 @@ func TestFlowTokenChangesInspector(t *testing.T) {
 			},
 		}, {
 			name:             "evm transaction",
-			tokenDefinitions: inspection.DefaultTokenDiffSearchTokens(chain, false),
+			tokenDefinitions: inspection.DefaultTokenDiffSearchTokens(chain),
 			txBody: func(t *testing.T, chain flow.Chain, _ []flow.Address) *flow.TransactionBody {
 				sc := systemcontracts.SystemContractsForChain(chain.ChainID())
 

--- a/fvm/inspection/token_changes.go
+++ b/fvm/inspection/token_changes.go
@@ -734,9 +734,7 @@ var tokenDiffSearchDomains = []common.StorageDomain{
 type TokenChangesSearchTokens map[string]SearchToken
 
 // DefaultTokenDiffSearchTokens returns the default settings for token inspection
-// We temporarily want to handle all token mints as a warning. To do that set the
-// `withoutMintingEvent` to true.
-func DefaultTokenDiffSearchTokens(chain flow.Chain, withoutMintingEvent bool) TokenChangesSearchTokens {
+func DefaultTokenDiffSearchTokens(chain flow.Chain) TokenChangesSearchTokens {
 	sc := systemcontracts.SystemContractsForChain(chain.ChainID())
 	flowTokenID := fmt.Sprintf("A.%s.FlowToken.Vault", sc.FlowToken.Address.Hex())
 	flowTokenMintedEventID := fmt.Sprintf("A.%s.FlowToken.TokensMinted", sc.FlowToken.Address.Hex())
@@ -750,10 +748,7 @@ func DefaultTokenDiffSearchTokens(chain flow.Chain, withoutMintingEvent bool) To
 			SinksSources: map[string]func(flow.Event) (int64, error){},
 		},
 	}
-
-	if !withoutMintingEvent {
-		searchTokens[flowTokenID].SinksSources[flowTokenMintedEventID] = decodeFlowEventAmount(false)
-	}
+	searchTokens[flowTokenID].SinksSources[flowTokenMintedEventID] = decodeFlowEventAmount(false)
 
 	// EVM bridge events: FLOW tokens moving between Cadence and EVM.
 	// Deposited = tokens leave Cadence into EVM (sink, negative).


### PR DESCRIPTION
We wanted the minting to trigger an error while we were still testing out the token tracker. This is not needed anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified token change inspection configuration. Token minting events are now always included in token tracking (previously optional).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->