### PR TITLE
Networking security patches 

### DIFF
--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -16,6 +16,8 @@ network-config:
   dns-cache-ttl: 5m
   # The size of the queue for notifications about new peers in the disallow list.
   disallow-list-notification-cache-size: 100
+  # Maximum number of messages in the inbound message queue. Limits memory growth from message flooding.
+  message-queue-size: 100_000
   unicast:
     rate-limiter:
       # Setting this to true will disable connection disconnects and gating when unicast rate limiters are configured

--- a/engine/access/rpc/backend/events/events.go
+++ b/engine/access/rpc/backend/events/events.go
@@ -94,10 +94,15 @@ func (e *Events) GetEventsForHeightRange(
 		return nil, status.Error(codes.InvalidArgument, "start height must not be larger than end height")
 	}
 
-	rangeSize := endHeight - startHeight + 1 // range is inclusive on both ends
-	if rangeSize > uint64(e.maxHeightRange) {
+	// Overflow-safe range validation: compute (endHeight - startHeight) first, then check if
+	// adding 1 (for inclusive range) would exceed maxHeightRange. This avoids the overflow that
+	// occurs when endHeight = math.MaxUint64 and startHeight = 0, where (endHeight - startHeight + 1)
+	// wraps to 0.
+	rangeSpan := endHeight - startHeight // safe: we already checked endHeight >= startHeight
+	if rangeSpan >= uint64(e.maxHeightRange) {
+		// rangeSpan + 1 > maxHeightRange, but we compute it this way to avoid overflow
 		return nil, status.Errorf(codes.InvalidArgument,
-			"requested block range (%d) exceeded maximum (%d)", rangeSize, e.maxHeightRange)
+			"requested block range (%d) exceeded maximum (%d)", rangeSpan+1, e.maxHeightRange)
 	}
 
 	// get the latest sealed block header

--- a/engine/access/rpc/backend/events/events_test.go
+++ b/engine/access/rpc/backend/events/events_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"testing"
 
@@ -315,6 +316,38 @@ func (s *EventsSuite) TestGetEventsForHeightRange_HandlesErrors() {
 		endHeight := startHeight + DefaultMaxHeightRange
 
 		response, err := backend.GetEventsForHeightRange(ctx, targetEvent, startHeight, endHeight, encoding)
+		s.Assert().Equal(codes.InvalidArgument, status.Code(err))
+		s.Assert().Nil(response)
+	})
+
+	// Regression tests for unsigned integer overflow vulnerability (KRITT-1)
+	// When endHeight = math.MaxUint64 and startHeight = 0, the computation
+	// (endHeight - startHeight + 1) would overflow to 0, bypassing the range check.
+	s.Run("returns error for max uint64 end height - overflow prevention", func() {
+		backend := s.defaultBackend(query_mode.IndexQueryModeExecutionNodesOnly, s.eventsIndex)
+
+		response, err := backend.GetEventsForHeightRange(ctx, targetEvent, 0, math.MaxUint64, encoding)
+		s.Assert().Equal(codes.InvalidArgument, status.Code(err))
+		s.Assert().Contains(err.Error(), "exceeded maximum")
+		s.Assert().Nil(response)
+	})
+
+	s.Run("returns error for max uint64 end height with non-zero start - overflow prevention", func() {
+		backend := s.defaultBackend(query_mode.IndexQueryModeExecutionNodesOnly, s.eventsIndex)
+
+		response, err := backend.GetEventsForHeightRange(ctx, targetEvent, 100, math.MaxUint64, encoding)
+		s.Assert().Equal(codes.InvalidArgument, status.Code(err))
+		s.Assert().Contains(err.Error(), "exceeded maximum")
+		s.Assert().Nil(response)
+	})
+
+	s.Run("returns error for range exactly at max boundary", func() {
+		backend := s.defaultBackend(query_mode.IndexQueryModeExecutionNodesOnly, s.eventsIndex)
+		// Range of exactly maxHeightRange should be allowed (inclusive range = maxHeightRange blocks)
+		// But range of maxHeightRange + 1 blocks (endHeight = startHeight + maxHeightRange) should fail
+
+		// endHeight = startHeight + maxHeightRange gives maxHeightRange + 1 blocks, should fail
+		response, err := backend.GetEventsForHeightRange(ctx, targetEvent, startHeight, startHeight+DefaultMaxHeightRange, encoding)
 		s.Assert().Equal(codes.InvalidArgument, status.Code(err))
 		s.Assert().Nil(response)
 	})

--- a/engine/access/subscription/streamer.go
+++ b/engine/access/subscription/streamer.go
@@ -59,8 +59,17 @@ func (s *Streamer) Stream(ctx context.Context) {
 	s.log.Debug().Msg("starting streaming")
 	defer s.log.Debug().Msg("finished streaming")
 
+	// Check if context is already cancelled before subscribing to avoid leaking subscribers
+	select {
+	case <-ctx.Done():
+		s.sub.Fail(fmt.Errorf("client disconnected before subscribe: %w", ctx.Err()))
+		return
+	default:
+	}
+
 	notifier := engine.NewNotifier()
 	s.broadcaster.Subscribe(notifier)
+	defer s.broadcaster.Unsubscribe(notifier)
 
 	// always check the first time. This ensures that streaming continues to work even if the
 	// execution sync is not functioning (e.g. on a past spork network, or during an temporary outage)

--- a/engine/access/subscription/streamer_test.go
+++ b/engine/access/subscription/streamer_test.go
@@ -242,12 +242,19 @@ func TestStreamUnsubscribesOnContextCancel(t *testing.T) {
 			synctest.Wait()
 			assert.Equal(t, numStreams, broadcaster.SubscriberCount())
 
+			// Verify broadcast reaches all subscribers
+			broadcaster.Publish()
+			synctest.Wait()
+
 			// Cancel streams one by one and verify count decreases
 			for i := 0; i < numStreams; i++ {
 				cancels[i]()
 				synctest.Wait()
 				assert.Equal(t, numStreams-i-1, broadcaster.SubscriberCount())
 			}
+
+			// Verify broadcasting to empty subscriber list works
+			broadcaster.Publish()
 		})
 	})
 }

--- a/engine/access/subscription/streamer_test.go
+++ b/engine/access/subscription/streamer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -116,38 +117,36 @@ func TestStreamUnsubscribesOnContextCancel(t *testing.T) {
 
 	t.Run("unsubscribes on context cancel", func(t *testing.T) {
 		t.Parallel()
-		ctx, cancel := context.WithCancel(context.Background())
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
 
-		sub := submock.NewStreamable(t)
-		sub.On("ID").Return(uuid.NewString())
-		// Mock Next to return ErrBlockNotReady so the stream waits for more notifications
-		sub.On("Next", mock.Anything).Return(nil, subscription.ErrBlockNotReady).Maybe()
-		sub.On("Fail", mock.Anything).Return().Once()
+			sub := submock.NewStreamable(t)
+			sub.On("ID").Return(uuid.NewString())
+			// Mock Next to return ErrBlockNotReady so the stream waits for more notifications
+			sub.On("Next", mock.Anything).Return(nil, subscription.ErrBlockNotReady).Maybe()
+			sub.On("Fail", mock.Anything).Return().Once()
 
-		broadcaster := engine.NewBroadcaster()
-		streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
+			broadcaster := engine.NewBroadcaster()
+			streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
 
-		assert.Equal(t, 0, broadcaster.SubscriberCount())
+			assert.Equal(t, 0, broadcaster.SubscriberCount())
 
-		// Start streaming in a goroutine
-		done := make(chan struct{})
-		go func() {
-			streamer.Stream(ctx)
-			close(done)
-		}()
+			// Start streaming in a goroutine
+			go streamer.Stream(ctx)
 
-		// Wait a bit for the stream to start and subscribe
-		time.Sleep(10 * time.Millisecond)
-		assert.Equal(t, 1, broadcaster.SubscriberCount())
+			// Wait for the stream to start and subscribe (blocks until goroutine is waiting)
+			synctest.Wait()
+			assert.Equal(t, 1, broadcaster.SubscriberCount())
 
-		// Cancel the context
-		cancel()
+			// Cancel the context
+			cancel()
 
-		// Wait for the stream to finish
-		unittest.RequireReturnsBefore(t, func() { <-done }, 100*time.Millisecond, "stream should finish")
+			// Wait for the stream to finish
+			synctest.Wait()
 
-		// Verify subscriber was removed
-		assert.Equal(t, 0, broadcaster.SubscriberCount())
+			// Verify subscriber was removed
+			assert.Equal(t, 0, broadcaster.SubscriberCount())
+		})
 	})
 
 	t.Run("unsubscribes on error", func(t *testing.T) {
@@ -218,42 +217,38 @@ func TestStreamUnsubscribesOnContextCancel(t *testing.T) {
 
 	t.Run("multiple streams subscribe and unsubscribe correctly", func(t *testing.T) {
 		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			broadcaster := engine.NewBroadcaster()
+			const numStreams = 10
 
-		broadcaster := engine.NewBroadcaster()
-		const numStreams = 10
+			cancels := make([]context.CancelFunc, numStreams)
 
-		contexts := make([]context.Context, numStreams)
-		cancels := make([]context.CancelFunc, numStreams)
-		done := make([]chan struct{}, numStreams)
+			for i := 0; i < numStreams; i++ {
+				var ctx context.Context
+				ctx, cancels[i] = context.WithCancel(context.Background())
 
-		for i := 0; i < numStreams; i++ {
-			contexts[i], cancels[i] = context.WithCancel(context.Background())
-			done[i] = make(chan struct{})
+				sub := submock.NewStreamable(t)
+				sub.On("ID").Return(uuid.NewString())
+				// Mock Next to return ErrBlockNotReady so the stream waits for more notifications
+				sub.On("Next", mock.Anything).Return(nil, subscription.ErrBlockNotReady).Maybe()
+				sub.On("Fail", mock.Anything).Return().Once()
 
-			sub := submock.NewStreamable(t)
-			sub.On("ID").Return(uuid.NewString())
-			// Mock Next to return ErrBlockNotReady so the stream waits for more notifications
-			sub.On("Next", mock.Anything).Return(nil, subscription.ErrBlockNotReady).Maybe()
-			sub.On("Fail", mock.Anything).Return().Once()
+				streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
 
-			streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
+				go streamer.Stream(ctx)
+			}
 
-			go func(d chan struct{}, s *subscription.Streamer, c context.Context) {
-				s.Stream(c)
-				close(d)
-			}(done[i], streamer, contexts[i])
-		}
+			// Wait for all streams to start (blocks until all goroutines are waiting)
+			synctest.Wait()
+			assert.Equal(t, numStreams, broadcaster.SubscriberCount())
 
-		// Wait for all streams to start
-		time.Sleep(50 * time.Millisecond)
-		assert.Equal(t, numStreams, broadcaster.SubscriberCount())
-
-		// Cancel streams one by one and verify count decreases
-		for i := 0; i < numStreams; i++ {
-			cancels[i]()
-			unittest.RequireReturnsBefore(t, func() { <-done[i] }, 100*time.Millisecond, "stream should finish")
-			assert.Equal(t, numStreams-i-1, broadcaster.SubscriberCount())
-		}
+			// Cancel streams one by one and verify count decreases
+			for i := 0; i < numStreams; i++ {
+				cancels[i]()
+				synctest.Wait()
+				assert.Equal(t, numStreams-i-1, broadcaster.SubscriberCount())
+			}
+		})
 	})
 }
 

--- a/engine/access/subscription/streamer_test.go
+++ b/engine/access/subscription/streamer_test.go
@@ -107,6 +107,156 @@ func TestStreamRatelimited(t *testing.T) {
 	}
 }
 
+// TestStreamUnsubscribesOnContextCancel tests that the streamer properly unsubscribes from the
+// broadcaster when the context is cancelled, preventing subscriber leaks.
+func TestStreamUnsubscribesOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	timeout := subscription.DefaultSendTimeout
+
+	t.Run("unsubscribes on context cancel", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+
+		sub := submock.NewStreamable(t)
+		sub.On("ID").Return(uuid.NewString())
+		// Mock Next to return ErrBlockNotReady so the stream waits for more notifications
+		sub.On("Next", mock.Anything).Return(nil, subscription.ErrBlockNotReady).Maybe()
+		sub.On("Fail", mock.Anything).Return().Once()
+
+		broadcaster := engine.NewBroadcaster()
+		streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
+
+		assert.Equal(t, 0, broadcaster.SubscriberCount())
+
+		// Start streaming in a goroutine
+		done := make(chan struct{})
+		go func() {
+			streamer.Stream(ctx)
+			close(done)
+		}()
+
+		// Wait a bit for the stream to start and subscribe
+		time.Sleep(10 * time.Millisecond)
+		assert.Equal(t, 1, broadcaster.SubscriberCount())
+
+		// Cancel the context
+		cancel()
+
+		// Wait for the stream to finish
+		unittest.RequireReturnsBefore(t, func() { <-done }, 100*time.Millisecond, "stream should finish")
+
+		// Verify subscriber was removed
+		assert.Equal(t, 0, broadcaster.SubscriberCount())
+	})
+
+	t.Run("unsubscribes on error", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		sub := submock.NewStreamable(t)
+		sub.On("ID").Return(uuid.NewString())
+		sub.On("Next", mock.Anything).Return(nil, testErr).Once()
+		sub.On("Fail", mock.Anything).Return().Once()
+
+		broadcaster := engine.NewBroadcaster()
+		streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
+
+		assert.Equal(t, 0, broadcaster.SubscriberCount())
+
+		unittest.RequireReturnsBefore(t, func() {
+			streamer.Stream(ctx)
+		}, 100*time.Millisecond, "stream should finish")
+
+		// Verify subscriber was removed after error
+		assert.Equal(t, 0, broadcaster.SubscriberCount())
+	})
+
+	t.Run("unsubscribes on end of data", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		sub := submock.NewStreamable(t)
+		sub.On("ID").Return(uuid.NewString())
+		sub.On("Next", mock.Anything).Return(nil, subscription.ErrEndOfData).Once()
+		sub.On("Close").Return().Once()
+
+		broadcaster := engine.NewBroadcaster()
+		streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
+
+		assert.Equal(t, 0, broadcaster.SubscriberCount())
+
+		unittest.RequireReturnsBefore(t, func() {
+			streamer.Stream(ctx)
+		}, 100*time.Millisecond, "stream should finish")
+
+		// Verify subscriber was removed after end of data
+		assert.Equal(t, 0, broadcaster.SubscriberCount())
+	})
+
+	t.Run("does not subscribe if context already cancelled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel before streaming starts
+
+		sub := submock.NewStreamable(t)
+		sub.On("ID").Return(uuid.NewString())
+		sub.On("Fail", mock.Anything).Return().Once()
+
+		broadcaster := engine.NewBroadcaster()
+		streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
+
+		assert.Equal(t, 0, broadcaster.SubscriberCount())
+
+		unittest.RequireReturnsBefore(t, func() {
+			streamer.Stream(ctx)
+		}, 100*time.Millisecond, "stream should finish immediately")
+
+		// Verify no subscriber was ever added
+		assert.Equal(t, 0, broadcaster.SubscriberCount())
+	})
+
+	t.Run("multiple streams subscribe and unsubscribe correctly", func(t *testing.T) {
+		t.Parallel()
+
+		broadcaster := engine.NewBroadcaster()
+		const numStreams = 10
+
+		contexts := make([]context.Context, numStreams)
+		cancels := make([]context.CancelFunc, numStreams)
+		done := make([]chan struct{}, numStreams)
+
+		for i := 0; i < numStreams; i++ {
+			contexts[i], cancels[i] = context.WithCancel(context.Background())
+			done[i] = make(chan struct{})
+
+			sub := submock.NewStreamable(t)
+			sub.On("ID").Return(uuid.NewString())
+			// Mock Next to return ErrBlockNotReady so the stream waits for more notifications
+			sub.On("Next", mock.Anything).Return(nil, subscription.ErrBlockNotReady).Maybe()
+			sub.On("Fail", mock.Anything).Return().Once()
+
+			streamer := subscription.NewStreamer(unittest.Logger(), broadcaster, timeout, subscription.DefaultResponseLimit, sub)
+
+			go func(d chan struct{}, s *subscription.Streamer, c context.Context) {
+				s.Stream(c)
+				close(d)
+			}(done[i], streamer, contexts[i])
+		}
+
+		// Wait for all streams to start
+		time.Sleep(50 * time.Millisecond)
+		assert.Equal(t, numStreams, broadcaster.SubscriberCount())
+
+		// Cancel streams one by one and verify count decreases
+		for i := 0; i < numStreams; i++ {
+			cancels[i]()
+			unittest.RequireReturnsBefore(t, func() { <-done[i] }, 100*time.Millisecond, "stream should finish")
+			assert.Equal(t, numStreams-i-1, broadcaster.SubscriberCount())
+		}
+	})
+}
+
 // TestLongStreamRatelimited tests that the streamer is uses the correct rate limit over a longer
 // period of time
 func TestLongStreamRatelimited(t *testing.T) {

--- a/engine/broadcaster.go
+++ b/engine/broadcaster.go
@@ -30,6 +30,31 @@ func (b *Broadcaster) Subscribe(n Notifiable) {
 	b.subscribers = append(b.subscribers, n)
 }
 
+// Unsubscribe removes a Notifier from the list of subscribers. If the subscriber is not found,
+// this is a no-op.
+func (b *Broadcaster) Unsubscribe(n Notifiable) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for i, sub := range b.subscribers {
+		if sub == n {
+			// Remove by swapping with the last element and truncating
+			b.subscribers[i] = b.subscribers[len(b.subscribers)-1]
+			b.subscribers[len(b.subscribers)-1] = nil // Allow GC
+			b.subscribers = b.subscribers[:len(b.subscribers)-1]
+			return
+		}
+	}
+}
+
+// SubscriberCount returns the current number of subscribers.
+func (b *Broadcaster) SubscriberCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return len(b.subscribers)
+}
+
 // Publish sends notifications to all subscribers
 func (b *Broadcaster) Publish() {
 	b.mu.RLock()

--- a/engine/broadcaster_test.go
+++ b/engine/broadcaster_test.go
@@ -13,6 +13,114 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+func TestUnsubscribe(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unsubscribe removes subscriber", func(t *testing.T) {
+		t.Parallel()
+		b := engine.NewBroadcaster()
+
+		notifier1 := engine.NewNotifier()
+		notifier2 := engine.NewNotifier()
+		notifier3 := engine.NewNotifier()
+
+		b.Subscribe(notifier1)
+		b.Subscribe(notifier2)
+		b.Subscribe(notifier3)
+
+		assert.Equal(t, 3, b.SubscriberCount())
+
+		b.Unsubscribe(notifier2)
+		assert.Equal(t, 2, b.SubscriberCount())
+
+		// Verify remaining subscribers still receive notifications
+		received1 := make(chan struct{}, 1)
+		received3 := make(chan struct{}, 1)
+
+		go func() {
+			<-notifier1.Channel()
+			received1 <- struct{}{}
+		}()
+		go func() {
+			<-notifier3.Channel()
+			received3 <- struct{}{}
+		}()
+
+		b.Publish()
+
+		unittest.RequireReturnsBefore(t, func() { <-received1 }, 100*time.Millisecond, "notifier1 should receive")
+		unittest.RequireReturnsBefore(t, func() { <-received3 }, 100*time.Millisecond, "notifier3 should receive")
+	})
+
+	t.Run("unsubscribe non-existent subscriber is no-op", func(t *testing.T) {
+		t.Parallel()
+		b := engine.NewBroadcaster()
+
+		notifier1 := engine.NewNotifier()
+		notifier2 := engine.NewNotifier()
+
+		b.Subscribe(notifier1)
+		assert.Equal(t, 1, b.SubscriberCount())
+
+		// Unsubscribe a notifier that was never subscribed
+		b.Unsubscribe(notifier2)
+		assert.Equal(t, 1, b.SubscriberCount())
+	})
+
+	t.Run("unsubscribe same subscriber twice is no-op", func(t *testing.T) {
+		t.Parallel()
+		b := engine.NewBroadcaster()
+
+		notifier := engine.NewNotifier()
+
+		b.Subscribe(notifier)
+		assert.Equal(t, 1, b.SubscriberCount())
+
+		b.Unsubscribe(notifier)
+		assert.Equal(t, 0, b.SubscriberCount())
+
+		// Unsubscribe again should be a no-op
+		b.Unsubscribe(notifier)
+		assert.Equal(t, 0, b.SubscriberCount())
+	})
+
+	t.Run("concurrent subscribe and unsubscribe", func(t *testing.T) {
+		t.Parallel()
+		b := engine.NewBroadcaster()
+
+		const numOperations = 100
+		notifiers := make([]engine.Notifier, numOperations)
+		for i := 0; i < numOperations; i++ {
+			notifiers[i] = engine.NewNotifier()
+		}
+
+		// Subscribe all notifiers concurrently
+		var wg sync.WaitGroup
+		wg.Add(numOperations)
+		for i := 0; i < numOperations; i++ {
+			go func(n engine.Notifier) {
+				defer wg.Done()
+				b.Subscribe(n)
+			}(notifiers[i])
+		}
+		wg.Wait()
+
+		assert.Equal(t, numOperations, b.SubscriberCount())
+
+		// Unsubscribe all notifiers concurrently
+		wg.Add(numOperations)
+		for i := 0; i < numOperations; i++ {
+			go func(n engine.Notifier) {
+				defer wg.Done()
+				b.Unsubscribe(n)
+			}(notifiers[i])
+		}
+		wg.Wait()
+
+		assert.Equal(t, 0, b.SubscriberCount())
+	})
+}
+
 func TestPublish(t *testing.T) {
 	t.Parallel()
 

--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -284,7 +284,6 @@ func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 	entityIDs := make([]flow.Identifier, 0, len(requestedIDs))
 	seen := make(map[flow.Identifier]struct{})
 	var cumulativeSize int
-	budgetExceeded := false
 
 	for _, entityID := range requestedIDs {
 		// skip requesting duplicate entity IDs
@@ -316,7 +315,6 @@ func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 
 		// Check if adding this entity would exceed the response byte budget
 		if cumulativeSize+len(blob) > e.maxResponseByteSize {
-			budgetExceeded = true
 			lg.Info().
 				Int("cumulative_size", cumulativeSize).
 				Int("blob_size", len(blob)).
@@ -330,8 +328,6 @@ func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 		entityIDs = append(entityIDs, entityID)
 		cumulativeSize += len(blob)
 	}
-
-	_ = budgetExceeded // used for logging above; silence unused warning
 
 	// NOTE: we do _NOT_ avoid sending empty responses, as this will allow
 	// the requester to know we don't have any of the requested entities, which

--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -33,7 +33,9 @@ const (
 
 	// DefaultMaxEntityIDs is the default maximum number of entity IDs that can be requested in a single
 	// EntityRequest. This limit prevents amplification attacks where a small request triggers excessive
-	// retrieval and serialization work.
+	// retrieval and serialization work. Note: the default requester engine (engine/common/requester) only
+	// requests up to 32 entity IDs per batch (see BatchThreshold), so this limit provides ample headroom
+	// for legitimate requests.
 	DefaultMaxEntityIDs = 100
 
 	// DefaultMaxResponseByteSize is the default maximum cumulative byte size of encoded entities in a response.

--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -30,6 +30,17 @@ const (
 	// DefaultEntityRequestCacheSize is the default max message queue size for the provider engine.
 	// This equates to ~5GB of memory usage with a full queue (10M*500)
 	DefaultEntityRequestCacheSize = 500
+
+	// DefaultMaxEntityIDs is the default maximum number of entity IDs that can be requested in a single
+	// EntityRequest. This limit prevents amplification attacks where a small request triggers excessive
+	// retrieval and serialization work.
+	DefaultMaxEntityIDs = 100
+
+	// DefaultMaxResponseByteSize is the default maximum cumulative byte size of encoded entities in a response.
+	// This is set conservatively below the network's DefaultMaxUnicastMsgSize (10MB) to account for
+	// message overhead (headers, encoding wrappers, etc.). The provider will stop adding entities to the
+	// response once this budget is exceeded, preventing unbounded serialization work.
+	DefaultMaxResponseByteSize = 8 * 1024 * 1024 // 8MB
 )
 
 // RetrieveFunc is a function provided to the provider engine upon construction.
@@ -56,9 +67,34 @@ type Engine struct {
 	retrieve       RetrieveFunc
 	// buffered channel for EntityRequest workers to pick and process.
 	requestChannel chan *internal.EntityRequest
+	// maxEntityIDs is the maximum number of entity IDs allowed per request.
+	// Requests with more IDs will be truncated to this limit.
+	maxEntityIDs int
+	// maxResponseByteSize is the maximum cumulative byte size of encoded entities in a response.
+	// The provider will stop adding entities once this budget is exceeded.
+	maxResponseByteSize int
 }
 
 var _ network.MessageProcessor = (*Engine)(nil)
+
+// Option is a functional option for configuring the provider Engine.
+type Option func(*Engine)
+
+// WithMaxEntityIDs sets the maximum number of entity IDs that can be requested in a single request.
+// Requests with more IDs will be truncated to this limit.
+func WithMaxEntityIDs(max int) Option {
+	return func(e *Engine) {
+		e.maxEntityIDs = max
+	}
+}
+
+// WithMaxResponseByteSize sets the maximum cumulative byte size of encoded entities in a response.
+// The provider will stop adding entities once this budget is exceeded.
+func WithMaxResponseByteSize(max int) Option {
+	return func(e *Engine) {
+		e.maxResponseByteSize = max
+	}
+}
 
 // New creates a new provider engine, operating on the provided network channel, and accepting requests for entities
 // from a node within the set obtained by applying the provided selector filter. It uses the injected retrieve function
@@ -73,7 +109,8 @@ func New(
 	requestWorkers uint,
 	channel channels.Channel,
 	selector flow.IdentityFilter[flow.Identity],
-	retrieve RetrieveFunc) (*Engine, error) {
+	retrieve RetrieveFunc,
+	opts ...Option) (*Engine, error) {
 
 	// make sure we don't respond to request sent by self or unauthorized nodes
 	selector = filter.And(
@@ -114,15 +151,22 @@ func New(
 
 	// initialize the propagation engine with its dependencies
 	e := &Engine{
-		log:            log.With().Str("engine", "provider").Logger(),
-		metrics:        metrics,
-		state:          state,
-		channel:        channel,
-		selector:       selector,
-		retrieve:       retrieve,
-		requestHandler: handler,
-		requestQueue:   requestQueue,
-		requestChannel: make(chan *internal.EntityRequest, requestWorkers),
+		log:                 log.With().Str("engine", "provider").Logger(),
+		metrics:             metrics,
+		state:               state,
+		channel:             channel,
+		selector:            selector,
+		retrieve:            retrieve,
+		requestHandler:      handler,
+		requestQueue:        requestQueue,
+		requestChannel:      make(chan *internal.EntityRequest, requestWorkers),
+		maxEntityIDs:        DefaultMaxEntityIDs,
+		maxResponseByteSize: DefaultMaxResponseByteSize,
+	}
+
+	// apply functional options
+	for _, opt := range opts {
+		opt(e)
 	}
 
 	// register the engine with the network layer and store the conduit
@@ -176,21 +220,45 @@ func (e *Engine) Process(channel channels.Channel, originID flow.Identifier, eve
 }
 
 // onEntityRequest processes an entity request message from a remote node.
+//
+// To prevent amplification attacks, this method enforces two limits:
+//   - Maximum number of entity IDs per request (truncates to maxEntityIDs)
+//   - Maximum cumulative response size (stops adding entities once maxResponseByteSize is exceeded)
+//
 // Error returns:
-// * NetworkTransmissionError if there is a network error happens on transmitting the requested entities.
-// * InvalidInputError if the list of requested entities is invalid (empty).
-// * generic error in case of unexpected failure or implementation bug.
+//   - NetworkTransmissionError if there is a network error happens on transmitting the requested entities.
+//   - InvalidInputError if the list of requested entities is invalid (empty).
+//   - generic error in case of unexpected failure or implementation bug.
 func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 	defer e.metrics.MessageHandled(e.channel.String(), metrics.MessageEntityRequest)
 
+	requestedIDs := request.EntityIds
+	truncated := false
+
+	// Enforce maximum number of entity IDs per request to limit retrieval work
+	if len(requestedIDs) > e.maxEntityIDs {
+		requestedIDs = requestedIDs[:e.maxEntityIDs]
+		truncated = true
+	}
+
 	lg := e.log.With().
 		Str("origin_id", request.OriginId.String()).
-		Strs("entity_ids", flow.IdentifierList(request.EntityIds).Strings()).
+		Strs("entity_ids", flow.IdentifierList(requestedIDs).Strings()).
 		Logger()
 
-	lg.Info().
-		Uint64("nonce", request.Nonce).
-		Msg("entity request received")
+	if truncated {
+		lg.Warn().
+			Uint64("nonce", request.Nonce).
+			Int("original_count", len(request.EntityIds)).
+			Int("truncated_to", len(requestedIDs)).
+			Bool(logging.KeySuspicious, true).
+			Msg("entity request truncated: exceeded maximum entity IDs limit")
+	} else {
+		lg.Info().
+			Uint64("nonce", request.Nonce).
+			Int("requested_count", len(request.EntityIds)).
+			Msg("entity request received")
+	}
 
 	// TODO: add reputation system to punish nodes for malicious behaviour (spam / repeated requests)
 
@@ -207,11 +275,16 @@ func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 		return engine.NewInvalidInputErrorf("invalid requester origin (%x)", request.OriginId)
 	}
 
-	// try to retrieve each entity and skip missing ones
-	entities := make([]flow.Entity, 0, len(request.EntityIds))
-	entityIDs := make([]flow.Identifier, 0, len(request.EntityIds))
+	// Retrieve and encode entities one at a time, tracking cumulative response size.
+	// We encode during retrieval (rather than in a separate loop) to allow early termination
+	// once the response byte budget is exceeded. This prevents unbounded serialization work.
+	blobs := make([][]byte, 0, len(requestedIDs))
+	entityIDs := make([]flow.Identifier, 0, len(requestedIDs))
 	seen := make(map[flow.Identifier]struct{})
-	for _, entityID := range request.EntityIds {
+	var cumulativeSize int
+	budgetExceeded := false
+
+	for _, entityID := range requestedIDs {
 		// skip requesting duplicate entity IDs
 		if _, ok := seen[entityID]; ok {
 			lg.Warn().
@@ -220,6 +293,7 @@ func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 				Msg("duplicate entity ID in entity request")
 			continue
 		}
+		seen[entityID] = struct{}{}
 
 		entity, err := e.retrieve(entityID)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -231,20 +305,31 @@ func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 		if err != nil {
 			return fmt.Errorf("could not retrieve entity (%x): %w", entityID, err)
 		}
-		entities = append(entities, entity)
-		entityIDs = append(entityIDs, entityID)
-		seen[entityID] = struct{}{}
-	}
 
-	// encode all of the entities
-	blobs := make([][]byte, 0, len(entities))
-	for _, entity := range entities {
+		// Encode the entity immediately to check size budget
 		blob, err := msgpack.Marshal(entity)
 		if err != nil {
 			return fmt.Errorf("could not encode entity (%x): %w", entity.ID(), err)
 		}
+
+		// Check if adding this entity would exceed the response byte budget
+		if cumulativeSize+len(blob) > e.maxResponseByteSize {
+			budgetExceeded = true
+			lg.Info().
+				Int("cumulative_size", cumulativeSize).
+				Int("blob_size", len(blob)).
+				Int("max_response_size", e.maxResponseByteSize).
+				Int("entities_included", len(blobs)).
+				Msg("response byte budget exceeded, returning partial response")
+			break
+		}
+
 		blobs = append(blobs, blob)
+		entityIDs = append(entityIDs, entityID)
+		cumulativeSize += len(blob)
 	}
+
+	_ = budgetExceeded // used for logging above; silence unused warning
 
 	// NOTE: we do _NOT_ avoid sending empty responses, as this will allow
 	// the requester to know we don't have any of the requested entities, which

--- a/engine/common/provider/engine_test.go
+++ b/engine/common/provider/engine_test.go
@@ -471,3 +471,212 @@ func TestOnEntityRequestInvalidOrigin(t *testing.T) {
 	require.NoError(t, err)
 	unittest.RequireCloseBefore(t, e.Done(), 100*time.Millisecond, "could not stop engine")
 }
+
+// TestOnEntityRequestTruncatesExcessiveIDs verifies that requests with more entity IDs than
+// the maximum limit are truncated. This prevents amplification attacks where a small request
+// triggers excessive retrieval work.
+func TestOnEntityRequestTruncatesExcessiveIDs(t *testing.T) {
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := irrecoverable.NewMockSignalerContext(t, cancelCtx)
+
+	// Set a low limit for testing
+	const maxEntityIDs = 3
+
+	entities := make(map[flow.Identifier]flow.Entity)
+	identities := unittest.IdentityListFixture(8)
+	selector := filter.HasNodeID[flow.Identity](identities.NodeIDs()...)
+	originID := identities[0].NodeID
+
+	// Create 5 collections, but only the first 3 should be returned due to the limit
+	coll1 := unittest.CollectionFixture(1)
+	coll2 := unittest.CollectionFixture(2)
+	coll3 := unittest.CollectionFixture(3)
+	coll4 := unittest.CollectionFixture(4)
+	coll5 := unittest.CollectionFixture(5)
+
+	entities[coll1.ID()] = coll1
+	entities[coll2.ID()] = coll2
+	entities[coll3.ID()] = coll3
+	entities[coll4.ID()] = coll4
+	entities[coll5.ID()] = coll5
+
+	retrieve := func(entityID flow.Identifier) (flow.Entity, error) {
+		entity, ok := entities[entityID]
+		if !ok {
+			return nil, storage.ErrNotFound
+		}
+		return entity, nil
+	}
+
+	final := protocol.NewSnapshot(t)
+	final.On("Identities", mock.Anything).Return(
+		func(selector flow.IdentityFilter[flow.Identity]) flow.IdentityList {
+			return identities.Filter(selector)
+		},
+		nil,
+	)
+
+	state := protocol.NewState(t)
+	state.On("Final").Return(final, nil)
+
+	net := mocknetwork.NewEngineRegistry(t)
+	con := mocknetwork.NewConduit(t)
+	net.On("Register", mock.Anything, mock.Anything).Return(con, nil)
+	con.On("Unicast", mock.Anything, mock.Anything).Run(
+		func(args mock.Arguments) {
+			defer cancel()
+
+			response := args.Get(0).(*messages.EntityResponse)
+			nodeID := args.Get(1).(flow.Identifier)
+			assert.Equal(t, nodeID, originID)
+
+			// Only the first 3 collections should be returned due to the maxEntityIDs limit
+			assert.Len(t, response.Blobs, maxEntityIDs, "response should contain exactly maxEntityIDs entities")
+
+			var returnedEntities []flow.Entity
+			for _, blob := range response.Blobs {
+				coll := &flow.Collection{}
+				_ = msgpack.Unmarshal(blob, &coll)
+				returnedEntities = append(returnedEntities, coll)
+			}
+			// The request was [coll1, coll2, coll3, coll4, coll5], truncated to first 3
+			assert.ElementsMatch(t, returnedEntities, []flow.Entity{&coll1, &coll2, &coll3})
+		},
+	).Return(nil)
+
+	me := mockmodule.NewLocal(t)
+	me.On("NodeID").Return(unittest.IdentifierFixture())
+	requestQueue := queue.NewHeroStore(10, unittest.Logger(), metrics.NewNoopCollector())
+
+	e, err := provider.New(
+		unittest.Logger(),
+		metrics.NewNoopCollector(),
+		net,
+		me,
+		state,
+		requestQueue,
+		provider.DefaultRequestProviderWorkers,
+		channels.TestNetworkChannel,
+		selector,
+		retrieve,
+		provider.WithMaxEntityIDs(maxEntityIDs))
+	require.NoError(t, err)
+
+	// Request 5 entities, but only 3 should be returned
+	request := &flow.EntityRequest{
+		Nonce:     rand.Uint64(),
+		EntityIDs: []flow.Identifier{coll1.ID(), coll2.ID(), coll3.ID(), coll4.ID(), coll5.ID()},
+	}
+
+	e.Start(ctx)
+	unittest.RequireCloseBefore(t, e.Ready(), 100*time.Millisecond, "could not start engine")
+	err = e.Process(channels.TestNetworkChannel, originID, request)
+	require.NoError(t, err, "should not error when truncating excessive IDs")
+	unittest.RequireCloseBefore(t, e.Done(), 100*time.Millisecond, "could not stop engine")
+}
+
+// TestOnEntityRequestResponseByteBudget verifies that the response byte budget is enforced.
+// The provider should stop adding entities once the cumulative encoded size exceeds the budget,
+// preventing unbounded serialization work.
+func TestOnEntityRequestResponseByteBudget(t *testing.T) {
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := irrecoverable.NewMockSignalerContext(t, cancelCtx)
+
+	entities := make(map[flow.Identifier]flow.Entity)
+	identities := unittest.IdentityListFixture(8)
+	selector := filter.HasNodeID[flow.Identity](identities.NodeIDs()...)
+	originID := identities[0].NodeID
+
+	// Create collections with varying sizes
+	coll1 := unittest.CollectionFixture(1)
+	coll2 := unittest.CollectionFixture(2)
+	coll3 := unittest.CollectionFixture(3)
+
+	entities[coll1.ID()] = coll1
+	entities[coll2.ID()] = coll2
+	entities[coll3.ID()] = coll3
+
+	// Calculate the encoded size of the first collection to set a budget that allows
+	// only 1-2 collections
+	blob1, err := msgpack.Marshal(coll1)
+	require.NoError(t, err)
+	blob2, err := msgpack.Marshal(coll2)
+	require.NoError(t, err)
+
+	// Set budget to allow first two collections but not the third
+	maxResponseByteSize := len(blob1) + len(blob2) + 10 // small buffer, but not enough for coll3
+
+	retrieve := func(entityID flow.Identifier) (flow.Entity, error) {
+		entity, ok := entities[entityID]
+		if !ok {
+			return nil, storage.ErrNotFound
+		}
+		return entity, nil
+	}
+
+	final := protocol.NewSnapshot(t)
+	final.On("Identities", mock.Anything).Return(
+		func(selector flow.IdentityFilter[flow.Identity]) flow.IdentityList {
+			return identities.Filter(selector)
+		},
+		nil,
+	)
+
+	state := protocol.NewState(t)
+	state.On("Final").Return(final, nil)
+
+	net := mocknetwork.NewEngineRegistry(t)
+	con := mocknetwork.NewConduit(t)
+	net.On("Register", mock.Anything, mock.Anything).Return(con, nil)
+	con.On("Unicast", mock.Anything, mock.Anything).Run(
+		func(args mock.Arguments) {
+			defer cancel()
+
+			response := args.Get(0).(*messages.EntityResponse)
+			nodeID := args.Get(1).(flow.Identifier)
+			assert.Equal(t, nodeID, originID)
+
+			// Should have at most 2 entities due to byte budget
+			assert.LessOrEqual(t, len(response.Blobs), 2, "response should not exceed byte budget")
+
+			// Calculate total response size
+			totalSize := 0
+			for _, blob := range response.Blobs {
+				totalSize += len(blob)
+			}
+			assert.LessOrEqual(t, totalSize, maxResponseByteSize, "total response size should not exceed budget")
+		},
+	).Return(nil)
+
+	me := mockmodule.NewLocal(t)
+	me.On("NodeID").Return(unittest.IdentifierFixture())
+	requestQueue := queue.NewHeroStore(10, unittest.Logger(), metrics.NewNoopCollector())
+
+	e, err := provider.New(
+		unittest.Logger(),
+		metrics.NewNoopCollector(),
+		net,
+		me,
+		state,
+		requestQueue,
+		provider.DefaultRequestProviderWorkers,
+		channels.TestNetworkChannel,
+		selector,
+		retrieve,
+		provider.WithMaxResponseByteSize(maxResponseByteSize))
+	require.NoError(t, err)
+
+	// Request all 3 entities, but byte budget should limit response
+	request := &flow.EntityRequest{
+		Nonce:     rand.Uint64(),
+		EntityIDs: []flow.Identifier{coll1.ID(), coll2.ID(), coll3.ID()},
+	}
+
+	e.Start(ctx)
+	unittest.RequireCloseBefore(t, e.Ready(), 100*time.Millisecond, "could not start engine")
+	err = e.Process(channels.TestNetworkChannel, originID, request)
+	require.NoError(t, err, "should not error when byte budget is exceeded")
+	unittest.RequireCloseBefore(t, e.Done(), 100*time.Millisecond, "could not stop engine")
+}

--- a/network/netconf/config.go
+++ b/network/netconf/config.go
@@ -33,6 +33,10 @@ type Config struct {
 	DNSCacheTTL time.Duration `validate:"gt=0s" mapstructure:"dns-cache-ttl"`
 	// DisallowListNotificationCacheSize size of the queue for notifications about new peers in the disallow list.
 	DisallowListNotificationCacheSize uint32 `validate:"gt=0" mapstructure:"disallow-list-notification-cache-size"`
+	// MessageQueueSize is the maximum number of messages that can be buffered in the inbound message queue.
+	// This limit prevents unbounded memory growth from message flooding attacks.
+	// If set to 0, a default value will be used.
+	MessageQueueSize uint32 `mapstructure:"message-queue-size"`
 }
 
 // AlspConfig is the config for the Application Layer Spam Prevention (ALSP) protocol.

--- a/network/netconf/flags.go
+++ b/network/netconf/flags.go
@@ -19,6 +19,7 @@ const (
 	peerUpdateInterval                = "peerupdate-interval"
 	dnsCacheTTL                       = "dns-cache-ttl"
 	disallowListNotificationCacheSize = "disallow-list-notification-cache-size"
+	messageQueueSize                  = "message-queue-size"
 	// resource manager config
 	rootResourceManagerPrefix  = "libp2p-resource-manager"
 	memoryLimitRatioPrefix     = "memory-limit-ratio"
@@ -51,6 +52,7 @@ func AllFlagNames() []string {
 		preferredUnicastsProtocols,
 		receivedMessageCacheSize,
 		peerUpdateInterval,
+		messageQueueSize,
 		BuildFlagName(unicastKey, MessageTimeoutKey),
 		BuildFlagName(unicastKey, unicastManagerKey, createStreamBackoffDelayKey),
 		BuildFlagName(unicastKey, unicastManagerKey, streamZeroRetryResetThresholdKey),
@@ -235,6 +237,10 @@ func InitializeNetworkFlags(flags *pflag.FlagSet, config *Config) {
 		disallowListNotificationCacheSize,
 		config.DisallowListNotificationCacheSize,
 		"cache size for notification events from disallow list")
+	flags.Uint32(
+		messageQueueSize,
+		config.MessageQueueSize,
+		"maximum number of messages in the inbound message queue (0 = use default)")
 	flags.Duration(peerUpdateInterval, config.PeerUpdateInterval, "how often to refresh the peer connections for the node")
 	flags.Duration(BuildFlagName(unicastKey, MessageTimeoutKey), config.Unicast.MessageTimeout, "how long a unicast transmission can take to complete")
 	flags.Duration(BuildFlagName(unicastKey, unicastManagerKey, createStreamBackoffDelayKey), config.Unicast.UnicastManager.CreateStreamBackoffDelay,

--- a/network/queue/messageQueue.go
+++ b/network/queue/messageQueue.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"container/heap"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -10,24 +11,37 @@ import (
 	"github.com/onflow/flow-go/module"
 )
 
+// ErrQueueFull is returned when attempting to insert a message into a full queue.
+var ErrQueueFull = errors.New("message queue is full")
+
 type Priority int
 
 const LowPriority = Priority(1)
 const MediumPriority = Priority(5)
 const HighPriority = Priority(10)
 
+// DefaultMaxSize is the default maximum number of messages that can be queued.
+// This limit prevents unbounded memory growth from message flooding attacks.
+const DefaultMaxSize = 100_000
+
 // MessagePriorityFunc - the callback function to derive priority of a message
 type MessagePriorityFunc func(message any) (Priority, error)
 
-// MessageQueue is the heap based priority queue implementation of the MessageQueue implementation
+// MessageQueue is the heap based priority queue implementation of the MessageQueue implementation.
+// It enforces a maximum size limit to prevent unbounded memory growth from message flooding attacks.
 type MessageQueue struct {
 	pq           *priorityQueue
 	cond         *sync.Cond
 	priorityFunc MessagePriorityFunc
 	ctx          context.Context
 	metrics      module.NetworkInboundQueueMetrics
+	maxSize      int
 }
 
+// Insert adds a message to the queue.
+//
+// Expected error returns during normal operation:
+//   - [ErrQueueFull]: when the queue has reached its maximum capacity
 func (mq *MessageQueue) Insert(message any) error {
 
 	if err := mq.ctx.Err(); err != nil {
@@ -49,6 +63,12 @@ func (mq *MessageQueue) Insert(message any) error {
 
 	// lock the underlying mutex
 	mq.cond.L.Lock()
+
+	// check if queue is at capacity
+	if mq.pq.Len() >= mq.maxSize {
+		mq.cond.L.Unlock()
+		return fmt.Errorf("queue at capacity (%d messages): %w", mq.maxSize, ErrQueueFull)
+	}
 
 	// push message to the underlying priority queue
 	heap.Push(mq.pq, item)
@@ -92,7 +112,12 @@ func (mq *MessageQueue) Len() int {
 	return mq.pq.Len()
 }
 
-func NewMessageQueue(ctx context.Context, priorityFunc MessagePriorityFunc, metrics module.NetworkInboundQueueMetrics) *MessageQueue {
+// NewMessageQueue creates a new bounded message queue with the specified maximum size.
+// If maxSize is 0 or negative, DefaultMaxSize is used.
+func NewMessageQueue(ctx context.Context, priorityFunc MessagePriorityFunc, metrics module.NetworkInboundQueueMetrics, maxSize int) *MessageQueue {
+	if maxSize <= 0 {
+		maxSize = DefaultMaxSize
+	}
 	var items = make([]*item, 0)
 	pq := priorityQueue(items)
 	mq := &MessageQueue{
@@ -100,6 +125,7 @@ func NewMessageQueue(ctx context.Context, priorityFunc MessagePriorityFunc, metr
 		priorityFunc: priorityFunc,
 		ctx:          ctx,
 		metrics:      metrics,
+		maxSize:      maxSize,
 	}
 	m := sync.Mutex{}
 	mq.cond = sync.NewCond(&m)

--- a/network/queue/messageQueue_test.go
+++ b/network/queue/messageQueue_test.go
@@ -49,7 +49,7 @@ func TestConcurrentQueueAccess(t *testing.T) {
 	close(msgChan)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	mq := queue.NewMessageQueue(ctx, priorityFunc, metrics.NewNoopCollector())
+	mq := queue.NewMessageQueue(ctx, priorityFunc, metrics.NewNoopCollector(), 0)
 
 	writeWg := sync.WaitGroup{}
 	write := func() {
@@ -96,7 +96,7 @@ func TestConcurrentQueueAccess(t *testing.T) {
 // TestQueueShutdown tests that Remove unblocks when the context is shutdown
 func TestQueueShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	mq := queue.NewMessageQueue(ctx, fixedPriority, metrics.NewNoopCollector())
+	mq := queue.NewMessageQueue(ctx, fixedPriority, metrics.NewNoopCollector(), 0)
 	ch := make(chan struct{})
 
 	go func() {
@@ -131,7 +131,7 @@ func testQueue(t *testing.T, messages map[string]queue.Priority) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	// create the queue
-	mq := queue.NewMessageQueue(ctx, priorityFunc, metrics.NewNoopCollector())
+	mq := queue.NewMessageQueue(ctx, priorityFunc, metrics.NewNoopCollector(), 0)
 
 	// insert all elements in the queue
 	for msg, p := range messages {
@@ -167,7 +167,7 @@ func BenchmarkPush(b *testing.B) {
 	b.StopTimer()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var mq = queue.NewMessageQueue(ctx, randomPriority, metrics.NewNoopCollector())
+	var mq = queue.NewMessageQueue(ctx, randomPriority, metrics.NewNoopCollector(), 0)
 	for i := 0; i < b.N; i++ {
 		err := mq.Insert("test")
 		if err != nil {
@@ -187,7 +187,7 @@ func BenchmarkPop(b *testing.B) {
 	b.StopTimer()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var mq = queue.NewMessageQueue(ctx, randomPriority, metrics.NewNoopCollector())
+	var mq = queue.NewMessageQueue(ctx, randomPriority, metrics.NewNoopCollector(), 0)
 	for i := 0; i < b.N; i++ {
 		err := mq.Insert("test")
 		if err != nil {
@@ -220,6 +220,39 @@ func randomPriority(_ any) (queue.Priority, error) {
 
 	p := rand.Intn(int(queue.HighPriority-queue.LowPriority+1)) + int(queue.LowPriority)
 	return queue.Priority(p), nil
+}
+
+// TestQueueFull tests that inserting into a full queue returns ErrQueueFull
+func TestQueueFull(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	maxSize := 10
+	mq := queue.NewMessageQueue(ctx, fixedPriority, metrics.NewNoopCollector(), maxSize)
+
+	// fill the queue to capacity
+	for i := 0; i < maxSize; i++ {
+		err := mq.Insert("message")
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, maxSize, mq.Len())
+
+	// next insert should fail with ErrQueueFull
+	err := mq.Insert("overflow")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, queue.ErrQueueFull)
+
+	// queue length should still be at maxSize
+	assert.Equal(t, maxSize, mq.Len())
+
+	// removing one element should allow inserting again
+	_ = mq.Remove()
+	assert.Equal(t, maxSize-1, mq.Len())
+
+	err = mq.Insert("new message")
+	assert.NoError(t, err)
+	assert.Equal(t, maxSize, mq.Len())
 }
 
 func fixedPriority(_ any) (queue.Priority, error) {

--- a/network/queue/queueWorker_test.go
+++ b/network/queue/queueWorker_test.go
@@ -40,7 +40,7 @@ func testWorkers(t *testing.T, maxPriority int, messageCnt int, workerCnt int) {
 		assert.True(t, ok)
 		return queue.Priority(i), nil
 	},
-		metrics.NewNoopCollector())
+		metrics.NewNoopCollector(), 0)
 
 	var l sync.Mutex                                // protect comparisons with expectedPriority
 	messagesPerPriority := messageCnt / maxPriority // messages per priority

--- a/network/underlay/network.go
+++ b/network/underlay/network.go
@@ -455,7 +455,7 @@ func (n *Network) processRegisterBlobServiceRequests(parent irrecoverable.Signal
 
 // createInboundMessageQueue creates the queue that will be used to process incoming messages.
 func (n *Network) createInboundMessageQueue(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
-	n.queue = queue.NewMessageQueue(ctx, queue.GetEventPriority, n.metrics)
+	n.queue = queue.NewMessageQueue(ctx, queue.GetEventPriority, n.metrics, queue.DefaultMaxSize)
 	queue.CreateQueueWorkers(ctx, queue.DefaultNumWorkers, n.queue, n.queueSubmitFunc)
 
 	ready()
@@ -1328,6 +1328,11 @@ func (n *Network) processMessage(scope network.IncomingMessageScope) {
 	// if validation passed, send the message to the overlay
 	err := n.Receive(scope)
 	if err != nil {
+		if errors.Is(err, queue.ErrQueueFull) {
+			// queue full is expected during message floods
+			logger.Warn().Msg("message dropped: queue full")
+			return
+		}
 		n.logger.Error().Err(err).Msg("could not deliver payload")
 	}
 }

--- a/network/underlay/network.go
+++ b/network/underlay/network.go
@@ -118,6 +118,7 @@ type Network struct {
 	authorizedSenderValidator   *validator.AuthorizedSenderValidator
 	preferredUnicasts           []protocols.ProtocolName
 	unicastStreamAuthorizer     func(sender, receiver flow.Role) bool
+	messageQueueSize            int
 }
 
 var _ network.EngineRegistry = &Network{}
@@ -171,6 +172,9 @@ type NetworkConfig struct {
 	// stream to a receiver role, before any message data is read from the stream. If nil,
 	// defaults to message.IsAuthorizedUnicastSenderRole.
 	UnicastStreamAuthorizer func(sender, receiver flow.Role) bool
+	// MessageQueueSize is the maximum number of messages that can be buffered in the inbound message queue.
+	// If set to 0, queue.DefaultMaxSize will be used.
+	MessageQueueSize int
 }
 
 // Validate validates the configuration, and sets default values for any missing fields.
@@ -305,6 +309,7 @@ func NewNetwork(param *NetworkConfig, opts ...NetworkOption) (*Network, error) {
 		unicastRateLimiters:         ratelimit.NoopRateLimiters(),
 		validators:                  DefaultValidators(param.Logger.With().Str("component", "network-validators").Logger(), param.Me.NodeID()),
 		unicastStreamAuthorizer:     param.UnicastStreamAuthorizer,
+		messageQueueSize:            param.MessageQueueSize,
 	}
 
 	n.subscriptionManager = subscription.NewChannelSubscriptionManager(n)
@@ -455,7 +460,7 @@ func (n *Network) processRegisterBlobServiceRequests(parent irrecoverable.Signal
 
 // createInboundMessageQueue creates the queue that will be used to process incoming messages.
 func (n *Network) createInboundMessageQueue(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
-	n.queue = queue.NewMessageQueue(ctx, queue.GetEventPriority, n.metrics, queue.DefaultMaxSize)
+	n.queue = queue.NewMessageQueue(ctx, queue.GetEventPriority, n.metrics, n.messageQueueSize)
 	queue.CreateQueueWorkers(ctx, queue.DefaultNumWorkers, n.queue, n.queueSubmitFunc)
 
 	ready()


### PR DESCRIPTION
This PR address several security vulnerabilities in Flow's networking and API layers:

### Unicast Stream Pre-Authorization

Files: network/message/authorization.go, network/underlay/network.go

Adds coarse-grained authorization based on sender/receiver role before reading any data from unicast streams.
Previously, authorization only occurred after fully receiving and parsing messages, allowing unauthorized peers to tie
up resources.


### Event Index Overflow Protection

Files: engine/access/rpc/backend/events/events.go

Fixes an integer overflow vulnerability in the events backend that could be triggered by malicious input.


### Bounded Message Queue (OOM Prevention)

Files: network/queue/messageQueue.go, network/netconf/config.go, config/default-config.yml

Adds a configurable size limit to the network message queue. Previously, the queue was unbounded, allowing an attacker
to flood messages faster than workers could process them, causing memory exhaustion. A staked access node
could crash consensus nodes in ~5 minutes.


### EntityRequest Amplification Prevention

Files: engine/common/provider/engine.go

Adds DefaultMaxEntityIDs (100) limit and response-size budgeting to the provider engine. Previously, a malicious access
 node could send a tiny request with many collection IDs, forcing collection nodes to retrieve and serialize gigabytes
of data before the response-size limit was checked—a severe amplification attack vector.


### Subscription Cleanup (Memory Leak Fix)

Files: engine/access/subscription/streamer.go, engine/broadcaster.go

Adds Unsubscribe method and ensures Streamer.Stream() cleans up its notifier on exit via defer. Prevents memory leaks
from accumulating stale subscriptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable inbound message queue capacity (default: 100,000 messages)
  * Per-request entity limits and response size budgets for provider queries

* **Bug Fixes**
  * Fixed potential overflow in block height range validation
  * Improved subscription unsubscribe handling when clients disconnect
  * Message delivery explicitly handles full queue conditions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/onflow/flow-go/pull/8557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->