### PR TITLE
normalize cluster topic labels in metrics to prevent unbounded cardin…

### DIFF
--- a/module/metrics/alsp.go
+++ b/module/metrics/alsp.go
@@ -4,6 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/network/channels"
 )
 
 // AlspMetrics is a struct that contains all the metrics related to the ALSP module.
@@ -35,21 +36,16 @@ func NewAlspMetrics() *AlspMetrics {
 	return alsp
 }
 
-// OnClusterTopicMetricsCleanup removes all misbehavior counter label values associated with the given
-// cluster topic to prevent unbounded metric cardinality growth during epoch transitions.
-func (a *AlspMetrics) OnClusterTopicMetricsCleanup(topic string) {
-	a.reportedMisbehaviorCount.DeletePartialMatch(prometheus.Labels{LabelChannel: topic})
-}
-
 // OnMisbehaviorReported is called when a misbehavior is reported by the application layer to ALSP.
 // An engine detecting a spamming-related misbehavior reports it to the ALSP module. It increases
 // the counter vector of reported misbehavior.
+// Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
 // Args:
 // - channel: the channel on which the misbehavior was reported
 // - misbehaviorType: the type of misbehavior reported
 func (a *AlspMetrics) OnMisbehaviorReported(channel string, misbehaviorType string) {
 	a.reportedMisbehaviorCount.With(prometheus.Labels{
-		LabelChannel:     channel,
+		LabelChannel:     channels.NormalizeTopicForMetrics(channel),
 		LabelMisbehavior: misbehaviorType,
 	}).Inc()
 }

--- a/module/metrics/gossipsub_score.go
+++ b/module/metrics/gossipsub_score.go
@@ -143,31 +143,21 @@ func (g *GossipSubScoreMetrics) OnBehaviourPenaltyUpdated(penalty float64) {
 }
 
 func (g *GossipSubScoreMetrics) OnTimeInMeshUpdated(topic channels.Topic, duration time.Duration) {
-	g.timeInMesh.WithLabelValues(string(topic)).Observe(duration.Seconds())
+	g.timeInMesh.WithLabelValues(channels.NormalizeTopicForMetrics(string(topic))).Observe(duration.Seconds())
 }
 
 func (g *GossipSubScoreMetrics) OnFirstMessageDeliveredUpdated(topic channels.Topic, f float64) {
-	g.firstMessageDelivery.WithLabelValues(string(topic)).Observe(f)
+	g.firstMessageDelivery.WithLabelValues(channels.NormalizeTopicForMetrics(string(topic))).Observe(f)
 }
 
 func (g *GossipSubScoreMetrics) OnMeshMessageDeliveredUpdated(topic channels.Topic, f float64) {
-	g.meshMessageDelivery.WithLabelValues(string(topic)).Observe(f)
+	g.meshMessageDelivery.WithLabelValues(channels.NormalizeTopicForMetrics(string(topic))).Observe(f)
 }
 
 func (g *GossipSubScoreMetrics) OnInvalidMessageDeliveredUpdated(topic channels.Topic, f float64) {
-	g.invalidMessageDelivery.WithLabelValues(string(topic)).Observe(f)
+	g.invalidMessageDelivery.WithLabelValues(channels.NormalizeTopicForMetrics(string(topic))).Observe(f)
 }
 
 func (g *GossipSubScoreMetrics) SetWarningStateCount(u uint) {
 	g.warningStateGauge.Set(float64(u))
-}
-
-// OnClusterTopicMetricsCleanup removes all per-topic scoring metric label values associated with
-// the given cluster topic. Call this when the local node leaves a cluster topic to prevent
-// unbounded metric cardinality growth across epoch transitions.
-func (g *GossipSubScoreMetrics) OnClusterTopicMetricsCleanup(topic string) {
-	g.timeInMesh.DeleteLabelValues(topic)
-	g.meshMessageDelivery.DeleteLabelValues(topic)
-	g.firstMessageDelivery.DeleteLabelValues(topic)
-	g.invalidMessageDelivery.DeleteLabelValues(topic)
 }

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -291,18 +291,21 @@ func (nc *NetworkCollector) QueueDuration(duration time.Duration, priority int) 
 }
 
 // MessageProcessingStarted increments the metric tracking the number of messages being processed by the node.
+// Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
 func (nc *NetworkCollector) MessageProcessingStarted(topic string) {
-	nc.numMessagesProcessing.WithLabelValues(topic).Inc()
+	nc.numMessagesProcessing.WithLabelValues(channels.NormalizeTopicForMetrics(topic)).Inc()
 }
 
 // UnicastMessageSendingStarted increments the metric tracking the number of unicast messages sent by the node.
+// Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
 func (nc *NetworkCollector) UnicastMessageSendingStarted(topic string) {
-	nc.numDirectMessagesSending.WithLabelValues(topic).Inc()
+	nc.numDirectMessagesSending.WithLabelValues(channels.NormalizeTopicForMetrics(topic)).Inc()
 }
 
 // UnicastMessageSendingCompleted decrements the metric tracking the number of unicast messages sent by the node.
+// Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
 func (nc *NetworkCollector) UnicastMessageSendingCompleted(topic string) {
-	nc.numDirectMessagesSending.WithLabelValues(topic).Dec()
+	nc.numDirectMessagesSending.WithLabelValues(channels.NormalizeTopicForMetrics(topic)).Dec()
 }
 
 func (nc *NetworkCollector) RoutingTablePeerAdded() {
@@ -315,9 +318,11 @@ func (nc *NetworkCollector) RoutingTablePeerRemoved() {
 
 // MessageProcessingFinished tracks the time spent by the node to process a message and decrements the metric tracking
 // the number of messages being processed by the node.
+// Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
 func (nc *NetworkCollector) MessageProcessingFinished(topic string, duration time.Duration) {
-	nc.numMessagesProcessing.WithLabelValues(topic).Dec()
-	nc.inboundProcessTime.WithLabelValues(topic).Add(duration.Seconds())
+	normalizedTopic := channels.NormalizeTopicForMetrics(topic)
+	nc.numMessagesProcessing.WithLabelValues(normalizedTopic).Dec()
+	nc.inboundProcessTime.WithLabelValues(normalizedTopic).Add(duration.Seconds())
 }
 
 // OutboundConnections updates the metric tracking the number of outbound connections of this node
@@ -357,11 +362,13 @@ func (nc *NetworkCollector) OnDNSLookupRequestDropped() {
 }
 
 // OnUnauthorizedMessage tracks the number of unauthorized messages seen on the network.
+// Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
 func (nc *NetworkCollector) OnUnauthorizedMessage(role, msgType, topic, offense string) {
-	nc.unAuthorizedMessagesCount.WithLabelValues(role, msgType, topic, offense).Inc()
+	nc.unAuthorizedMessagesCount.WithLabelValues(role, msgType, channels.NormalizeTopicForMetrics(topic), offense).Inc()
 }
 
 // OnRateLimitedPeer tracks the number of rate limited messages seen on the network.
+// Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
 func (nc *NetworkCollector) OnRateLimitedPeer(peerID peer.ID, role, msgType, topic, reason string) {
 	nc.logger.Warn().
 		Str("peer_id", logging2.PeerId(peerID)).
@@ -371,7 +378,7 @@ func (nc *NetworkCollector) OnRateLimitedPeer(peerID peer.ID, role, msgType, top
 		Str("reason", reason).
 		Bool(logging.KeySuspicious, true).
 		Msg("unicast peer rate limited")
-	nc.rateLimitedUnicastMessagesCount.WithLabelValues(role, msgType, topic, reason).Inc()
+	nc.rateLimitedUnicastMessagesCount.WithLabelValues(role, msgType, channels.NormalizeTopicForMetrics(topic), reason).Inc()
 }
 
 // OnViolationReportSkipped tracks the number of slashing violations consumer violations that were not


### PR DESCRIPTION
local_mesh_size{topic="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ local_mesh_size{topic="consensus-cluster"}

graft_topic_total{topic="sync-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ graft_topic_total{topic="sync-cluster"}

prune_topic_total{topic="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ prune_topic_total{topic="consensus-cluster"}

received_ihave_message_ids{channel="sync-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ received_ihave_message_ids{channel="sync-cluster"}

time_in_mesh_quantum_count{channel="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ time_in_mesh_quantum_count{channel="consensus-cluster"}

mesh_message_delivery{channel="sync-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ mesh_message_delivery{channel="sync-cluster"}

first_message_delivery_count{channel="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ first_message_delivery_count{channel="consensus-cluster"}

invalid_message_delivery_count{channel="sync-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ invalid_message_delivery_count{channel="sync-cluster"}

inbound_message_size_bytes{channel="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ inbound_message_size_bytes{channel="consensus-cluster"}

outbound_message_size_bytes{channel="sync-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ outbound_message_size_bytes{channel="sync-cluster"}

duplicate_messages_dropped{channel="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ duplicate_messages_dropped{channel="consensus-cluster"}

current_messages_processing{topic="sync-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ current_messages_processing{topic="sync-cluster"}

engine_message_processing_time_seconds{topic="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ engine_message_processing_time_seconds{topic="consensus-cluster"}

direct_messages_in_progress{topic="sync-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ direct_messages_in_progress{topic="sync-cluster"}

unauthorized_messages_count{topic="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ unauthorized_messages_count{topic="consensus-cluster"}

rate_limited_unicast_messages_count{topic="sync-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ rate_limited_unicast_messages_count{topic="sync-cluster"}

reported_misbehavior_total{channel="consensus-cluster-cluster-232-d9efe2a782b6967a8c0854f9c23c9d3e..."}
→ reported_misbehavior_total{channel="consensus-cluster"}
