### PR TITLE
extend cluster topic metrics cleanup to cover all per-topic metric families

### DIFF
--- a/module/metrics/alsp.go
+++ b/module/metrics/alsp.go
@@ -35,6 +35,12 @@ func NewAlspMetrics() *AlspMetrics {
 	return alsp
 }
 
+// OnClusterTopicMetricsCleanup removes all misbehavior counter label values associated with the given
+// cluster topic to prevent unbounded metric cardinality growth during epoch transitions.
+func (a *AlspMetrics) OnClusterTopicMetricsCleanup(topic string) {
+	a.reportedMisbehaviorCount.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
+}
+
 // OnMisbehaviorReported is called when a misbehavior is reported by the application layer to ALSP.
 // An engine detecting a spamming-related misbehavior reports it to the ALSP module. It increases
 // the counter vector of reported misbehavior.

--- a/module/metrics/gossipsub_score.go
+++ b/module/metrics/gossipsub_score.go
@@ -161,3 +161,13 @@ func (g *GossipSubScoreMetrics) OnInvalidMessageDeliveredUpdated(topic channels.
 func (g *GossipSubScoreMetrics) SetWarningStateCount(u uint) {
 	g.warningStateGauge.Set(float64(u))
 }
+
+// OnClusterTopicMetricsCleanup removes all per-topic scoring metric label values associated with
+// the given cluster topic. Call this when the local node leaves a cluster topic to prevent
+// unbounded metric cardinality growth across epoch transitions.
+func (g *GossipSubScoreMetrics) OnClusterTopicMetricsCleanup(topic string) {
+	g.timeInMesh.DeleteLabelValues(topic)
+	g.meshMessageDelivery.DeleteLabelValues(topic)
+	g.firstMessageDelivery.DeleteLabelValues(topic)
+	g.invalidMessageDelivery.DeleteLabelValues(topic)
+}

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -277,19 +277,32 @@ func (nc *NetworkCollector) DuplicateInboundMessagesDropped(topic, protocol, mes
 // OnClusterTopicMetricsCleanup removes all metric label values associated with the given cluster topic.
 // This prevents unbounded metric cardinality growth during epoch transitions when collection nodes
 // join new clusters and leave old ones. Only call this for cluster topics (sync-cluster-*, consensus-cluster-*).
-// This method overrides the embedded LocalGossipSubRouterMetrics.OnClusterTopicMetricsCleanup to also
-// clean up inbound/outbound message size metrics and iHave message ID metrics.
 func (nc *NetworkCollector) OnClusterTopicMetricsCleanup(topic string) {
-	// Clean up LocalGossipSubRouterMetrics (localMeshSize, peerGraftTopicCount, peerPruneTopicCount)
+	// LocalGossipSubRouterMetrics: localMeshSize, peerGraftTopicCount, peerPruneTopicCount
 	nc.LocalGossipSubRouterMetrics.OnClusterTopicMetricsCleanup(topic)
 
-	// Clean up GossipSubRpcValidationInspectorMetrics (receivedIHaveMsgIDsHistogram)
+	// GossipSubRpcValidationInspectorMetrics: receivedIHaveMsgIDsHistogram
 	nc.GossipSubRpcValidationInspectorMetrics.OnClusterTopicMetricsCleanup(topic)
 
-	// Clean up inbound/outbound message size metrics using partial match on topic
+	// GossipSubScoreMetrics: timeInMesh, meshMessageDelivery, firstMessageDelivery, invalidMessageDelivery
+	nc.GossipSubScoreMetrics.OnClusterTopicMetricsCleanup(topic)
+
+	// inbound/outbound message size and duplicate drop counters (multi-label: channel + protocol + message)
 	nc.inboundMessageSize.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
 	nc.outboundMessageSize.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
 	nc.duplicateMessagesDropped.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
+
+	// message processing gauges and inbound process time counter (single label: channel)
+	nc.numMessagesProcessing.DeleteLabelValues(topic)
+	nc.numDirectMessagesSending.DeleteLabelValues(topic)
+	nc.inboundProcessTime.DeleteLabelValues(topic)
+
+	// security metrics (multi-label: role + message + channel + reason)
+	nc.unAuthorizedMessagesCount.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
+	nc.rateLimitedUnicastMessagesCount.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
+
+	// ALSP misbehavior counter (multi-label: channel + misbehavior)
+	nc.AlspMetrics.reportedMisbehaviorCount.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
 }
 
 func (nc *NetworkCollector) MessageAdded(priority int) {

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -302,7 +302,7 @@ func (nc *NetworkCollector) OnClusterTopicMetricsCleanup(topic string) {
 	nc.rateLimitedUnicastMessagesCount.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
 
 	// ALSP misbehavior counter (multi-label: channel + misbehavior)
-	nc.AlspMetrics.reportedMisbehaviorCount.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
+	nc.AlspMetrics.OnClusterTopicMetricsCleanup(topic)
 }
 
 func (nc *NetworkCollector) MessageAdded(priority int) {


### PR DESCRIPTION
Extends #8562 to address remaining per-topic metrics that also accumulate stale cluster-ID-based label series across epoch transitions.

## Problem

PR #8562 introduced `OnClusterTopicMetricsCleanup` but only covered a subset of the per-topic metrics tracked by `NetworkCollector`. The following metric families were missed and continue to accumulate stale time series when a collection node transitions to a new cluster each epoch:

| Metric | Type | Missed in #8562 |
|--------|------|-----------------|
| `gossipsub_time_in_mesh_quantum_count` | HistogramVec | `GossipSubScoreMetrics` |
| `gossipsub_mesh_message_delivery` | HistogramVec | `GossipSubScoreMetrics` |
| `gossipsub_first_message_delivery_count` | HistogramVec | `GossipSubScoreMetrics` |
| `gossipsub_invalid_message_delivery_count` | HistogramVec | `GossipSubScoreMetrics` |
| `current_messages_processing` | GaugeVec | `NetworkCollector` |
| `direct_messages_in_progress` | GaugeVec | `NetworkCollector` |
| `engine_message_processing_time_seconds` | CounterVec | `NetworkCollector` |
| `unauthorized_messages_count` | CounterVec | `NetworkCollector` |
| `rate_limited_unicast_messages_count` | CounterVec | `NetworkCollector` |
| `reported_misbehavior_total` | CounterVec | `AlspMetrics` |

## Changes

- `gossipsub_score.go`: adds `OnClusterTopicMetricsCleanup` to `GossipSubScoreMetrics` covering the 4 per-topic scoring histograms
- `network.go`: extends `NetworkCollector.OnClusterTopicMetricsCleanup` to also delegate to `GossipSubScoreMetrics` and delete the remaining per-channel metrics on `NetworkCollector` and `AlspMetrics`

No new interfaces or mock changes needed — `GossipSubScoreMetrics.OnClusterTopicMetricsCleanup` is called internally by `NetworkCollector` and is not part of any exported interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)