### PR TITLE
[Storehouse] 002 - Payloadless forest

### DIFF
--- a/ledger/complete/payloadless/forest.go
+++ b/ledger/complete/payloadless/forest.go
@@ -1,16 +1,19 @@
-package mtrie
+package payloadless
 
 import (
 	"fmt"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/hash"
-	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 	"github.com/onflow/flow-go/module"
 )
 
-// Forest holds several in-memory tries. As Forest is a storage-abstraction layer,
+// Forest holds several in-memory payloadless tries. As Forest is a storage-abstraction layer,
 // we assume that all registers are addressed via paths of pre-defined uniform length.
+//
+// Unlike the full mtrie Forest, this variant stores only leaf hashes (HashLeaf(path, value))
+// per register and not the underlying payload values. Reads therefore return leaf hashes,
+// not values.
 //
 // Forest has a limit, the forestCapacity, on the number of tries it is able to store.
 // If more tries are added than the capacity, the Least Recently Used trie is
@@ -26,7 +29,7 @@ type Forest struct {
 	// needed trie in the forest might cause a fatal application logic error.
 	tries          *TrieCache
 	forestCapacity int
-	onTreeEvicted  func(tree *trie.MTrie)
+	onTreeEvicted  func(tree *MTrie)
 	metrics        module.LedgerMetrics
 }
 
@@ -36,7 +39,7 @@ type Forest struct {
 // If more tries are added than the capacity, the Least Recently Added trie is removed (evicted) from the Forest (FIFO queue).
 // Make sure you chose a sufficiently large forestCapacity, such that, when reaching the capacity, the
 // Least Recently Added trie will never be needed again.
-func NewForest(forestCapacity int, metrics module.LedgerMetrics, onTreeEvicted func(tree *trie.MTrie)) (*Forest, error) {
+func NewForest(forestCapacity int, metrics module.LedgerMetrics, onTreeEvicted func(tree *MTrie)) (*Forest, error) {
 	forest := &Forest{tries: NewTrieCache(uint(forestCapacity), onTreeEvicted),
 		forestCapacity: forestCapacity,
 		onTreeEvicted:  onTreeEvicted,
@@ -44,7 +47,7 @@ func NewForest(forestCapacity int, metrics module.LedgerMetrics, onTreeEvicted f
 	}
 
 	// add trie with no allocated registers
-	emptyTrie := trie.NewEmptyMTrie()
+	emptyTrie := NewEmptyMTrie()
 	err := forest.AddTrie(emptyTrie)
 	if err != nil {
 		return nil, fmt.Errorf("adding empty trie to forest failed: %w", err)
@@ -52,12 +55,14 @@ func NewForest(forestCapacity int, metrics module.LedgerMetrics, onTreeEvicted f
 	return forest, nil
 }
 
-// ValueSizes returns value sizes for a slice of paths and error (if any)
+// HasPaths returns, for each input path, whether the path has an allocated register
+// in the trie identified by `r.RootHash`. This replaces the full forest's ValueSizes
+// method since the payloadless trie does not store payload byte sizes.
 // TODO: can be optimized further if we don't care about changing the order of the input r.Paths
-func (f *Forest) ValueSizes(r *ledger.TrieRead) ([]int, error) {
+func (f *Forest) HasPaths(r *ledger.TrieRead) ([]bool, error) {
 
 	if len(r.Paths) == 0 {
-		return []int{}, nil
+		return []bool{}, nil
 	}
 
 	// lookup the trie by rootHash
@@ -69,7 +74,7 @@ func (f *Forest) ValueSizes(r *ledger.TrieRead) ([]int, error) {
 	// deduplicate paths:
 	// Generally, we expect the VM to deduplicate reads and writes. Hence, the following is a pre-caution.
 	// TODO: We could take out the following de-duplication logic
-	//       Which increases the cost for duplicates but reduces ValueSizes complexity without duplicates.
+	//       Which increases the cost for duplicates but reduces complexity without duplicates.
 	deduplicatedPaths := make([]ledger.Path, 0, len(r.Paths))
 	pathOrgIndex := make(map[ledger.Path][]int)
 	for i, path := range r.Paths {
@@ -82,43 +87,40 @@ func (f *Forest) ValueSizes(r *ledger.TrieRead) ([]int, error) {
 		pathOrgIndex[path] = append(indices, i)
 	}
 
-	sizes := trie.UnsafeValueSizes(deduplicatedPaths) // this sorts deduplicatedPaths IN-PLACE
+	leafHashes := trie.UnsafeRead(deduplicatedPaths) // this sorts deduplicatedPaths IN-PLACE
 
-	// reconstruct value sizes in the same key order that called the method
-	orderedValueSizes := make([]int, len(r.Paths))
-	totalValueSize := 0
+	// reconstruct existence in the same key order that called the method
+	exists := make([]bool, len(r.Paths))
 	for i, p := range deduplicatedPaths {
-		size := sizes[i]
-		indices := pathOrgIndex[p]
-		for _, j := range indices {
-			orderedValueSizes[j] = size
+		has := leafHashes[i] != nil
+		for _, j := range pathOrgIndex[p] {
+			exists[j] = has
 		}
-		totalValueSize += len(indices) * size
 	}
-	// TODO rename the metrics
-	f.metrics.ReadValuesSize(uint64(totalValueSize))
 
-	return orderedValueSizes, nil
+	return exists, nil
 }
 
-// ReadSingleValue reads value for a single path and returns value and error (if any)
-func (f *Forest) ReadSingleValue(r *ledger.TrieReadSingleValue) (ledger.Value, error) {
+// ReadSingleLeafHash reads the leaf hash for a single path. Returns nil if no
+// leaf exists at that path or the leaf represents an unallocated register.
+func (f *Forest) ReadSingleLeafHash(r *ledger.TrieReadSingleValue) (*hash.Hash, error) {
 	// lookup the trie by rootHash
 	trie, err := f.GetTrie(r.RootHash)
 	if err != nil {
 		return nil, err
 	}
 
-	payload := trie.ReadSinglePayload(r.Path)
-	return payload.Value().DeepCopy(), nil
+	return trie.ReadSingleLeafHash(r.Path), nil
 }
 
-// Read reads values for an slice of paths and returns values and error (if any)
+// ReadLeafHashes reads leaf hashes for a slice of paths and returns the leaf hashes
+// in the same order as the input. A nil entry indicates the path has no allocated
+// register in the trie.
 // TODO: can be optimized further if we don't care about changing the order of the input r.Paths
-func (f *Forest) Read(r *ledger.TrieRead) ([]ledger.Value, error) {
+func (f *Forest) ReadLeafHashes(r *ledger.TrieRead) ([]*hash.Hash, error) {
 
 	if len(r.Paths) == 0 {
-		return []ledger.Value{}, nil
+		return []*hash.Hash{}, nil
 	}
 
 	// lookup the trie by rootHash
@@ -127,10 +129,9 @@ func (f *Forest) Read(r *ledger.TrieRead) ([]ledger.Value, error) {
 		return nil, err
 	}
 
-	// call ReadSinglePayload if there is only one path
+	// call ReadSingleLeafHash if there is only one path
 	if len(r.Paths) == 1 {
-		payload := trie.ReadSinglePayload(r.Paths[0])
-		return []ledger.Value{payload.Value().DeepCopy()}, nil
+		return []*hash.Hash{trie.ReadSingleLeafHash(r.Paths[0])}, nil
 	}
 
 	// deduplicate keys:
@@ -149,30 +150,28 @@ func (f *Forest) Read(r *ledger.TrieRead) ([]ledger.Value, error) {
 		pathOrgIndex[path] = append(indices, i)
 	}
 
-	payloads := trie.UnsafeRead(deduplicatedPaths) // this sorts deduplicatedPaths IN-PLACE
+	leafHashes := trie.UnsafeRead(deduplicatedPaths) // this sorts deduplicatedPaths IN-PLACE
 
-	// reconstruct the payloads in the same key order that called the method
-	orderedValues := make([]ledger.Value, len(r.Paths))
-	totalPayloadSize := 0
+	// reconstruct the leaf hashes in the same key order that called the method
+	orderedLeafHashes := make([]*hash.Hash, len(r.Paths))
 	for i, p := range deduplicatedPaths {
-		payload := payloads[i]
-		indices := pathOrgIndex[p]
-		for _, j := range indices {
-			orderedValues[j] = payload.Value().DeepCopy()
+		lh := leafHashes[i]
+		for _, j := range pathOrgIndex[p] {
+			orderedLeafHashes[j] = lh
 		}
-		totalPayloadSize += len(indices) * payload.Size()
 	}
-	// TODO rename the metrics
-	f.metrics.ReadValuesSize(uint64(totalPayloadSize))
 
-	return orderedValues, nil
+	return orderedLeafHashes, nil
 }
 
-// Update creates a new trie by updating Values for registers in the parent trie,
+// Update creates a new trie by updating values for registers in the parent trie,
 // adds new trie to forest, and returns rootHash and error (if any).
 // In case there are multiple updates to the same register, Update will persist
 // the latest written value.
 // Note: Update adds new trie to forest, unlike NewTrie().
+//
+// The input `u.Payloads` are interpreted by extracting only the value bytes; the
+// payloadless trie does not store the payload key.
 func (f *Forest) Update(u *ledger.TrieUpdate) (ledger.RootHash, error) {
 	t, err := f.NewTrie(u)
 	if err != nil {
@@ -187,12 +186,14 @@ func (f *Forest) Update(u *ledger.TrieUpdate) (ledger.RootHash, error) {
 	return t.RootHash(), nil
 }
 
-// NewTrie creates a new trie by updating Values for registers in the parent trie,
+// NewTrie creates a new trie by updating values for registers in the parent trie,
 // and returns new trie and error (if any).
 // In case there are multiple updates to the same register, NewTrie will persist
 // the latest written value.
 // Note: NewTrie doesn't add new trie to forest, unlike Update().
-func (f *Forest) NewTrie(u *ledger.TrieUpdate) (*trie.MTrie, error) {
+//
+// Only the payload's value bytes are used; keys are discarded.
+func (f *Forest) NewTrie(u *ledger.TrieUpdate) (*MTrie, error) {
 
 	parentTrie, err := f.GetTrie(u.RootHash)
 	if err != nil {
@@ -206,40 +207,33 @@ func (f *Forest) NewTrie(u *ledger.TrieUpdate) (*trie.MTrie, error) {
 	// Deduplicate writes to the same register: we only retain the value of the last write
 	// Generally, we expect the VM to deduplicate reads and writes.
 	deduplicatedPaths := make([]ledger.Path, 0, len(u.Paths))
-	deduplicatedPayloads := make([]ledger.Payload, 0, len(u.Paths))
-	payloadMap := make(map[ledger.Path]int) // index into deduplicatedPaths, deduplicatedPayloads with register update
-	totalPayloadSize := 0
+	deduplicatedValues := make([][]byte, 0, len(u.Paths))
+	valueMap := make(map[ledger.Path]int) // index into deduplicatedPaths, deduplicatedValues with register update
 	for i, path := range u.Paths {
-		payload := u.Payloads[i]
+		value := []byte(u.Payloads[i].Value())
 		// check if we already have encountered an update for the respective register
-		if idx, ok := payloadMap[path]; ok {
-			oldPayload := deduplicatedPayloads[idx]
-			deduplicatedPayloads[idx] = *payload
-			totalPayloadSize += -oldPayload.Size() + payload.Size()
+		if idx, ok := valueMap[path]; ok {
+			deduplicatedValues[idx] = value
 		} else {
-			payloadMap[path] = len(deduplicatedPaths)
+			valueMap[path] = len(deduplicatedPaths)
 			deduplicatedPaths = append(deduplicatedPaths, path)
-			deduplicatedPayloads = append(deduplicatedPayloads, *u.Payloads[i])
-			totalPayloadSize += payload.Size()
+			deduplicatedValues = append(deduplicatedValues, value)
 		}
 	}
 
-	// Update metrics with number of updated payloads and size of updated payloads.
+	// Update metrics with number of updated registers.
 	// TODO rename metrics names
-	f.metrics.UpdateValuesNumber(uint64(len(deduplicatedPayloads)))
-	f.metrics.UpdateValuesSize(uint64(totalPayloadSize))
+	f.metrics.UpdateValuesNumber(uint64(len(deduplicatedValues)))
 
 	// apply pruning on update
 	applyPruning := true
-	newTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(parentTrie, deduplicatedPaths, deduplicatedPayloads, applyPruning)
+	newTrie, maxDepthTouched, err := NewTrieWithUpdatedRegisters(parentTrie, deduplicatedPaths, deduplicatedValues, applyPruning)
 	if err != nil {
 		return nil, fmt.Errorf("constructing updated trie failed: %w", err)
 	}
 
 	f.metrics.LatestTrieRegCount(newTrie.AllocatedRegCount())
 	f.metrics.LatestTrieRegCountDiff(int64(newTrie.AllocatedRegCount() - parentTrie.AllocatedRegCount()))
-	f.metrics.LatestTrieRegSize(newTrie.AllocatedRegSize())
-	f.metrics.LatestTrieRegSizeDiff(int64(newTrie.AllocatedRegSize() - parentTrie.AllocatedRegSize()))
 	f.metrics.LatestTrieMaxDepthTouched(maxDepthTouched)
 
 	return newTrie, nil
@@ -247,29 +241,31 @@ func (f *Forest) NewTrie(u *ledger.TrieUpdate) (*trie.MTrie, error) {
 
 // Proofs returns a batch proof for the given paths.
 //
-// Proves are generally _not_ provided in the register order of the query.
+// Proofs are generally _not_ provided in the register order of the query.
 // In the current implementation, input paths in the TrieRead `r` are sorted in an ascendent order,
 // The output proofs are provided following the order of the sorted paths.
-func (f *Forest) Proofs(r *ledger.TrieRead) (*ledger.TrieBatchProof, error) {
+//
+// Returned proofs carry leaf hashes (HashLeaf(path, value)) rather than full payloads.
+func (f *Forest) Proofs(r *ledger.TrieRead) (*ledger.PayloadlessTrieBatchProof, error) {
 
 	// no path, empty batchproof
 	if len(r.Paths) == 0 {
-		return ledger.NewTrieBatchProof(), nil
+		return ledger.NewPayloadlessTrieBatchProof(), nil
 	}
 
 	// look up for non existing paths
-	retValueSizes, err := f.ValueSizes(r)
+	exists, err := f.HasPaths(r)
 	if err != nil {
 		return nil, err
 	}
 
 	notFoundPaths := make([]ledger.Path, 0)
-	notFoundPayloads := make([]ledger.Payload, 0)
+	notFoundValues := make([][]byte, 0)
 	for i, path := range r.Paths {
 		// add if empty
-		if retValueSizes[i] == 0 {
+		if !exists[i] {
 			notFoundPaths = append(notFoundPaths, path)
-			notFoundPayloads = append(notFoundPayloads, *ledger.EmptyPayload())
+			notFoundValues = append(notFoundValues, nil)
 		}
 	}
 
@@ -285,7 +281,7 @@ func (f *Forest) Proofs(r *ledger.TrieRead) (*ledger.TrieBatchProof, error) {
 		// so for non-inclusion proofs we expand the trie with nil value and use an inclusion proof
 		// instead. if pruning is enabled it would break this trick and return the exact trie.
 		applyPruning := false
-		newTrie, _, err := trie.NewTrieWithUpdatedRegisters(stateTrie, notFoundPaths, notFoundPayloads, applyPruning)
+		newTrie, _, err := NewTrieWithUpdatedRegisters(stateTrie, notFoundPaths, notFoundValues, applyPruning)
 		if err != nil {
 			return nil, err
 		}
@@ -309,7 +305,7 @@ func (f *Forest) HasTrie(rootHash ledger.RootHash) bool {
 
 // GetTrie returns trie at specific rootHash
 // warning, use this function for read-only operation
-func (f *Forest) GetTrie(rootHash ledger.RootHash) (*trie.MTrie, error) {
+func (f *Forest) GetTrie(rootHash ledger.RootHash) (*MTrie, error) {
 	// if in memory
 	if trie, found := f.tries.Get(rootHash); found {
 		return trie, nil
@@ -318,12 +314,12 @@ func (f *Forest) GetTrie(rootHash ledger.RootHash) (*trie.MTrie, error) {
 }
 
 // GetTries returns list of currently cached tree root hashes
-func (f *Forest) GetTries() ([]*trie.MTrie, error) {
+func (f *Forest) GetTries() ([]*MTrie, error) {
 	return f.tries.Tries(), nil
 }
 
 // AddTries adds a trie to the forest
-func (f *Forest) AddTries(newTries []*trie.MTrie) error {
+func (f *Forest) AddTries(newTries []*MTrie) error {
 	for _, t := range newTries {
 		err := f.AddTrie(t)
 		if err != nil {
@@ -334,7 +330,7 @@ func (f *Forest) AddTries(newTries []*trie.MTrie) error {
 }
 
 // AddTrie adds a trie to the forest
-func (f *Forest) AddTrie(newTrie *trie.MTrie) error {
+func (f *Forest) AddTrie(newTrie *MTrie) error {
 	if newTrie == nil {
 		return nil
 	}
@@ -353,7 +349,7 @@ func (f *Forest) AddTrie(newTrie *trie.MTrie) error {
 
 // GetEmptyRootHash returns the rootHash of empty Trie
 func (f *Forest) GetEmptyRootHash() ledger.RootHash {
-	return trie.EmptyTrieRootHash()
+	return EmptyTrieRootHash()
 }
 
 // MostRecentTouchedRootHash returns the rootHash of the most recently touched trie

--- a/ledger/complete/payloadless/forest.go
+++ b/ledger/complete/payloadless/forest.go
@@ -110,7 +110,19 @@ func (f *Forest) ReadSingleLeafHash(r *ledger.TrieReadSingleValue) (*hash.Hash, 
 		return nil, err
 	}
 
-	return trie.ReadSingleLeafHash(r.Path), nil
+	return copyLeafHash(trie.ReadSingleLeafHash(r.Path)), nil
+}
+
+// copyLeafHash returns a defensive copy of the given leaf hash, or nil if the input is nil.
+// The trie nodes are immutable and hand out pointers to their stored leaf hashes; returning a
+// copy ensures callers cannot mutate a node's leaf hash through the returned pointer. This
+// mirrors the full forest, which deep-copies values before returning them from Read.
+func copyLeafHash(leafHash *hash.Hash) *hash.Hash {
+	if leafHash == nil {
+		return nil
+	}
+	h := *leafHash
+	return &h
 }
 
 // ReadLeafHashes reads leaf hashes for a slice of paths and returns the leaf hashes
@@ -131,7 +143,7 @@ func (f *Forest) ReadLeafHashes(r *ledger.TrieRead) ([]*hash.Hash, error) {
 
 	// call ReadSingleLeafHash if there is only one path
 	if len(r.Paths) == 1 {
-		return []*hash.Hash{trie.ReadSingleLeafHash(r.Paths[0])}, nil
+		return []*hash.Hash{copyLeafHash(trie.ReadSingleLeafHash(r.Paths[0]))}, nil
 	}
 
 	// deduplicate keys:
@@ -157,7 +169,8 @@ func (f *Forest) ReadLeafHashes(r *ledger.TrieRead) ([]*hash.Hash, error) {
 	for i, p := range deduplicatedPaths {
 		lh := leafHashes[i]
 		for _, j := range pathOrgIndex[p] {
-			orderedLeafHashes[j] = lh
+			// copy per output slot so duplicate paths don't alias the same hash
+			orderedLeafHashes[j] = copyLeafHash(lh)
 		}
 	}
 

--- a/ledger/complete/payloadless/forest.go
+++ b/ledger/complete/payloadless/forest.go
@@ -1,0 +1,382 @@
+package mtrie
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/hash"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
+	"github.com/onflow/flow-go/module"
+)
+
+// Forest holds several in-memory tries. As Forest is a storage-abstraction layer,
+// we assume that all registers are addressed via paths of pre-defined uniform length.
+//
+// Forest has a limit, the forestCapacity, on the number of tries it is able to store.
+// If more tries are added than the capacity, the Least Recently Used trie is
+// removed (evicted) from the Forest. THIS IS A ROUGH HEURISTIC as it might evict
+// tries that are still needed. In fully matured Flow, we will have an
+// explicit eviction policy.
+//
+// TODO: Storage Eviction Policy for Forest
+// For the execution node: we only evict on sealing a result.
+type Forest struct {
+	// tries stores all MTries in the forest. It is NOT a CACHE in the conventional sense:
+	// there is no mechanism to load a trie from disk in case of a cache miss. Missing a
+	// needed trie in the forest might cause a fatal application logic error.
+	tries          *TrieCache
+	forestCapacity int
+	onTreeEvicted  func(tree *trie.MTrie)
+	metrics        module.LedgerMetrics
+}
+
+// NewForest returns a new instance of memory forest.
+//
+// CAUTION on forestCapacity: the specified capacity MUST be SUFFICIENT to store all needed MTries in the forest.
+// If more tries are added than the capacity, the Least Recently Added trie is removed (evicted) from the Forest (FIFO queue).
+// Make sure you chose a sufficiently large forestCapacity, such that, when reaching the capacity, the
+// Least Recently Added trie will never be needed again.
+func NewForest(forestCapacity int, metrics module.LedgerMetrics, onTreeEvicted func(tree *trie.MTrie)) (*Forest, error) {
+	forest := &Forest{tries: NewTrieCache(uint(forestCapacity), onTreeEvicted),
+		forestCapacity: forestCapacity,
+		onTreeEvicted:  onTreeEvicted,
+		metrics:        metrics,
+	}
+
+	// add trie with no allocated registers
+	emptyTrie := trie.NewEmptyMTrie()
+	err := forest.AddTrie(emptyTrie)
+	if err != nil {
+		return nil, fmt.Errorf("adding empty trie to forest failed: %w", err)
+	}
+	return forest, nil
+}
+
+// ValueSizes returns value sizes for a slice of paths and error (if any)
+// TODO: can be optimized further if we don't care about changing the order of the input r.Paths
+func (f *Forest) ValueSizes(r *ledger.TrieRead) ([]int, error) {
+
+	if len(r.Paths) == 0 {
+		return []int{}, nil
+	}
+
+	// lookup the trie by rootHash
+	trie, err := f.GetTrie(r.RootHash)
+	if err != nil {
+		return nil, err
+	}
+
+	// deduplicate paths:
+	// Generally, we expect the VM to deduplicate reads and writes. Hence, the following is a pre-caution.
+	// TODO: We could take out the following de-duplication logic
+	//       Which increases the cost for duplicates but reduces ValueSizes complexity without duplicates.
+	deduplicatedPaths := make([]ledger.Path, 0, len(r.Paths))
+	pathOrgIndex := make(map[ledger.Path][]int)
+	for i, path := range r.Paths {
+		// only collect duplicated paths once
+		indices, ok := pathOrgIndex[path]
+		if !ok { // deduplication here is optional
+			deduplicatedPaths = append(deduplicatedPaths, path)
+		}
+		// append the index
+		pathOrgIndex[path] = append(indices, i)
+	}
+
+	sizes := trie.UnsafeValueSizes(deduplicatedPaths) // this sorts deduplicatedPaths IN-PLACE
+
+	// reconstruct value sizes in the same key order that called the method
+	orderedValueSizes := make([]int, len(r.Paths))
+	totalValueSize := 0
+	for i, p := range deduplicatedPaths {
+		size := sizes[i]
+		indices := pathOrgIndex[p]
+		for _, j := range indices {
+			orderedValueSizes[j] = size
+		}
+		totalValueSize += len(indices) * size
+	}
+	// TODO rename the metrics
+	f.metrics.ReadValuesSize(uint64(totalValueSize))
+
+	return orderedValueSizes, nil
+}
+
+// ReadSingleValue reads value for a single path and returns value and error (if any)
+func (f *Forest) ReadSingleValue(r *ledger.TrieReadSingleValue) (ledger.Value, error) {
+	// lookup the trie by rootHash
+	trie, err := f.GetTrie(r.RootHash)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := trie.ReadSinglePayload(r.Path)
+	return payload.Value().DeepCopy(), nil
+}
+
+// Read reads values for an slice of paths and returns values and error (if any)
+// TODO: can be optimized further if we don't care about changing the order of the input r.Paths
+func (f *Forest) Read(r *ledger.TrieRead) ([]ledger.Value, error) {
+
+	if len(r.Paths) == 0 {
+		return []ledger.Value{}, nil
+	}
+
+	// lookup the trie by rootHash
+	trie, err := f.GetTrie(r.RootHash)
+	if err != nil {
+		return nil, err
+	}
+
+	// call ReadSinglePayload if there is only one path
+	if len(r.Paths) == 1 {
+		payload := trie.ReadSinglePayload(r.Paths[0])
+		return []ledger.Value{payload.Value().DeepCopy()}, nil
+	}
+
+	// deduplicate keys:
+	// Generally, we expect the VM to deduplicate reads and writes. Hence, the following is a pre-caution.
+	// TODO: We could take out the following de-duplication logic
+	//       Which increases the cost for duplicates but reduces read complexity without duplicates.
+	deduplicatedPaths := make([]ledger.Path, 0, len(r.Paths))
+	pathOrgIndex := make(map[ledger.Path][]int)
+	for i, path := range r.Paths {
+		// only collect duplicated keys once
+		indices, ok := pathOrgIndex[path]
+		if !ok { // deduplication here is optional
+			deduplicatedPaths = append(deduplicatedPaths, path)
+		}
+		// append the index
+		pathOrgIndex[path] = append(indices, i)
+	}
+
+	payloads := trie.UnsafeRead(deduplicatedPaths) // this sorts deduplicatedPaths IN-PLACE
+
+	// reconstruct the payloads in the same key order that called the method
+	orderedValues := make([]ledger.Value, len(r.Paths))
+	totalPayloadSize := 0
+	for i, p := range deduplicatedPaths {
+		payload := payloads[i]
+		indices := pathOrgIndex[p]
+		for _, j := range indices {
+			orderedValues[j] = payload.Value().DeepCopy()
+		}
+		totalPayloadSize += len(indices) * payload.Size()
+	}
+	// TODO rename the metrics
+	f.metrics.ReadValuesSize(uint64(totalPayloadSize))
+
+	return orderedValues, nil
+}
+
+// Update creates a new trie by updating Values for registers in the parent trie,
+// adds new trie to forest, and returns rootHash and error (if any).
+// In case there are multiple updates to the same register, Update will persist
+// the latest written value.
+// Note: Update adds new trie to forest, unlike NewTrie().
+func (f *Forest) Update(u *ledger.TrieUpdate) (ledger.RootHash, error) {
+	t, err := f.NewTrie(u)
+	if err != nil {
+		return ledger.RootHash(hash.DummyHash), err
+	}
+
+	err = f.AddTrie(t)
+	if err != nil {
+		return ledger.RootHash(hash.DummyHash), fmt.Errorf("adding updated trie to forest failed: %w", err)
+	}
+
+	return t.RootHash(), nil
+}
+
+// NewTrie creates a new trie by updating Values for registers in the parent trie,
+// and returns new trie and error (if any).
+// In case there are multiple updates to the same register, NewTrie will persist
+// the latest written value.
+// Note: NewTrie doesn't add new trie to forest, unlike Update().
+func (f *Forest) NewTrie(u *ledger.TrieUpdate) (*trie.MTrie, error) {
+
+	parentTrie, err := f.GetTrie(u.RootHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(u.Paths) == 0 { // no key no change
+		return parentTrie, nil
+	}
+
+	// Deduplicate writes to the same register: we only retain the value of the last write
+	// Generally, we expect the VM to deduplicate reads and writes.
+	deduplicatedPaths := make([]ledger.Path, 0, len(u.Paths))
+	deduplicatedPayloads := make([]ledger.Payload, 0, len(u.Paths))
+	payloadMap := make(map[ledger.Path]int) // index into deduplicatedPaths, deduplicatedPayloads with register update
+	totalPayloadSize := 0
+	for i, path := range u.Paths {
+		payload := u.Payloads[i]
+		// check if we already have encountered an update for the respective register
+		if idx, ok := payloadMap[path]; ok {
+			oldPayload := deduplicatedPayloads[idx]
+			deduplicatedPayloads[idx] = *payload
+			totalPayloadSize += -oldPayload.Size() + payload.Size()
+		} else {
+			payloadMap[path] = len(deduplicatedPaths)
+			deduplicatedPaths = append(deduplicatedPaths, path)
+			deduplicatedPayloads = append(deduplicatedPayloads, *u.Payloads[i])
+			totalPayloadSize += payload.Size()
+		}
+	}
+
+	// Update metrics with number of updated payloads and size of updated payloads.
+	// TODO rename metrics names
+	f.metrics.UpdateValuesNumber(uint64(len(deduplicatedPayloads)))
+	f.metrics.UpdateValuesSize(uint64(totalPayloadSize))
+
+	// apply pruning on update
+	applyPruning := true
+	newTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(parentTrie, deduplicatedPaths, deduplicatedPayloads, applyPruning)
+	if err != nil {
+		return nil, fmt.Errorf("constructing updated trie failed: %w", err)
+	}
+
+	f.metrics.LatestTrieRegCount(newTrie.AllocatedRegCount())
+	f.metrics.LatestTrieRegCountDiff(int64(newTrie.AllocatedRegCount() - parentTrie.AllocatedRegCount()))
+	f.metrics.LatestTrieRegSize(newTrie.AllocatedRegSize())
+	f.metrics.LatestTrieRegSizeDiff(int64(newTrie.AllocatedRegSize() - parentTrie.AllocatedRegSize()))
+	f.metrics.LatestTrieMaxDepthTouched(maxDepthTouched)
+
+	return newTrie, nil
+}
+
+// Proofs returns a batch proof for the given paths.
+//
+// Proves are generally _not_ provided in the register order of the query.
+// In the current implementation, input paths in the TrieRead `r` are sorted in an ascendent order,
+// The output proofs are provided following the order of the sorted paths.
+func (f *Forest) Proofs(r *ledger.TrieRead) (*ledger.TrieBatchProof, error) {
+
+	// no path, empty batchproof
+	if len(r.Paths) == 0 {
+		return ledger.NewTrieBatchProof(), nil
+	}
+
+	// look up for non existing paths
+	retValueSizes, err := f.ValueSizes(r)
+	if err != nil {
+		return nil, err
+	}
+
+	notFoundPaths := make([]ledger.Path, 0)
+	notFoundPayloads := make([]ledger.Payload, 0)
+	for i, path := range r.Paths {
+		// add if empty
+		if retValueSizes[i] == 0 {
+			notFoundPaths = append(notFoundPaths, path)
+			notFoundPayloads = append(notFoundPayloads, *ledger.EmptyPayload())
+		}
+	}
+
+	stateTrie, err := f.GetTrie(r.RootHash)
+	if err != nil {
+		return nil, err
+	}
+
+	// if we have to insert empty values
+	if len(notFoundPaths) > 0 {
+		// for proofs, we have to set the pruning to false,
+		// currently batch proofs are only consists of inclusion proofs
+		// so for non-inclusion proofs we expand the trie with nil value and use an inclusion proof
+		// instead. if pruning is enabled it would break this trick and return the exact trie.
+		applyPruning := false
+		newTrie, _, err := trie.NewTrieWithUpdatedRegisters(stateTrie, notFoundPaths, notFoundPayloads, applyPruning)
+		if err != nil {
+			return nil, err
+		}
+
+		// rootHash shouldn't change
+		if newTrie.RootHash() != r.RootHash {
+			return nil, fmt.Errorf("root hash has changed during the operation %x, %x", newTrie.RootHash(), r.RootHash)
+		}
+		stateTrie = newTrie
+	}
+
+	bp := stateTrie.UnsafeProofs(r.Paths)
+	return bp, nil
+}
+
+// HasTrie returns true if trie exist at specific rootHash
+func (f *Forest) HasTrie(rootHash ledger.RootHash) bool {
+	_, found := f.tries.Get(rootHash)
+	return found
+}
+
+// GetTrie returns trie at specific rootHash
+// warning, use this function for read-only operation
+func (f *Forest) GetTrie(rootHash ledger.RootHash) (*trie.MTrie, error) {
+	// if in memory
+	if trie, found := f.tries.Get(rootHash); found {
+		return trie, nil
+	}
+	return nil, fmt.Errorf("trie with the given rootHash %s not found", rootHash)
+}
+
+// GetTries returns list of currently cached tree root hashes
+func (f *Forest) GetTries() ([]*trie.MTrie, error) {
+	return f.tries.Tries(), nil
+}
+
+// AddTries adds a trie to the forest
+func (f *Forest) AddTries(newTries []*trie.MTrie) error {
+	for _, t := range newTries {
+		err := f.AddTrie(t)
+		if err != nil {
+			return fmt.Errorf("adding tries to forest failed: %w", err)
+		}
+	}
+	return nil
+}
+
+// AddTrie adds a trie to the forest
+func (f *Forest) AddTrie(newTrie *trie.MTrie) error {
+	if newTrie == nil {
+		return nil
+	}
+
+	// TODO: check Thread safety
+	rootHash := newTrie.RootHash()
+	if _, found := f.tries.Get(rootHash); found {
+		// do no op
+		return nil
+	}
+	f.tries.Push(newTrie)
+	f.metrics.ForestNumberOfTrees(uint64(f.tries.Count()))
+
+	return nil
+}
+
+// GetEmptyRootHash returns the rootHash of empty Trie
+func (f *Forest) GetEmptyRootHash() ledger.RootHash {
+	return trie.EmptyTrieRootHash()
+}
+
+// MostRecentTouchedRootHash returns the rootHash of the most recently touched trie
+func (f *Forest) MostRecentTouchedRootHash() (ledger.RootHash, error) {
+	trie := f.tries.LastAddedTrie()
+	if trie != nil {
+		return trie.RootHash(), nil
+	}
+	return ledger.RootHash(hash.DummyHash), fmt.Errorf("no trie is stored in the forest")
+}
+
+// PurgeCacheExcept removes all tries in the memory except the one with the given root hash
+func (f *Forest) PurgeCacheExcept(rootHash ledger.RootHash) error {
+	trie, found := f.tries.Get(rootHash)
+	if !found {
+		return fmt.Errorf("trie with the given root hash not found")
+	}
+	f.tries.Purge()
+	f.tries.Push(trie)
+	return nil
+}
+
+// Size returns the number of active tries in this store
+func (f *Forest) Size() int {
+	return f.tries.Count()
+}

--- a/ledger/complete/payloadless/forest_equivalence_test.go
+++ b/ledger/complete/payloadless/forest_equivalence_test.go
@@ -1,0 +1,366 @@
+package payloadless_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/hash"
+	"github.com/onflow/flow-go/ledger/common/testutils"
+	"github.com/onflow/flow-go/ledger/complete/mtrie"
+	"github.com/onflow/flow-go/ledger/complete/payloadless"
+	"github.com/onflow/flow-go/module/metrics"
+)
+
+// These tests build a regular mtrie.Forest and a payloadless.Forest from the same
+// inputs and assert they agree on observable outputs. The payloadless forest is
+// designed to be hash-equivalent to the full forest when given identical
+// TrieUpdates, so any divergence in root hash, leaf reads, existence checks, or
+// proof interim hashes is a bug.
+
+// forestPair holds a regular and a payloadless forest that are kept in lockstep.
+type forestPair struct {
+	m  *mtrie.Forest
+	pl *payloadless.Forest
+}
+
+func newForestPair(t *testing.T, capacity int) *forestPair {
+	t.Helper()
+	noop := &metrics.NoopCollector{}
+	m, err := mtrie.NewForest(capacity, noop, nil)
+	require.NoError(t, err)
+	pl, err := payloadless.NewForest(capacity, noop, nil)
+	require.NoError(t, err)
+	return &forestPair{m: m, pl: pl}
+}
+
+// applyUpdate sends the same TrieUpdate to both forests. The same root hash
+// must be returned by both. Each forest internally re-uses or permutes the
+// slices in its input, so we hand each a defensive deep copy.
+func (fp *forestPair) applyUpdate(t *testing.T, u *ledger.TrieUpdate) (ledger.RootHash, ledger.RootHash) {
+	t.Helper()
+
+	mRoot, err := fp.m.Update(cloneUpdate(u))
+	require.NoError(t, err)
+	plRoot, err := fp.pl.Update(cloneUpdate(u))
+	require.NoError(t, err)
+	require.Equal(t, mRoot, plRoot, "root hash mismatch between full and payloadless forest")
+	return mRoot, plRoot
+}
+
+// cloneUpdate returns a deep copy of u suitable for passing to a Forest that
+// permutes its inputs in place.
+func cloneUpdate(u *ledger.TrieUpdate) *ledger.TrieUpdate {
+	paths := make([]ledger.Path, len(u.Paths))
+	copy(paths, u.Paths)
+	payloads := make([]*ledger.Payload, len(u.Payloads))
+	for i, p := range u.Payloads {
+		payloads[i] = p
+	}
+	return &ledger.TrieUpdate{RootHash: u.RootHash, Paths: paths, Payloads: payloads}
+}
+
+// TestForestEquivalence_Empty verifies the empty root hashes match.
+func TestForestEquivalence_Empty(t *testing.T) {
+	fp := newForestPair(t, 5)
+	require.Equal(t, fp.m.GetEmptyRootHash(), fp.pl.GetEmptyRootHash())
+}
+
+// TestForestEquivalence_SingleUpdate verifies a single TrieUpdate produces the
+// same root hash in both forests.
+func TestForestEquivalence_SingleUpdate(t *testing.T) {
+	fp := newForestPair(t, 5)
+
+	path := testutils.PathByUint16(56809)
+	payload := testutils.LightPayload(56810, 59656)
+	update := &ledger.TrieUpdate{
+		RootHash: fp.m.GetEmptyRootHash(),
+		Paths:    []ledger.Path{path},
+		Payloads: []*ledger.Payload{payload},
+	}
+
+	fp.applyUpdate(t, update)
+}
+
+// TestForestEquivalence_IncrementalUpdates verifies root hashes agree after each
+// round of updates over many rounds.
+func TestForestEquivalence_IncrementalUpdates(t *testing.T) {
+	fp := newForestPair(t, 100)
+
+	rootHash := fp.m.GetEmptyRootHash()
+	rng := &payloadlessRNG{seed: 0}
+
+	for round := 1; round <= 10; round++ {
+		paths, payloads := randomUpdate(rng, round*40)
+		update := &ledger.TrieUpdate{RootHash: rootHash, Paths: paths, Payloads: payloads}
+		newRoot, _ := fp.applyUpdate(t, update)
+		rootHash = newRoot
+	}
+}
+
+// TestForestEquivalence_Forking verifies that forking a base trie into two
+// children yields matching root hashes in both forests.
+func TestForestEquivalence_Forking(t *testing.T) {
+	fp := newForestPair(t, 10)
+
+	rng := &payloadlessRNG{seed: 0}
+	basePaths, basePayloads := randomUpdate(rng, 50)
+	baseUpdate := &ledger.TrieUpdate{
+		RootHash: fp.m.GetEmptyRootHash(),
+		Paths:    basePaths,
+		Payloads: basePayloads,
+	}
+	baseRoot, _ := fp.applyUpdate(t, baseUpdate)
+
+	// fork A
+	pathsA, payloadsA := randomUpdate(rng, 30)
+	updateA := &ledger.TrieUpdate{RootHash: baseRoot, Paths: pathsA, Payloads: payloadsA}
+	fp.applyUpdate(t, updateA)
+
+	// fork B (independent from A)
+	pathsB, payloadsB := randomUpdate(rng, 30)
+	updateB := &ledger.TrieUpdate{RootHash: baseRoot, Paths: pathsB, Payloads: payloadsB}
+	fp.applyUpdate(t, updateB)
+}
+
+// TestForestEquivalence_Reads verifies that for every path in the trie, the
+// payloadless ReadLeafHashes returns HashLeaf(path, value) where value is what
+// the full Read returns.
+func TestForestEquivalence_Reads(t *testing.T) {
+	fp := newForestPair(t, 5)
+
+	rng := &payloadlessRNG{seed: 0}
+	paths, payloads := randomUpdate(rng, 200)
+	update := &ledger.TrieUpdate{
+		RootHash: fp.m.GetEmptyRootHash(),
+		Paths:    paths,
+		Payloads: payloads,
+	}
+	root, _ := fp.applyUpdate(t, update)
+
+	// Mix of allocated and unallocated paths.
+	queryPaths := make([]ledger.Path, 0, len(paths)+30)
+	queryPaths = append(queryPaths, paths...)
+	for i := 0; i < 30; i++ {
+		var p ledger.Path
+		p[0] = 0xff
+		p[31] = byte(i)
+		queryPaths = append(queryPaths, p)
+	}
+
+	mPaths := append([]ledger.Path(nil), queryPaths...)
+	plPaths := append([]ledger.Path(nil), queryPaths...)
+
+	mValues, err := fp.m.Read(&ledger.TrieRead{RootHash: root, Paths: mPaths})
+	require.NoError(t, err)
+	plLeafHashes, err := fp.pl.ReadLeafHashes(&ledger.TrieRead{RootHash: root, Paths: plPaths})
+	require.NoError(t, err)
+
+	require.Equal(t, len(queryPaths), len(mValues))
+	require.Equal(t, len(queryPaths), len(plLeafHashes))
+
+	for i, p := range queryPaths {
+		if len(mValues[i]) == 0 {
+			// full forest returned empty value → payloadless must report nil
+			require.Nilf(t, plLeafHashes[i], "expected nil leaf hash at index %d for unallocated path", i)
+			continue
+		}
+		require.NotNilf(t, plLeafHashes[i], "expected non-nil leaf hash at index %d for allocated path", i)
+		expected := hash.HashLeaf(hash.Hash(p), []byte(mValues[i]))
+		require.Equalf(t, expected, *plLeafHashes[i], "leaf hash mismatch at index %d", i)
+	}
+}
+
+// TestForestEquivalence_ReadSingle verifies the single-path read APIs agree.
+func TestForestEquivalence_ReadSingle(t *testing.T) {
+	fp := newForestPair(t, 5)
+
+	rng := &payloadlessRNG{seed: 0}
+	paths, payloads := randomUpdate(rng, 50)
+	update := &ledger.TrieUpdate{
+		RootHash: fp.m.GetEmptyRootHash(),
+		Paths:    paths,
+		Payloads: payloads,
+	}
+	root, _ := fp.applyUpdate(t, update)
+
+	// allocated paths
+	for i, p := range paths {
+		mValue, err := fp.m.ReadSingleValue(&ledger.TrieReadSingleValue{RootHash: root, Path: p})
+		require.NoError(t, err)
+		plLeafHash, err := fp.pl.ReadSingleLeafHash(&ledger.TrieReadSingleValue{RootHash: root, Path: p})
+		require.NoError(t, err)
+
+		if len(mValue) == 0 {
+			require.Nil(t, plLeafHash)
+			continue
+		}
+		require.NotNil(t, plLeafHash)
+		expected := hash.HashLeaf(hash.Hash(p), []byte(mValue))
+		require.Equalf(t, expected, *plLeafHash, "leaf hash mismatch for path index %d", i)
+	}
+
+	// unallocated paths
+	for i := 0; i < 20; i++ {
+		var p ledger.Path
+		p[0] = 0xfe
+		p[31] = byte(i)
+
+		mValue, err := fp.m.ReadSingleValue(&ledger.TrieReadSingleValue{RootHash: root, Path: p})
+		require.NoError(t, err)
+		plLeafHash, err := fp.pl.ReadSingleLeafHash(&ledger.TrieReadSingleValue{RootHash: root, Path: p})
+		require.NoError(t, err)
+
+		require.Equal(t, 0, len(mValue))
+		require.Nil(t, plLeafHash)
+	}
+}
+
+// TestForestEquivalence_HasPathsVsValueSizes verifies that for every path,
+// payloadless.HasPaths reports true iff the full forest's ValueSizes is > 0.
+func TestForestEquivalence_HasPathsVsValueSizes(t *testing.T) {
+	fp := newForestPair(t, 5)
+
+	rng := &payloadlessRNG{seed: 0}
+	paths, payloads := randomUpdate(rng, 150)
+	update := &ledger.TrieUpdate{
+		RootHash: fp.m.GetEmptyRootHash(),
+		Paths:    paths,
+		Payloads: payloads,
+	}
+	root, _ := fp.applyUpdate(t, update)
+
+	// Mix allocated paths with some unallocated and duplicate entries.
+	queryPaths := make([]ledger.Path, 0, len(paths)+25)
+	queryPaths = append(queryPaths, paths...)
+	for i := 0; i < 20; i++ {
+		var p ledger.Path
+		p[0] = 0xfd
+		p[31] = byte(i)
+		queryPaths = append(queryPaths, p)
+	}
+	// add a few duplicates
+	queryPaths = append(queryPaths, paths[0], paths[1], paths[0])
+
+	mPaths := append([]ledger.Path(nil), queryPaths...)
+	plPaths := append([]ledger.Path(nil), queryPaths...)
+
+	sizes, err := fp.m.ValueSizes(&ledger.TrieRead{RootHash: root, Paths: mPaths})
+	require.NoError(t, err)
+	exists, err := fp.pl.HasPaths(&ledger.TrieRead{RootHash: root, Paths: plPaths})
+	require.NoError(t, err)
+
+	require.Equal(t, len(queryPaths), len(sizes))
+	require.Equal(t, len(queryPaths), len(exists))
+
+	for i := range queryPaths {
+		require.Equalf(t, sizes[i] > 0, exists[i], "existence mismatch at index %d (size=%d)", i, sizes[i])
+	}
+}
+
+// TestForestEquivalence_Proofs verifies that the proof interim hashes and
+// structural fields (Flags, Steps, Inclusion, Path) match between the two
+// forests. Inclusion proofs additionally carry HashLeaf(payload.Value()) in
+// the payloadless variant.
+func TestForestEquivalence_Proofs(t *testing.T) {
+	fp := newForestPair(t, 5)
+
+	rng := &payloadlessRNG{seed: 0}
+	paths, payloads := randomUpdate(rng, 150)
+	update := &ledger.TrieUpdate{
+		RootHash: fp.m.GetEmptyRootHash(),
+		Paths:    paths,
+		Payloads: payloads,
+	}
+	root, _ := fp.applyUpdate(t, update)
+
+	// Query a mix of allocated and unallocated paths.
+	queryPaths := make([]ledger.Path, 0, 60)
+	queryPaths = append(queryPaths, paths[:40]...)
+	for i := 0; i < 20; i++ {
+		var p ledger.Path
+		p[0] = 0xfc
+		p[31] = byte(i)
+		queryPaths = append(queryPaths, p)
+	}
+
+	mPaths := append([]ledger.Path(nil), queryPaths...)
+	plPaths := append([]ledger.Path(nil), queryPaths...)
+
+	mBatch, err := fp.m.Proofs(&ledger.TrieRead{RootHash: root, Paths: mPaths})
+	require.NoError(t, err)
+	plBatch, err := fp.pl.Proofs(&ledger.TrieRead{RootHash: root, Paths: plPaths})
+	require.NoError(t, err)
+
+	require.Equal(t, mBatch.Size(), plBatch.Size())
+
+	// Both forests sort the input paths before generating proofs and return
+	// proofs indexed by the resulting order. Index by path so we compare the
+	// same proof regardless of internal ordering choices.
+	mByPath := make(map[ledger.Path]*ledger.TrieProof, len(mPaths))
+	for i, p := range mPaths {
+		mByPath[p] = mBatch.Proofs[i]
+	}
+	plByPath := make(map[ledger.Path]*ledger.PayloadlessTrieProof, len(plPaths))
+	for i, p := range plPaths {
+		plByPath[p] = plBatch.Proofs[i]
+	}
+
+	for _, p := range queryPaths {
+		mp := mByPath[p]
+		plp := plByPath[p]
+
+		require.Equalf(t, mp.Inclusion, plp.Inclusion, "Inclusion mismatch for path %x", p[:])
+		require.Equalf(t, mp.Steps, plp.Steps, "Steps mismatch for path %x", p[:])
+		require.Equalf(t, mp.Flags, plp.Flags, "Flags mismatch for path %x", p[:])
+		require.Equalf(t, mp.Interims, plp.Interims, "Interims mismatch for path %x", p[:])
+		require.Equal(t, mp.Path, plp.Path)
+
+		if mp.Inclusion {
+			// `forest.Proofs` pre-expands the trie with EmptyPayloads for
+			// previously-unallocated paths, turning them into inclusion
+			// proofs of empty leaves. In the payloadless variant, those
+			// empty leaves carry a nil leafHash.
+			if mp.Payload.IsEmpty() {
+				require.Nilf(t, plp.LeafHash, "payloadless leaf hash should be nil for empty inclusion (path %x)", mp.Path[:])
+			} else {
+				require.NotNilf(t, plp.LeafHash, "payloadless leaf hash should be non-nil for non-empty inclusion (path %x)", mp.Path[:])
+				expected := hash.HashLeaf(hash.Hash(mp.Path), []byte(mp.Payload.Value()))
+				require.Equal(t, expected, *plp.LeafHash)
+			}
+		}
+	}
+}
+
+// payloadlessRNG is a self-contained LCG so the equivalence test doesn't depend
+// on internals of either forest_test.go or trie_test.go (those are in
+// different test packages).
+type payloadlessRNG struct {
+	seed uint64
+}
+
+func (r *payloadlessRNG) next() uint16 {
+	r.seed = (r.seed*1140671485 + 12820163) % 65536
+	return uint16(r.seed)
+}
+
+// randomUpdate generates deduplicated path/payload pairs for a TrieUpdate.
+func randomUpdate(rng *payloadlessRNG, n int) ([]ledger.Path, []*ledger.Payload) {
+	seen := make(map[ledger.Path]int, n)
+	paths := make([]ledger.Path, 0, n)
+	payloads := make([]*ledger.Payload, 0, n)
+	for i := 0; i < n; i++ {
+		path := testutils.PathByUint16LeftPadded(rng.next())
+		v := rng.next()
+		payload := testutils.LightPayload(v, v)
+		if idx, ok := seen[path]; ok {
+			payloads[idx] = payload
+			continue
+		}
+		seen[path] = len(paths)
+		paths = append(paths, path)
+		payloads = append(payloads, payload)
+	}
+	return paths, payloads
+}

--- a/ledger/complete/payloadless/forest_equivalence_test.go
+++ b/ledger/complete/payloadless/forest_equivalence_test.go
@@ -55,9 +55,7 @@ func cloneUpdate(u *ledger.TrieUpdate) *ledger.TrieUpdate {
 	paths := make([]ledger.Path, len(u.Paths))
 	copy(paths, u.Paths)
 	payloads := make([]*ledger.Payload, len(u.Payloads))
-	for i, p := range u.Payloads {
-		payloads[i] = p
-	}
+	copy(payloads, u.Payloads)
 	return &ledger.TrieUpdate{RootHash: u.RootHash, Paths: paths, Payloads: payloads}
 }
 

--- a/ledger/complete/payloadless/forest_test.go
+++ b/ledger/complete/payloadless/forest_test.go
@@ -1,21 +1,13 @@
-package mtrie
+package payloadless
 
 import (
-	"bytes"
-	"math/rand"
-	"sort"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/hash"
-	prf "github.com/onflow/flow-go/ledger/common/proof"
 	"github.com/onflow/flow-go/ledger/common/testutils"
-	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
-	"github.com/onflow/flow-go/ledger/partial/ptrie"
 	"github.com/onflow/flow-go/module/metrics"
 )
 
@@ -26,11 +18,11 @@ func TestTrieOperations(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make new Trie (independently of MForest):
-	nt := trie.NewEmptyMTrie()
+	nt := NewEmptyMTrie()
 	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
 	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
 
-	updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(nt, []ledger.Path{p1}, []ledger.Payload{*v1}, true)
+	updatedTrie, _, err := NewTrieWithUpdatedRegisters(nt, []ledger.Path{p1}, [][]byte{[]byte(v1.Value())}, true)
 	require.NoError(t, err)
 
 	// Add trie
@@ -45,7 +37,7 @@ func TestTrieOperations(t *testing.T) {
 }
 
 // TestTrieUpdate updates the empty trie with some values and verifies that the
-// written values can be retrieved from the updated trie.
+// written leaf hashes can be retrieved from the updated trie.
 func TestTrieUpdate(t *testing.T) {
 
 	metricsCollector := &metrics.NoopCollector{}
@@ -63,16 +55,16 @@ func TestTrieUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	require.Equal(t, retValues[0], payloads[0].Value())
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashes)
 }
 
 // TestLeftEmptyInsert tests inserting a new value into an empty sub-trie:
 //  1. we first construct a baseTrie holding a couple of values on the right branch [~]
 //  2. we update a previously non-existent register on the left branch (X)
 //
-// We verify that values for _all_ paths in the updated Trie have correct payloads
+// We verify that leaf hashes for _all_ paths in the updated Trie have correct values
 func TestLeftEmptyInsert(t *testing.T) {
 	//////////////////////
 	//     insert X     //
@@ -101,7 +93,6 @@ func TestLeftEmptyInsert(t *testing.T) {
 	baseTrie, err := forest.GetTrie(baseRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), baseTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
 
 	p3 := pathByUint8s([]uint8{uint8(1), uint8(1)})
 	v3 := payloadBySlices([]byte{'C'}, []byte{'C'})
@@ -115,22 +106,19 @@ func TestLeftEmptyInsert(t *testing.T) {
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), updatedTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], payloads[i].Value())
-	}
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashes)
 }
 
 // TestRightEmptyInsert tests inserting a new value into an empty sub-trie:
 //  1. we first construct a baseTrie holding a couple of values on the left branch [~]
 //  2. we update a previously non-existent register on the right branch (X)
 //
-// We verify that values for _all_ paths in the updated Trie have correct payloads
+// We verify that leaf hashes for _all_ paths in the updated Trie have correct values
 func TestRightEmptyInsert(t *testing.T) {
 	///////////////////////
 	//     insert X      //
@@ -158,7 +146,6 @@ func TestRightEmptyInsert(t *testing.T) {
 	baseTrie, err := forest.GetTrie(baseRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), baseTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
 
 	// path: 1000...
 	p3 := pathByUint8s([]uint8{uint8(129), uint8(1)})
@@ -173,16 +160,13 @@ func TestRightEmptyInsert(t *testing.T) {
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), updatedTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
 
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], payloads[i].Value())
-	}
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashes)
 }
 
 // TestExpansionInsert tests inserting a new value into a populated sub-trie, where a
@@ -190,7 +174,7 @@ func TestRightEmptyInsert(t *testing.T) {
 //  1. we first construct a baseTrie holding a couple of values on the right branch [~]
 //  2. we update a previously non-existent register on the right branch turning [~] to [~']
 //
-// We verify that values for _all_ paths in the updated Trie have correct payloads
+// We verify that leaf hashes for _all_ paths in the updated Trie are correct
 func TestExpansionInsert(t *testing.T) {
 	////////////////////////
 	// modify [~] -> [~'] //
@@ -215,7 +199,6 @@ func TestExpansionInsert(t *testing.T) {
 	baseTrie, err := forest.GetTrie(baseRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), baseTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v1.Size()), baseTrie.AllocatedRegSize())
 
 	// path: 1000001...
 	p2 := pathByUint8s([]uint8{uint8(130), uint8(1)})
@@ -230,16 +213,13 @@ func TestExpansionInsert(t *testing.T) {
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), updatedTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v1.Size()+v2.Size()), updatedTrie.AllocatedRegSize())
 
 	paths = []ledger.Path{p1, p2}
 	payloads = []*ledger.Payload{v1, v2}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], payloads[i].Value())
-	}
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashes)
 }
 
 // TestFullHouseInsert tests inserting a new value into a populated sub-trie, where a
@@ -248,7 +228,7 @@ func TestExpansionInsert(t *testing.T) {
 //  1. we first construct a baseTrie holding a couple of values on the right branch [~]
 //  2. we update a previously non-existent register on the right branch turning [~] to [~']
 //
-// We verify that values for _all_ paths in the updated Trie have correct payloads
+// We verify that leaf hashes for _all_ paths in the updated Trie are correct
 func TestFullHouseInsert(t *testing.T) {
 	///////////////////////
 	//   insert ~1<X<~2  //
@@ -281,7 +261,6 @@ func TestFullHouseInsert(t *testing.T) {
 	baseTrie, err := forest.GetTrie(baseRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), baseTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v0.Size()+v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
 
 	// we update value for path p1 and in addition add p3 that has the same prefix `10` as p1
 	v1 = payloadBySlices([]byte{'X'}, []byte{'X'})
@@ -299,21 +278,18 @@ func TestFullHouseInsert(t *testing.T) {
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(4), updatedTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v0.Size()+v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
 
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], payloads[i].Value())
-	}
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashes)
 }
 
 // TestLeafInsert inserts two keys, which only differ in their last bit.
 // I.e. the trie needs to be expanded to its hull depth
-// We verify that values for _all_ paths in the updated Trie have correct payloads
+// We verify that leaf hashes for _all_ paths in the updated Trie are correct
 func TestLeafInsert(t *testing.T) {
 	///////////////////////
 	//   insert 1, 2     //
@@ -343,18 +319,15 @@ func TestLeafInsert(t *testing.T) {
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), updatedTrie.AllocatedRegCount())
-	require.Equal(t, uint64(v1.Size()+v2.Size()), updatedTrie.AllocatedRegSize())
 
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], payloads[i].Value())
-	}
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashes)
 }
 
 // TestOverrideValue overrides an existing value in the trie (without any expansion)
-// We verify that values for _all_ paths in the updated Trie have correct payloads
+// We verify that leaf hashes for _all_ paths in the updated Trie are correct
 func TestOverrideValue(t *testing.T) {
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
@@ -384,10 +357,9 @@ func TestOverrideValue(t *testing.T) {
 	require.NoError(t, err)
 
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	require.Equal(t, retValues[0], payloads[0].Value())
-
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashes)
 }
 
 // TestDuplicateOverride tests behaviour when the updates contain two different payloads for the
@@ -417,14 +389,14 @@ func TestDuplicateOverride(t *testing.T) {
 
 	paths = []ledger.Path{p0}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	require.Equal(t, retValues[0], v2.Value())
+	requireLeafHashesMatch(t, paths, []*ledger.Payload{v2}, retLeafHashes)
 
 }
 
-// TestReadSafety check if payload returned from a forest are safe against modification,
-// ie. copy of the data is returned, instead of a slice
+// TestReadSafety checks that the slice returned by ReadLeafHashes is freshly allocated
+// per call, so modifying entries in one returned slice cannot affect subsequent reads.
 func TestReadSafety(t *testing.T) {
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
@@ -439,23 +411,25 @@ func TestReadSafety(t *testing.T) {
 	require.NoError(t, err)
 
 	read := &ledger.TrieRead{RootHash: baseRoot, Paths: paths}
-	data, err := forest.Read(read)
+	data, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-
 	require.Len(t, data, 1)
-	require.Equal(t, v0.Value(), data[0])
+	expected := hash.HashLeaf(hash.Hash(p0), []byte(v0.Value()))
+	require.NotNil(t, data[0])
+	require.Equal(t, expected, *data[0])
 
-	// modify returned slice
-	data[0] = []byte("new value")
+	// modify returned slice element
+	data[0] = nil
 
-	// read again
-	data2, err := forest.Read(read)
+	// read again, should not be affected
+	data2, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
 	require.Len(t, data2, 1)
-	require.Equal(t, v0.Value(), data2[0])
+	require.NotNil(t, data2[0])
+	require.Equal(t, expected, *data2[0])
 }
 
-// TestReadOrder tests that payloads from reading a trie are delivered in the order as specified by the paths
+// TestReadOrder tests that leaf hashes from reading a trie are delivered in the order as specified by the paths
 func TestReadOrder(t *testing.T) {
 
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
@@ -474,22 +448,20 @@ func TestReadOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	read := &ledger.TrieRead{RootHash: testRoot, Paths: []ledger.Path{p1, p2}}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retValues))
-	require.Equal(t, retValues[0], payloads[0].Value())
-	require.Equal(t, retValues[1], payloads[1].Value())
+	require.Equal(t, len(read.Paths), len(retLeafHashes))
+	requireLeafHashesMatch(t, []ledger.Path{p1, p2}, []*ledger.Payload{v1, v2}, retLeafHashes)
 
 	read = &ledger.TrieRead{RootHash: testRoot, Paths: []ledger.Path{p2, p1}}
-	retValues, err = forest.Read(read)
+	retLeafHashes, err = forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retValues))
-	require.Equal(t, retValues[1], payloads[0].Value())
-	require.Equal(t, retValues[0], payloads[1].Value())
+	require.Equal(t, len(read.Paths), len(retLeafHashes))
+	requireLeafHashesMatch(t, []ledger.Path{p2, p1}, []*ledger.Payload{v2, v1}, retLeafHashes)
 }
 
 // TestMixRead tests reading a mixture of set and unset registers.
-// We expect the default payload (nil) to be returned for unset registers.
+// We expect a nil leaf hash to be returned for unset registers.
 func TestMixRead(t *testing.T) {
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
@@ -521,15 +493,13 @@ func TestMixRead(t *testing.T) {
 	expectedPayloads := []*ledger.Payload{v1, v2, v3, v4}
 
 	read := &ledger.TrieRead{RootHash: baseRoot, Paths: readPaths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], expectedPayloads[i].Value())
-	}
+	requireLeafHashesMatch(t, readPaths, expectedPayloads, retLeafHashes)
 }
 
-// TestReadWithDuplicatedKeys reads a the values for two keys, where both keys have the same value.
-// We expect that we receive the respective value twice in the return.
+// TestReadWithDuplicatedKeys reads the leaf hashes for two keys, where both keys have the same value.
+// We expect that we receive the respective leaf hash twice in the return.
 func TestReadWithDuplicatedKeys(t *testing.T) {
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
@@ -549,12 +519,10 @@ func TestReadWithDuplicatedKeys(t *testing.T) {
 	paths = []ledger.Path{p1, p2, p3}
 	expectedPayloads := []*ledger.Payload{v1, v2, v1}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retValues))
-	for i := range paths {
-		require.Equal(t, retValues[i], expectedPayloads[i].Value())
-	}
+	require.Equal(t, len(read.Paths), len(retLeafHashes))
+	requireLeafHashesMatch(t, paths, expectedPayloads, retLeafHashes)
 }
 
 // TestReadNonExistingPath tests reading an unset path.
@@ -573,13 +541,13 @@ func TestReadNonExistingPath(t *testing.T) {
 
 	p2 := pathByUint8s([]uint8{uint8(116), uint8(129)})
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: []ledger.Path{p2}}
-	retValues, err := forest.Read(read)
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(retValues[0]))
+	require.Nil(t, retLeafHashes[0])
 }
 
-// TestReadSinglePayload tests reading a single payload of set/unset register.
-func TestReadSinglePayload(t *testing.T) {
+// TestReadSingleLeafHash tests reading a single leaf hash for set/unset registers.
+func TestReadSingleLeafHash(t *testing.T) {
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
 
@@ -606,34 +574,39 @@ func TestReadSinglePayload(t *testing.T) {
 	path4 := pathByUint8s([]uint8{uint8(23), uint8(82)})
 	payload4 := ledger.EmptyPayload()
 
-	expectedPayloads := make(map[ledger.Path]*ledger.Payload)
-	expectedPayloads[path1] = payload1
-	expectedPayloads[path2] = payload2
-	expectedPayloads[path3] = payload3
-	expectedPayloads[path4] = payload4
+	expectedPayloads := map[ledger.Path]*ledger.Payload{
+		path1: payload1,
+		path2: payload2,
+		path3: payload3,
+		path4: payload4,
+	}
 
-	// Batch read one payload at a time (less efficient)
+	// Batch read one leaf hash at a time (less efficient)
 	for path, payload := range expectedPayloads {
 		read := &ledger.TrieRead{RootHash: baseRoot, Paths: []ledger.Path{path}}
-		retValues, err := forest.Read(read)
+		retLeafHashes, err := forest.ReadLeafHashes(read)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(retValues))
+		require.Equal(t, 1, len(retLeafHashes))
 		if payload.IsEmpty() {
-			require.Equal(t, 0, len(retValues[0]))
+			require.Nil(t, retLeafHashes[0])
 		} else {
-			require.Equal(t, payload.Value(), retValues[0])
+			expected := hash.HashLeaf(hash.Hash(path), []byte(payload.Value()))
+			require.NotNil(t, retLeafHashes[0])
+			require.Equal(t, expected, *retLeafHashes[0])
 		}
 	}
 
-	// Read single value
+	// Read single leaf hash
 	for path, payload := range expectedPayloads {
 		read := &ledger.TrieReadSingleValue{RootHash: baseRoot, Path: path}
-		retValue, err := forest.ReadSingleValue(read)
+		retLeafHash, err := forest.ReadSingleLeafHash(read)
 		require.NoError(t, err)
 		if payload.IsEmpty() {
-			require.Equal(t, 0, len(retValue))
+			require.Nil(t, retLeafHash)
 		} else {
-			require.Equal(t, payload.Value(), retValue)
+			expected := hash.HashLeaf(hash.Hash(path), []byte(payload.Value()))
+			require.NotNil(t, retLeafHash)
+			require.Equal(t, expected, *retLeafHash)
 		}
 	}
 }
@@ -675,27 +648,21 @@ func TestForkingUpdates(t *testing.T) {
 	updatedRootB, err := forest.Update(updateB)
 	require.NoError(t, err)
 
-	// Verify payloads are preserved
+	// Verify leaf hashes are preserved
 	read := &ledger.TrieRead{RootHash: baseRoot, Paths: paths}
-	retValues, err := forest.Read(read) // reading from original Trie
+	retLeafHashes, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], payloads[i].Value())
-	}
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashes)
 
 	readA := &ledger.TrieRead{RootHash: updatedRootA, Paths: pathsA}
-	retValues, err = forest.Read(readA) // reading from updatedTrieA
+	retLeafHashes, err = forest.ReadLeafHashes(readA)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], payloadsA[i].Value())
-	}
+	requireLeafHashesMatch(t, pathsA, payloadsA, retLeafHashes)
 
 	readB := &ledger.TrieRead{RootHash: updatedRootB, Paths: pathsB}
-	retValues, err = forest.Read(readB) // reading from updatedTrieB
+	retLeafHashes, err = forest.ReadLeafHashes(readB)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValues[i], payloadsB[i].Value())
-	}
+	requireLeafHashesMatch(t, pathsB, payloadsB, retLeafHashes)
 }
 
 // TestIdenticalUpdateAppliedTwice updates a base trie in the same way twice.
@@ -728,227 +695,14 @@ func TestIdenticalUpdateAppliedTwice(t *testing.T) {
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRootA, Paths: paths}
-	retValuesA, err := forest.Read(read)
+	retLeafHashesA, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValuesA[i], payloads[i].Value())
-	}
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashesA)
 
 	read = &ledger.TrieRead{RootHash: updatedRootB, Paths: paths}
-	retValuesB, err := forest.Read(read)
+	retLeafHashesB, err := forest.ReadLeafHashes(read)
 	require.NoError(t, err)
-	for i := range paths {
-		require.Equal(t, retValuesB[i], payloads[i].Value())
-	}
-}
-
-func TestNonExistingInvalidProof(t *testing.T) {
-	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
-	require.NoError(t, err)
-	paths := testutils.RandomPaths(2)
-	payloads := testutils.RandomPayloads(len(paths), 10, 20)
-
-	existingPaths := paths[1:]
-	existingPayloads := payloads[1:]
-
-	nonExistingPaths := paths[:1]
-
-	activeRoot := forest.GetEmptyRootHash()
-
-	// adding a payload to a path
-	update := &ledger.TrieUpdate{RootHash: activeRoot, Paths: existingPaths, Payloads: existingPayloads}
-	activeRoot, err = forest.Update(update)
-	require.NoError(t, err, "error updating")
-
-	// reading proof for nonExistingPaths
-	read := &ledger.TrieRead{RootHash: activeRoot, Paths: nonExistingPaths}
-	batchProof, err := forest.Proofs(read)
-	require.NoError(t, err, "error generating proofs")
-
-	// now a malicious node modifies the proof to be Inclusion false
-	// and change the proof such that one interim node has invalid hash
-	batchProof.Proofs[0].Inclusion = false
-	batchProof.Proofs[0].Interims[0] = hash.DummyHash
-
-	// expect the VerifyTrieBatchProof should return false
-	require.False(t, prf.VerifyTrieBatchProof(batchProof, ledger.State(activeRoot)))
-}
-
-// TestRandomUpdateReadProofValueSizes repeats a sequence of actions update, read, get value sizes, and proof random paths
-// this simulates the common pattern of actions on flow
-func TestRandomUpdateReadProofValueSizes(t *testing.T) {
-
-	minPayloadByteSize := 2
-	maxPayloadByteSize := 10
-	rep := 10
-	maxNumPathsPerStep := 10
-	seed := time.Now().UnixNano()
-	t.Log(seed)
-
-	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
-	require.NoError(t, err)
-
-	activeRoot := forest.GetEmptyRootHash()
-	require.NoError(t, err)
-	latestPayloadByPath := make(map[ledger.Path]*ledger.Payload) // map store
-
-	for e := 0; e < rep; e++ {
-		paths := testutils.RandomPathsRandLen(maxNumPathsPerStep)
-		payloads := testutils.RandomPayloads(len(paths), minPayloadByteSize, maxPayloadByteSize)
-
-		// update map store with key values
-		// we use this at the end of each step to check all existing keys
-		for i, p := range paths {
-			latestPayloadByPath[p] = payloads[i]
-		}
-
-		// test reading for non-existing keys
-		nonExistingPaths := make([]ledger.Path, 0)
-		otherPaths := testutils.RandomPathsRandLen(maxNumPathsPerStep)
-		for _, p := range otherPaths {
-			if _, ok := latestPayloadByPath[p]; !ok {
-				nonExistingPaths = append(nonExistingPaths, p)
-			}
-		}
-		read := &ledger.TrieRead{RootHash: activeRoot, Paths: nonExistingPaths}
-		retValues, err := forest.Read(read)
-		require.NoError(t, err, "error reading - non existing paths")
-		for _, p := range retValues {
-			require.Equal(t, 0, len(p))
-		}
-
-		// test value sizes for non-existent keys
-		retValueSizes, err := forest.ValueSizes(read)
-		require.NoError(t, err, "error value sizes - non existent paths")
-		require.Equal(t, len(read.Paths), len(retValueSizes))
-		for _, size := range retValueSizes {
-			require.Equal(t, 0, size)
-		}
-
-		// test update
-		update := &ledger.TrieUpdate{RootHash: activeRoot, Paths: paths, Payloads: payloads}
-		activeRoot, err = forest.Update(update)
-		require.NoError(t, err, "error updating")
-
-		// test read
-		read = &ledger.TrieRead{RootHash: activeRoot, Paths: paths}
-		retValues, err = forest.Read(read)
-		require.NoError(t, err, "error reading")
-		for i := range payloads {
-			require.Equal(t, retValues[i], payloads[i].Value())
-		}
-
-		// test value sizes for existing keys
-		retValueSizes, err = forest.ValueSizes(read)
-		require.NoError(t, err, "error value sizes")
-		require.Equal(t, len(read.Paths), len(retValueSizes))
-		for i := range payloads {
-			require.Equal(t, payloads[i].Value().Size(), retValueSizes[i])
-		}
-
-		// test proof (mix of existing and non existing keys)
-		proofPaths := make([]ledger.Path, 0)
-		proofPaths = append(proofPaths, paths...)
-		proofPaths = append(proofPaths, nonExistingPaths...)
-
-		// shuffle the order of `proofPaths` to run `Proofs` on non-sorted input paths
-		rand.Shuffle(len(proofPaths), func(i, j int) {
-			proofPaths[i], proofPaths[j] = proofPaths[j], proofPaths[i]
-		})
-
-		// sort `proofPaths` into another slice
-		sortedPaths := sortedCopy(proofPaths)
-
-		read = &ledger.TrieRead{RootHash: activeRoot, Paths: proofPaths}
-		batchProof, err := forest.Proofs(read)
-		require.NoError(t, err, "error generating proofs")
-		assert.True(t, prf.VerifyTrieBatchProof(batchProof, ledger.State(activeRoot)))
-
-		// check `Proofs` has sorted the input paths.
-		// this check is needed to not weaken the SPoCK secret entropy,
-		// when `Proofs` is used to generate chunk data.
-		assert.Equal(t, sortedPaths, read.Paths)
-
-		// build a partial trie from batch proofs and check the root hash is equal
-		psmt, err := ptrie.NewPSMT(activeRoot, batchProof)
-		require.NoError(t, err, "error building partial trie")
-		assert.Equal(t, psmt.RootHash(), activeRoot)
-
-		// check payloads for all existing paths
-		allPaths := make([]ledger.Path, 0, len(latestPayloadByPath))
-		allPayloads := make([]*ledger.Payload, 0, len(latestPayloadByPath))
-		for p, v := range latestPayloadByPath {
-			allPaths = append(allPaths, p)
-			allPayloads = append(allPayloads, v)
-		}
-
-		read = &ledger.TrieRead{RootHash: activeRoot, Paths: allPaths}
-		retValues, err = forest.Read(read)
-		require.NoError(t, err)
-		for i, v := range allPayloads {
-			assert.Equal(t, retValues[i], v.Value())
-		}
-
-		// check value sizes for all existing paths
-		retValueSizes, err = forest.ValueSizes(read)
-		require.NoError(t, err)
-		require.Equal(t, len(read.Paths), len(retValueSizes))
-		for i, v := range allPayloads {
-			assert.Equal(t, v.Value().Size(), retValueSizes[i])
-		}
-	}
-}
-
-func sortedCopy(paths []ledger.Path) []ledger.Path {
-	sortedPaths := make([]ledger.Path, len(paths))
-	copy(sortedPaths, paths)
-	sort.Slice(sortedPaths, func(i, j int) bool {
-		return bytes.Compare(sortedPaths[i][:], sortedPaths[j][:]) < 0
-	})
-	return sortedPaths
-}
-
-// TestProofGenerationInclusion tests that inclusion proofs generated by a Trie pass verification
-func TestProofGenerationInclusion(t *testing.T) {
-
-	metricsCollector := &metrics.NoopCollector{}
-	forest, err := NewForest(5, metricsCollector, nil)
-	require.NoError(t, err)
-	emptyRoot := forest.GetEmptyRootHash()
-
-	p1 := pathByUint8s([]uint8{uint8(1), uint8(74)})
-	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
-	p2 := pathByUint8s([]uint8{uint8(2), uint8(74)})
-	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
-	p3 := pathByUint8s([]uint8{uint8(130), uint8(74)})
-	v3 := payloadBySlices([]byte{'C'}, []byte{'C'})
-	p4 := pathByUint8s([]uint8{uint8(131), uint8(74)})
-	v4 := payloadBySlices([]byte{'D'}, []byte{'D'})
-	paths := []ledger.Path{p1, p2, p3, p4}
-	payloads := []*ledger.Payload{v1, v2, v3, v4}
-
-	// shuffle the order of `proofPaths` to run `Proofs` on non-sorted input paths
-	rand.Shuffle(len(paths), func(i, j int) {
-		paths[i], paths[j] = paths[j], paths[i]
-	})
-
-	// sort `proofPaths` into another slice
-	sortedPaths := sortedCopy(paths)
-
-	update := &ledger.TrieUpdate{RootHash: emptyRoot, Paths: paths, Payloads: payloads}
-	updatedRoot, err := forest.Update(update)
-	require.NoError(t, err)
-	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	proof, err := forest.Proofs(read)
-	require.NoError(t, err)
-
-	// verify batch proofs.
-	assert.True(t, prf.VerifyTrieBatchProof(proof, ledger.State(updatedRoot)))
-
-	// check `Proofs` has sorted the input paths.
-	// this check is needed to not weaken the SPoCK secret entropy,
-	// when `Proofs` is used to generate chunk data.
-	assert.Equal(t, sortedPaths, read.Paths)
+	requireLeafHashesMatch(t, paths, payloads, retLeafHashesB)
 }
 
 func payloadBySlices(keydata []byte, valuedata []byte) *ledger.Payload {
@@ -963,8 +717,24 @@ func pathByUint8s(inputs []uint8) ledger.Path {
 	return b
 }
 
-// TestValueSizesOrder tests returned value sizes are in the order as specified by the paths
-func TestValueSizesOrder(t *testing.T) {
+// requireLeafHashesMatch asserts that retLeafHashes[i] equals HashLeaf(paths[i], payloads[i].Value())
+// for each non-empty payload, and is nil otherwise.
+func requireLeafHashesMatch(t *testing.T, paths []ledger.Path, payloads []*ledger.Payload, retLeafHashes []*hash.Hash) {
+	t.Helper()
+	require.Equal(t, len(paths), len(retLeafHashes))
+	for i := range paths {
+		if payloads[i].IsEmpty() {
+			require.Nil(t, retLeafHashes[i], "expected nil leaf hash at index %d", i)
+			continue
+		}
+		require.NotNil(t, retLeafHashes[i], "expected non-nil leaf hash at index %d", i)
+		expected := hash.HashLeaf(hash.Hash(paths[i]), []byte(payloads[i].Value()))
+		require.Equal(t, expected, *retLeafHashes[i], "leaf hash mismatch at index %d", i)
+	}
+}
+
+// TestHasPathsOrder tests returned existence flags are in the order as specified by the paths
+func TestHasPathsOrder(t *testing.T) {
 
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
@@ -983,26 +753,26 @@ func TestValueSizesOrder(t *testing.T) {
 	baseRoot, err := forest.Update(update)
 	require.NoError(t, err)
 
-	// Get value sizes for paths {p1, p2}
+	// Get HasPaths for paths {p1, p2}
 	read := &ledger.TrieRead{RootHash: baseRoot, Paths: []ledger.Path{p1, p2}}
-	retValueSizes, err := forest.ValueSizes(read)
+	exists, err := forest.HasPaths(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retValueSizes))
-	require.Equal(t, v1.Value().Size(), retValueSizes[0])
-	require.Equal(t, v2.Value().Size(), retValueSizes[1])
+	require.Equal(t, len(read.Paths), len(exists))
+	require.True(t, exists[0])
+	require.True(t, exists[1])
 
-	// Get value sizes for paths {p2, p1}
+	// Get HasPaths for paths {p2, p1}
 	read = &ledger.TrieRead{RootHash: baseRoot, Paths: []ledger.Path{p2, p1}}
-	retValueSizes, err = forest.ValueSizes(read)
+	exists, err = forest.HasPaths(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retValueSizes))
-	require.Equal(t, v2.Value().Size(), retValueSizes[0])
-	require.Equal(t, v1.Value().Size(), retValueSizes[1])
+	require.Equal(t, len(read.Paths), len(exists))
+	require.True(t, exists[0])
+	require.True(t, exists[1])
 }
 
-// TestMixGetValueSizes tests value sizes of a mix of set and unset registers.
-// We expect value size 0 to be returned for unset registers.
-func TestMixGetValueSizes(t *testing.T) {
+// TestMixHasPaths tests HasPaths for a mix of set and unset registers.
+// We expect false to be returned for unset registers.
+func TestMixHasPaths(t *testing.T) {
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
 
@@ -1027,21 +797,20 @@ func TestMixGetValueSizes(t *testing.T) {
 	p4 := pathByUint8s([]uint8{uint8(23), uint8(82)})
 
 	readPaths := []ledger.Path{p1, p2, p3, p4}
-	expectedValueSizes := []int{v1.Value().Size(), v2.Value().Size(), 0, 0}
+	expected := []bool{true, true, false, false}
 
 	read := &ledger.TrieRead{RootHash: baseRoot, Paths: readPaths}
-	retValueSizes, err := forest.ValueSizes(read)
+	exists, err := forest.HasPaths(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retValueSizes))
+	require.Equal(t, len(read.Paths), len(exists))
 	for i := range read.Paths {
-		require.Equal(t, expectedValueSizes[i], retValueSizes[i])
+		require.Equal(t, expected[i], exists[i])
 	}
 }
 
-// TestValueSizesWithDuplicatedKeys gets value sizes for two keys,
-// where both keys have the same value.
-// We expect to receive same value sizes twice.
-func TestValueSizesWithDuplicatedKeys(t *testing.T) {
+// TestHasPathsWithDuplicatedKeys checks HasPaths for two keys, where both keys are equal.
+// We expect to receive the same existence flag twice.
+func TestHasPathsWithDuplicatedKeys(t *testing.T) {
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
 
@@ -1063,14 +832,14 @@ func TestValueSizesWithDuplicatedKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	readPaths := []ledger.Path{p1, p2, p3}
-	expectedValueSizes := []int{v1.Value().Size(), v2.Value().Size(), v1.Value().Size()}
+	expected := []bool{true, true, true}
 
 	read := &ledger.TrieRead{RootHash: baseRoot, Paths: readPaths}
-	retValueSizes, err := forest.ValueSizes(read)
+	exists, err := forest.HasPaths(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retValueSizes))
+	require.Equal(t, len(read.Paths), len(exists))
 	for i := range read.Paths {
-		require.Equal(t, expectedValueSizes[i], retValueSizes[i])
+		require.Equal(t, expected[i], exists[i])
 	}
 }
 
@@ -1078,11 +847,11 @@ func TestPurgeCacheExcept(t *testing.T) {
 	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
 	require.NoError(t, err)
 
-	nt := trie.NewEmptyMTrie()
+	nt := NewEmptyMTrie()
 	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
 	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
 
-	updatedTrie1, _, err := trie.NewTrieWithUpdatedRegisters(nt, []ledger.Path{p1}, []ledger.Payload{*v1}, true)
+	updatedTrie1, _, err := NewTrieWithUpdatedRegisters(nt, []ledger.Path{p1}, [][]byte{[]byte(v1.Value())}, true)
 	require.NoError(t, err)
 
 	err = forest.AddTrie(updatedTrie1)
@@ -1091,7 +860,7 @@ func TestPurgeCacheExcept(t *testing.T) {
 	p2 := pathByUint8s([]uint8{uint8(12), uint8(34)})
 	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
 
-	updatedTrie2, _, err := trie.NewTrieWithUpdatedRegisters(nt, []ledger.Path{p2}, []ledger.Payload{*v2}, true)
+	updatedTrie2, _, err := NewTrieWithUpdatedRegisters(nt, []ledger.Path{p2}, [][]byte{[]byte(v2.Value())}, true)
 	require.NoError(t, err)
 
 	err = forest.AddTrie(updatedTrie2)

--- a/ledger/complete/payloadless/forest_test.go
+++ b/ledger/complete/payloadless/forest_test.go
@@ -1,0 +1,1127 @@
+package mtrie
+
+import (
+	"bytes"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/hash"
+	prf "github.com/onflow/flow-go/ledger/common/proof"
+	"github.com/onflow/flow-go/ledger/common/testutils"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
+	"github.com/onflow/flow-go/ledger/partial/ptrie"
+	"github.com/onflow/flow-go/module/metrics"
+)
+
+// TestTrieOperations tests adding removing and retrieving Trie from Forest
+func TestTrieOperations(t *testing.T) {
+
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// Make new Trie (independently of MForest):
+	nt := trie.NewEmptyMTrie()
+	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(nt, []ledger.Path{p1}, []ledger.Payload{*v1}, true)
+	require.NoError(t, err)
+
+	// Add trie
+	err = forest.AddTrie(updatedTrie)
+	require.NoError(t, err)
+
+	// Get trie
+	retnt, err := forest.GetTrie(updatedTrie.RootHash())
+	require.NoError(t, err)
+	require.Equal(t, retnt.RootHash(), updatedTrie.RootHash())
+	require.Equal(t, 2, forest.Size())
+}
+
+// TestTrieUpdate updates the empty trie with some values and verifies that the
+// written values can be retrieved from the updated trie.
+func TestTrieUpdate(t *testing.T) {
+
+	metricsCollector := &metrics.NoopCollector{}
+	forest, err := NewForest(5, metricsCollector, nil)
+	require.NoError(t, err)
+	rootHash := forest.GetEmptyRootHash()
+
+	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	paths := []ledger.Path{p1}
+	payloads := []*ledger.Payload{v1}
+	update := &ledger.TrieUpdate{RootHash: rootHash, Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	require.Equal(t, retValues[0], payloads[0].Value())
+}
+
+// TestLeftEmptyInsert tests inserting a new value into an empty sub-trie:
+//  1. we first construct a baseTrie holding a couple of values on the right branch [~]
+//  2. we update a previously non-existent register on the left branch (X)
+//
+// We verify that values for _all_ paths in the updated Trie have correct payloads
+func TestLeftEmptyInsert(t *testing.T) {
+	//////////////////////
+	//     insert X     //
+	//       ()         //
+	//      /  \        //
+	//    (X)  [~]      //
+	//////////////////////
+
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 1000...
+	p1 := pathByUint8s([]uint8{uint8(129), uint8(1)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	// path: 1100...
+	p2 := pathByUint8s([]uint8{uint8(193), uint8(1)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	baseTrie, err := forest.GetTrie(baseRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), baseTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
+
+	p3 := pathByUint8s([]uint8{uint8(1), uint8(1)})
+	v3 := payloadBySlices([]byte{'C'}, []byte{'C'})
+
+	paths = []ledger.Path{p3}
+	payloads = []*ledger.Payload{v3}
+	update = &ledger.TrieUpdate{RootHash: baseTrie.RootHash(), Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	updatedTrie, err := forest.GetTrie(updatedRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), updatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
+	paths = []ledger.Path{p1, p2, p3}
+	payloads = []*ledger.Payload{v1, v2, v3}
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], payloads[i].Value())
+	}
+}
+
+// TestRightEmptyInsert tests inserting a new value into an empty sub-trie:
+//  1. we first construct a baseTrie holding a couple of values on the left branch [~]
+//  2. we update a previously non-existent register on the right branch (X)
+//
+// We verify that values for _all_ paths in the updated Trie have correct payloads
+func TestRightEmptyInsert(t *testing.T) {
+	///////////////////////
+	//     insert X      //
+	//       ()          //
+	//      /  \         //
+	//    [~]  (X)       //
+	///////////////////////
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 0000...
+	p1 := pathByUint8s([]uint8{uint8(1), uint8(1)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	// path: 0100...
+	p2 := pathByUint8s([]uint8{uint8(64), uint8(1)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	baseTrie, err := forest.GetTrie(baseRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), baseTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
+
+	// path: 1000...
+	p3 := pathByUint8s([]uint8{uint8(129), uint8(1)})
+	v3 := payloadBySlices([]byte{'C'}, []byte{'C'})
+
+	paths = []ledger.Path{p3}
+	payloads = []*ledger.Payload{v3}
+	update = &ledger.TrieUpdate{RootHash: baseTrie.RootHash(), Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	updatedTrie, err := forest.GetTrie(updatedRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), updatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
+
+	paths = []ledger.Path{p1, p2, p3}
+	payloads = []*ledger.Payload{v1, v2, v3}
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], payloads[i].Value())
+	}
+}
+
+// TestExpansionInsert tests inserting a new value into a populated sub-trie, where a
+// leaf (holding a single value) would be replaced by an expanded sub-trie holding multiple value
+//  1. we first construct a baseTrie holding a couple of values on the right branch [~]
+//  2. we update a previously non-existent register on the right branch turning [~] to [~']
+//
+// We verify that values for _all_ paths in the updated Trie have correct payloads
+func TestExpansionInsert(t *testing.T) {
+	////////////////////////
+	// modify [~] -> [~'] //
+	//       ()           //
+	//      /  \          //
+	//         [~]        //
+	////////////////////////
+
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 100000...
+	p1 := pathByUint8s([]uint8{uint8(129), uint8(1)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	paths := []ledger.Path{p1}
+	payloads := []*ledger.Payload{v1}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	baseTrie, err := forest.GetTrie(baseRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), baseTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v1.Size()), baseTrie.AllocatedRegSize())
+
+	// path: 1000001...
+	p2 := pathByUint8s([]uint8{uint8(130), uint8(1)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths = []ledger.Path{p2}
+	payloads = []*ledger.Payload{v2}
+	update = &ledger.TrieUpdate{RootHash: baseTrie.RootHash(), Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	updatedTrie, err := forest.GetTrie(updatedRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), updatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v1.Size()+v2.Size()), updatedTrie.AllocatedRegSize())
+
+	paths = []ledger.Path{p1, p2}
+	payloads = []*ledger.Payload{v1, v2}
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], payloads[i].Value())
+	}
+}
+
+// TestFullHouseInsert tests inserting a new value into a populated sub-trie, where a
+// leaf's value is overridden _and_ further values are added which all fall into a subtree that
+// replaces the leaf:
+//  1. we first construct a baseTrie holding a couple of values on the right branch [~]
+//  2. we update a previously non-existent register on the right branch turning [~] to [~']
+//
+// We verify that values for _all_ paths in the updated Trie have correct payloads
+func TestFullHouseInsert(t *testing.T) {
+	///////////////////////
+	//   insert ~1<X<~2  //
+	//       ()          //
+	//      /  \         //
+	//    [~1]  [~2]     //
+	///////////////////////
+
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// paths p0 forms [~1]; p1 and p2 form [~2]
+	// path: 0100...
+	p0 := pathByUint8s([]uint8{uint8(64), uint8(1)})
+	v0 := payloadBySlices([]byte{'0'}, []byte{'0'})
+	// path: 1000...
+	p1 := pathByUint8s([]uint8{uint8(129), uint8(1)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	// path: 1100...
+	p2 := pathByUint8s([]uint8{uint8(193), uint8(1)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths := []ledger.Path{p0, p1, p2}
+	payloads := []*ledger.Payload{v0, v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	baseTrie, err := forest.GetTrie(baseRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), baseTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v0.Size()+v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
+
+	// we update value for path p1 and in addition add p3 that has the same prefix `10` as p1
+	v1 = payloadBySlices([]byte{'X'}, []byte{'X'})
+
+	// path: 1010...
+	p3 := pathByUint8s([]uint8{uint8(160), uint8(1)})
+	v3 := payloadBySlices([]byte{'C'}, []byte{'C'})
+
+	paths = []ledger.Path{p1, p3}
+	payloads = []*ledger.Payload{v1, v3}
+	update = &ledger.TrieUpdate{RootHash: baseTrie.RootHash(), Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	updatedTrie, err := forest.GetTrie(updatedRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(4), updatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v0.Size()+v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
+
+	paths = []ledger.Path{p1, p2, p3}
+	payloads = []*ledger.Payload{v1, v2, v3}
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], payloads[i].Value())
+	}
+}
+
+// TestLeafInsert inserts two keys, which only differ in their last bit.
+// I.e. the trie needs to be expanded to its hull depth
+// We verify that values for _all_ paths in the updated Trie have correct payloads
+func TestLeafInsert(t *testing.T) {
+	///////////////////////
+	//   insert 1, 2     //
+	//       ()          //
+	//      /  \         //
+	//     ()   ...      //
+	//          /  \     //
+	//         ()  ()    //
+	///////////////////////
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 000...0000000100000000
+	p1 := testutils.PathByUint16LeftPadded(256)
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	// path: 000...0000000100000001
+	p2 := testutils.PathByUint16LeftPadded(257)
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	updatedTrie, err := forest.GetTrie(updatedRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), updatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(v1.Size()+v2.Size()), updatedTrie.AllocatedRegSize())
+
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], payloads[i].Value())
+	}
+}
+
+// TestOverrideValue overrides an existing value in the trie (without any expansion)
+// We verify that values for _all_ paths in the updated Trie have correct payloads
+func TestOverrideValue(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 1000...
+	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	// path: 0111...
+	p2 := pathByUint8s([]uint8{uint8(116), uint8(129)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	// path: 1000...
+	p3 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v3 := payloadBySlices([]byte{'C'}, []byte{'C'})
+
+	paths = []ledger.Path{p3}
+	payloads = []*ledger.Payload{v3}
+	update = &ledger.TrieUpdate{RootHash: baseRoot, Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	require.Equal(t, retValues[0], payloads[0].Value())
+
+}
+
+// TestDuplicateOverride tests behaviour when the updates contain two different payloads for the
+// same path. I.e. we update with (p0, v0) and (p0, v1)
+// We expect that the _last_ written value is persisted in the Trie
+func TestDuplicateOverride(t *testing.T) {
+
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 1000...
+	p0 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v0 := payloadBySlices([]byte{'A'}, []byte{'A'})
+	paths := []ledger.Path{p0}
+	payloads := []*ledger.Payload{v0}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	v1 := payloadBySlices([]byte{'B'}, []byte{'B'})
+	v2 := payloadBySlices([]byte{'C'}, []byte{'C'})
+	paths = []ledger.Path{p0, p0}
+	payloads = []*ledger.Payload{v1, v2}
+	update = &ledger.TrieUpdate{RootHash: baseRoot, Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	paths = []ledger.Path{p0}
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	require.Equal(t, retValues[0], v2.Value())
+
+}
+
+// TestReadSafety check if payload returned from a forest are safe against modification,
+// ie. copy of the data is returned, instead of a slice
+func TestReadSafety(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 1000...
+	p0 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v0 := payloadBySlices([]byte{'A'}, []byte{'A'})
+	paths := []ledger.Path{p0}
+	payloads := []*ledger.Payload{v0}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	read := &ledger.TrieRead{RootHash: baseRoot, Paths: paths}
+	data, err := forest.Read(read)
+	require.NoError(t, err)
+
+	require.Len(t, data, 1)
+	require.Equal(t, v0.Value(), data[0])
+
+	// modify returned slice
+	data[0] = []byte("new value")
+
+	// read again
+	data2, err := forest.Read(read)
+	require.NoError(t, err)
+	require.Len(t, data2, 1)
+	require.Equal(t, v0.Value(), data2[0])
+}
+
+// TestReadOrder tests that payloads from reading a trie are delivered in the order as specified by the paths
+func TestReadOrder(t *testing.T) {
+
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	p1 := pathByUint8s([]uint8{uint8(116), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	p2 := pathByUint8s([]uint8{uint8(53), uint8(129)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	testRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	read := &ledger.TrieRead{RootHash: testRoot, Paths: []ledger.Path{p1, p2}}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	require.Equal(t, len(read.Paths), len(retValues))
+	require.Equal(t, retValues[0], payloads[0].Value())
+	require.Equal(t, retValues[1], payloads[1].Value())
+
+	read = &ledger.TrieRead{RootHash: testRoot, Paths: []ledger.Path{p2, p1}}
+	retValues, err = forest.Read(read)
+	require.NoError(t, err)
+	require.Equal(t, len(read.Paths), len(retValues))
+	require.Equal(t, retValues[1], payloads[0].Value())
+	require.Equal(t, retValues[0], payloads[1].Value())
+}
+
+// TestMixRead tests reading a mixture of set and unset registers.
+// We expect the default payload (nil) to be returned for unset registers.
+func TestMixRead(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 01111101...
+	p1 := pathByUint8s([]uint8{uint8(125), uint8(23)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	// path: 10110010...
+	p2 := pathByUint8s([]uint8{uint8(178), uint8(152)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	// path: 01101110...
+	p3 := pathByUint8s([]uint8{uint8(110), uint8(48)})
+	v3 := ledger.EmptyPayload()
+
+	// path: 00010111...
+	p4 := pathByUint8s([]uint8{uint8(23), uint8(82)})
+	v4 := ledger.EmptyPayload()
+
+	readPaths := []ledger.Path{p1, p2, p3, p4}
+	expectedPayloads := []*ledger.Payload{v1, v2, v3, v4}
+
+	read := &ledger.TrieRead{RootHash: baseRoot, Paths: readPaths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], expectedPayloads[i].Value())
+	}
+}
+
+// TestReadWithDuplicatedKeys reads a the values for two keys, where both keys have the same value.
+// We expect that we receive the respective value twice in the return.
+func TestReadWithDuplicatedKeys(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+	p2 := pathByUint8s([]uint8{uint8(116), uint8(129)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+	p3 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	paths = []ledger.Path{p1, p2, p3}
+	expectedPayloads := []*ledger.Payload{v1, v2, v1}
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	require.Equal(t, len(read.Paths), len(retValues))
+	for i := range paths {
+		require.Equal(t, retValues[i], expectedPayloads[i].Value())
+	}
+}
+
+// TestReadNonExistingPath tests reading an unset path.
+func TestReadNonExistingPath(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+	paths := []ledger.Path{p1}
+	payloads := []*ledger.Payload{v1}
+
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	p2 := pathByUint8s([]uint8{uint8(116), uint8(129)})
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: []ledger.Path{p2}}
+	retValues, err := forest.Read(read)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(retValues[0]))
+}
+
+// TestReadSinglePayload tests reading a single payload of set/unset register.
+func TestReadSinglePayload(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 01111101...
+	path1 := pathByUint8s([]uint8{uint8(125), uint8(23)})
+	payload1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	// path: 10110010...
+	path2 := pathByUint8s([]uint8{uint8(178), uint8(152)})
+	payload2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	paths := []ledger.Path{path1, path2}
+	payloads := []*ledger.Payload{payload1, payload2}
+
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	// path: 01101110...
+	path3 := pathByUint8s([]uint8{uint8(110), uint8(48)})
+	payload3 := ledger.EmptyPayload()
+
+	// path: 00010111...
+	path4 := pathByUint8s([]uint8{uint8(23), uint8(82)})
+	payload4 := ledger.EmptyPayload()
+
+	expectedPayloads := make(map[ledger.Path]*ledger.Payload)
+	expectedPayloads[path1] = payload1
+	expectedPayloads[path2] = payload2
+	expectedPayloads[path3] = payload3
+	expectedPayloads[path4] = payload4
+
+	// Batch read one payload at a time (less efficient)
+	for path, payload := range expectedPayloads {
+		read := &ledger.TrieRead{RootHash: baseRoot, Paths: []ledger.Path{path}}
+		retValues, err := forest.Read(read)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(retValues))
+		if payload.IsEmpty() {
+			require.Equal(t, 0, len(retValues[0]))
+		} else {
+			require.Equal(t, payload.Value(), retValues[0])
+		}
+	}
+
+	// Read single value
+	for path, payload := range expectedPayloads {
+		read := &ledger.TrieReadSingleValue{RootHash: baseRoot, Path: path}
+		retValue, err := forest.ReadSingleValue(read)
+		require.NoError(t, err)
+		if payload.IsEmpty() {
+			require.Equal(t, 0, len(retValue))
+		} else {
+			require.Equal(t, payload.Value(), retValue)
+		}
+	}
+}
+
+// TestForkingUpdates updates a base trie in two different ways. We expect
+// that for each update, a new trie is added to the forest preserving the
+// updated values independently of the other update.
+func TestForkingUpdates(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+	p2 := pathByUint8s([]uint8{uint8(116), uint8(129)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	// update baseTrie -> updatedTrieA
+	v1a := payloadBySlices([]byte{'C'}, []byte{'C'})
+	p3a := pathByUint8s([]uint8{uint8(116), uint8(22)})
+	v3a := payloadBySlices([]byte{'D'}, []byte{'D'})
+	pathsA := []ledger.Path{p1, p3a}
+	payloadsA := []*ledger.Payload{v1a, v3a}
+	updateA := &ledger.TrieUpdate{RootHash: baseRoot, Paths: pathsA, Payloads: payloadsA}
+	updatedRootA, err := forest.Update(updateA)
+	require.NoError(t, err)
+
+	// update baseTrie -> updatedTrieB
+	v1b := payloadBySlices([]byte{'E'}, []byte{'E'})
+	p3b := pathByUint8s([]uint8{uint8(116), uint8(22)})
+	v3b := payloadBySlices([]byte{'F'}, []byte{'F'})
+	pathsB := []ledger.Path{p1, p3b}
+	payloadsB := []*ledger.Payload{v1b, v3b}
+	updateB := &ledger.TrieUpdate{RootHash: baseRoot, Paths: pathsB, Payloads: payloadsB}
+	updatedRootB, err := forest.Update(updateB)
+	require.NoError(t, err)
+
+	// Verify payloads are preserved
+	read := &ledger.TrieRead{RootHash: baseRoot, Paths: paths}
+	retValues, err := forest.Read(read) // reading from original Trie
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], payloads[i].Value())
+	}
+
+	readA := &ledger.TrieRead{RootHash: updatedRootA, Paths: pathsA}
+	retValues, err = forest.Read(readA) // reading from updatedTrieA
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], payloadsA[i].Value())
+	}
+
+	readB := &ledger.TrieRead{RootHash: updatedRootB, Paths: pathsB}
+	retValues, err = forest.Read(readB) // reading from updatedTrieB
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValues[i], payloadsB[i].Value())
+	}
+}
+
+// TestIdenticalUpdateAppliedTwice updates a base trie in the same way twice.
+// Hence, the forest should de-duplicate the resulting two version of the identical trie
+// without an error.
+func TestIdenticalUpdateAppliedTwice(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+	p2 := pathByUint8s([]uint8{uint8(116), uint8(129)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	p3 := pathByUint8s([]uint8{uint8(116), uint8(22)})
+	v3 := payloadBySlices([]byte{'D'}, []byte{'D'})
+
+	update = &ledger.TrieUpdate{RootHash: baseRoot, Paths: []ledger.Path{p3}, Payloads: []*ledger.Payload{v3}}
+	updatedRootA, err := forest.Update(update)
+	require.NoError(t, err)
+	updatedRootB, err := forest.Update(update)
+	require.NoError(t, err)
+	require.Equal(t, updatedRootA, updatedRootB)
+
+	paths = []ledger.Path{p1, p2, p3}
+	payloads = []*ledger.Payload{v1, v2, v3}
+	read := &ledger.TrieRead{RootHash: updatedRootA, Paths: paths}
+	retValuesA, err := forest.Read(read)
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValuesA[i], payloads[i].Value())
+	}
+
+	read = &ledger.TrieRead{RootHash: updatedRootB, Paths: paths}
+	retValuesB, err := forest.Read(read)
+	require.NoError(t, err)
+	for i := range paths {
+		require.Equal(t, retValuesB[i], payloads[i].Value())
+	}
+}
+
+func TestNonExistingInvalidProof(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+	paths := testutils.RandomPaths(2)
+	payloads := testutils.RandomPayloads(len(paths), 10, 20)
+
+	existingPaths := paths[1:]
+	existingPayloads := payloads[1:]
+
+	nonExistingPaths := paths[:1]
+
+	activeRoot := forest.GetEmptyRootHash()
+
+	// adding a payload to a path
+	update := &ledger.TrieUpdate{RootHash: activeRoot, Paths: existingPaths, Payloads: existingPayloads}
+	activeRoot, err = forest.Update(update)
+	require.NoError(t, err, "error updating")
+
+	// reading proof for nonExistingPaths
+	read := &ledger.TrieRead{RootHash: activeRoot, Paths: nonExistingPaths}
+	batchProof, err := forest.Proofs(read)
+	require.NoError(t, err, "error generating proofs")
+
+	// now a malicious node modifies the proof to be Inclusion false
+	// and change the proof such that one interim node has invalid hash
+	batchProof.Proofs[0].Inclusion = false
+	batchProof.Proofs[0].Interims[0] = hash.DummyHash
+
+	// expect the VerifyTrieBatchProof should return false
+	require.False(t, prf.VerifyTrieBatchProof(batchProof, ledger.State(activeRoot)))
+}
+
+// TestRandomUpdateReadProofValueSizes repeats a sequence of actions update, read, get value sizes, and proof random paths
+// this simulates the common pattern of actions on flow
+func TestRandomUpdateReadProofValueSizes(t *testing.T) {
+
+	minPayloadByteSize := 2
+	maxPayloadByteSize := 10
+	rep := 10
+	maxNumPathsPerStep := 10
+	seed := time.Now().UnixNano()
+	t.Log(seed)
+
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	activeRoot := forest.GetEmptyRootHash()
+	require.NoError(t, err)
+	latestPayloadByPath := make(map[ledger.Path]*ledger.Payload) // map store
+
+	for e := 0; e < rep; e++ {
+		paths := testutils.RandomPathsRandLen(maxNumPathsPerStep)
+		payloads := testutils.RandomPayloads(len(paths), minPayloadByteSize, maxPayloadByteSize)
+
+		// update map store with key values
+		// we use this at the end of each step to check all existing keys
+		for i, p := range paths {
+			latestPayloadByPath[p] = payloads[i]
+		}
+
+		// test reading for non-existing keys
+		nonExistingPaths := make([]ledger.Path, 0)
+		otherPaths := testutils.RandomPathsRandLen(maxNumPathsPerStep)
+		for _, p := range otherPaths {
+			if _, ok := latestPayloadByPath[p]; !ok {
+				nonExistingPaths = append(nonExistingPaths, p)
+			}
+		}
+		read := &ledger.TrieRead{RootHash: activeRoot, Paths: nonExistingPaths}
+		retValues, err := forest.Read(read)
+		require.NoError(t, err, "error reading - non existing paths")
+		for _, p := range retValues {
+			require.Equal(t, 0, len(p))
+		}
+
+		// test value sizes for non-existent keys
+		retValueSizes, err := forest.ValueSizes(read)
+		require.NoError(t, err, "error value sizes - non existent paths")
+		require.Equal(t, len(read.Paths), len(retValueSizes))
+		for _, size := range retValueSizes {
+			require.Equal(t, 0, size)
+		}
+
+		// test update
+		update := &ledger.TrieUpdate{RootHash: activeRoot, Paths: paths, Payloads: payloads}
+		activeRoot, err = forest.Update(update)
+		require.NoError(t, err, "error updating")
+
+		// test read
+		read = &ledger.TrieRead{RootHash: activeRoot, Paths: paths}
+		retValues, err = forest.Read(read)
+		require.NoError(t, err, "error reading")
+		for i := range payloads {
+			require.Equal(t, retValues[i], payloads[i].Value())
+		}
+
+		// test value sizes for existing keys
+		retValueSizes, err = forest.ValueSizes(read)
+		require.NoError(t, err, "error value sizes")
+		require.Equal(t, len(read.Paths), len(retValueSizes))
+		for i := range payloads {
+			require.Equal(t, payloads[i].Value().Size(), retValueSizes[i])
+		}
+
+		// test proof (mix of existing and non existing keys)
+		proofPaths := make([]ledger.Path, 0)
+		proofPaths = append(proofPaths, paths...)
+		proofPaths = append(proofPaths, nonExistingPaths...)
+
+		// shuffle the order of `proofPaths` to run `Proofs` on non-sorted input paths
+		rand.Shuffle(len(proofPaths), func(i, j int) {
+			proofPaths[i], proofPaths[j] = proofPaths[j], proofPaths[i]
+		})
+
+		// sort `proofPaths` into another slice
+		sortedPaths := sortedCopy(proofPaths)
+
+		read = &ledger.TrieRead{RootHash: activeRoot, Paths: proofPaths}
+		batchProof, err := forest.Proofs(read)
+		require.NoError(t, err, "error generating proofs")
+		assert.True(t, prf.VerifyTrieBatchProof(batchProof, ledger.State(activeRoot)))
+
+		// check `Proofs` has sorted the input paths.
+		// this check is needed to not weaken the SPoCK secret entropy,
+		// when `Proofs` is used to generate chunk data.
+		assert.Equal(t, sortedPaths, read.Paths)
+
+		// build a partial trie from batch proofs and check the root hash is equal
+		psmt, err := ptrie.NewPSMT(activeRoot, batchProof)
+		require.NoError(t, err, "error building partial trie")
+		assert.Equal(t, psmt.RootHash(), activeRoot)
+
+		// check payloads for all existing paths
+		allPaths := make([]ledger.Path, 0, len(latestPayloadByPath))
+		allPayloads := make([]*ledger.Payload, 0, len(latestPayloadByPath))
+		for p, v := range latestPayloadByPath {
+			allPaths = append(allPaths, p)
+			allPayloads = append(allPayloads, v)
+		}
+
+		read = &ledger.TrieRead{RootHash: activeRoot, Paths: allPaths}
+		retValues, err = forest.Read(read)
+		require.NoError(t, err)
+		for i, v := range allPayloads {
+			assert.Equal(t, retValues[i], v.Value())
+		}
+
+		// check value sizes for all existing paths
+		retValueSizes, err = forest.ValueSizes(read)
+		require.NoError(t, err)
+		require.Equal(t, len(read.Paths), len(retValueSizes))
+		for i, v := range allPayloads {
+			assert.Equal(t, v.Value().Size(), retValueSizes[i])
+		}
+	}
+}
+
+func sortedCopy(paths []ledger.Path) []ledger.Path {
+	sortedPaths := make([]ledger.Path, len(paths))
+	copy(sortedPaths, paths)
+	sort.Slice(sortedPaths, func(i, j int) bool {
+		return bytes.Compare(sortedPaths[i][:], sortedPaths[j][:]) < 0
+	})
+	return sortedPaths
+}
+
+// TestProofGenerationInclusion tests that inclusion proofs generated by a Trie pass verification
+func TestProofGenerationInclusion(t *testing.T) {
+
+	metricsCollector := &metrics.NoopCollector{}
+	forest, err := NewForest(5, metricsCollector, nil)
+	require.NoError(t, err)
+	emptyRoot := forest.GetEmptyRootHash()
+
+	p1 := pathByUint8s([]uint8{uint8(1), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+	p2 := pathByUint8s([]uint8{uint8(2), uint8(74)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+	p3 := pathByUint8s([]uint8{uint8(130), uint8(74)})
+	v3 := payloadBySlices([]byte{'C'}, []byte{'C'})
+	p4 := pathByUint8s([]uint8{uint8(131), uint8(74)})
+	v4 := payloadBySlices([]byte{'D'}, []byte{'D'})
+	paths := []ledger.Path{p1, p2, p3, p4}
+	payloads := []*ledger.Payload{v1, v2, v3, v4}
+
+	// shuffle the order of `proofPaths` to run `Proofs` on non-sorted input paths
+	rand.Shuffle(len(paths), func(i, j int) {
+		paths[i], paths[j] = paths[j], paths[i]
+	})
+
+	// sort `proofPaths` into another slice
+	sortedPaths := sortedCopy(paths)
+
+	update := &ledger.TrieUpdate{RootHash: emptyRoot, Paths: paths, Payloads: payloads}
+	updatedRoot, err := forest.Update(update)
+	require.NoError(t, err)
+	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
+	proof, err := forest.Proofs(read)
+	require.NoError(t, err)
+
+	// verify batch proofs.
+	assert.True(t, prf.VerifyTrieBatchProof(proof, ledger.State(updatedRoot)))
+
+	// check `Proofs` has sorted the input paths.
+	// this check is needed to not weaken the SPoCK secret entropy,
+	// when `Proofs` is used to generate chunk data.
+	assert.Equal(t, sortedPaths, read.Paths)
+}
+
+func payloadBySlices(keydata []byte, valuedata []byte) *ledger.Payload {
+	key := ledger.Key{KeyParts: []ledger.KeyPart{{Type: 0, Value: keydata}}}
+	value := ledger.Value(valuedata)
+	return ledger.NewPayload(key, value)
+}
+
+func pathByUint8s(inputs []uint8) ledger.Path {
+	var b ledger.Path
+	copy(b[:], inputs)
+	return b
+}
+
+// TestValueSizesOrder tests returned value sizes are in the order as specified by the paths
+func TestValueSizesOrder(t *testing.T) {
+
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 01111101...
+	p1 := pathByUint8s([]uint8{uint8(125), uint8(23)})
+	v1 := testutils.RandomPayload(1, 100)
+
+	// path: 10110010...
+	p2 := pathByUint8s([]uint8{uint8(178), uint8(152)})
+	v2 := testutils.RandomPayload(1, 100)
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	// Get value sizes for paths {p1, p2}
+	read := &ledger.TrieRead{RootHash: baseRoot, Paths: []ledger.Path{p1, p2}}
+	retValueSizes, err := forest.ValueSizes(read)
+	require.NoError(t, err)
+	require.Equal(t, len(read.Paths), len(retValueSizes))
+	require.Equal(t, v1.Value().Size(), retValueSizes[0])
+	require.Equal(t, v2.Value().Size(), retValueSizes[1])
+
+	// Get value sizes for paths {p2, p1}
+	read = &ledger.TrieRead{RootHash: baseRoot, Paths: []ledger.Path{p2, p1}}
+	retValueSizes, err = forest.ValueSizes(read)
+	require.NoError(t, err)
+	require.Equal(t, len(read.Paths), len(retValueSizes))
+	require.Equal(t, v2.Value().Size(), retValueSizes[0])
+	require.Equal(t, v1.Value().Size(), retValueSizes[1])
+}
+
+// TestMixGetValueSizes tests value sizes of a mix of set and unset registers.
+// We expect value size 0 to be returned for unset registers.
+func TestMixGetValueSizes(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 01111101...
+	p1 := pathByUint8s([]uint8{uint8(125), uint8(23)})
+	v1 := testutils.RandomPayload(1, 100)
+
+	// path: 10110010...
+	p2 := pathByUint8s([]uint8{uint8(178), uint8(152)})
+	v2 := testutils.RandomPayload(1, 100)
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	// path: 01101110...
+	p3 := pathByUint8s([]uint8{uint8(110), uint8(48)})
+
+	// path: 00010111...
+	p4 := pathByUint8s([]uint8{uint8(23), uint8(82)})
+
+	readPaths := []ledger.Path{p1, p2, p3, p4}
+	expectedValueSizes := []int{v1.Value().Size(), v2.Value().Size(), 0, 0}
+
+	read := &ledger.TrieRead{RootHash: baseRoot, Paths: readPaths}
+	retValueSizes, err := forest.ValueSizes(read)
+	require.NoError(t, err)
+	require.Equal(t, len(read.Paths), len(retValueSizes))
+	for i := range read.Paths {
+		require.Equal(t, expectedValueSizes[i], retValueSizes[i])
+	}
+}
+
+// TestValueSizesWithDuplicatedKeys gets value sizes for two keys,
+// where both keys have the same value.
+// We expect to receive same value sizes twice.
+func TestValueSizesWithDuplicatedKeys(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	// path: 01111101...
+	p1 := pathByUint8s([]uint8{uint8(125), uint8(23)})
+	v1 := testutils.RandomPayload(1, 100)
+
+	// path: 10110010...
+	p2 := pathByUint8s([]uint8{uint8(178), uint8(152)})
+	v2 := testutils.RandomPayload(1, 100)
+
+	// same path as p1
+	p3 := pathByUint8s([]uint8{uint8(125), uint8(23)})
+
+	paths := []ledger.Path{p1, p2}
+	payloads := []*ledger.Payload{v1, v2}
+	update := &ledger.TrieUpdate{RootHash: forest.GetEmptyRootHash(), Paths: paths, Payloads: payloads}
+	baseRoot, err := forest.Update(update)
+	require.NoError(t, err)
+
+	readPaths := []ledger.Path{p1, p2, p3}
+	expectedValueSizes := []int{v1.Value().Size(), v2.Value().Size(), v1.Value().Size()}
+
+	read := &ledger.TrieRead{RootHash: baseRoot, Paths: readPaths}
+	retValueSizes, err := forest.ValueSizes(read)
+	require.NoError(t, err)
+	require.Equal(t, len(read.Paths), len(retValueSizes))
+	for i := range read.Paths {
+		require.Equal(t, expectedValueSizes[i], retValueSizes[i])
+	}
+}
+
+func TestPurgeCacheExcept(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+
+	nt := trie.NewEmptyMTrie()
+	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
+	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
+
+	updatedTrie1, _, err := trie.NewTrieWithUpdatedRegisters(nt, []ledger.Path{p1}, []ledger.Payload{*v1}, true)
+	require.NoError(t, err)
+
+	err = forest.AddTrie(updatedTrie1)
+	require.NoError(t, err)
+
+	p2 := pathByUint8s([]uint8{uint8(12), uint8(34)})
+	v2 := payloadBySlices([]byte{'B'}, []byte{'B'})
+
+	updatedTrie2, _, err := trie.NewTrieWithUpdatedRegisters(nt, []ledger.Path{p2}, []ledger.Payload{*v2}, true)
+	require.NoError(t, err)
+
+	err = forest.AddTrie(updatedTrie2)
+	require.NoError(t, err)
+	require.Equal(t, 3, forest.tries.Count())
+
+	err = forest.PurgeCacheExcept(updatedTrie2.RootHash())
+	require.NoError(t, err)
+	require.Equal(t, 1, forest.tries.Count())
+
+	ret, err := forest.GetTrie(updatedTrie2.RootHash())
+	require.NoError(t, err)
+	require.Equal(t, ret, updatedTrie2)
+
+	_, err = forest.GetTrie(updatedTrie1.RootHash())
+	require.Error(t, err)
+
+	// test purge with non existing trie
+	err = forest.PurgeCacheExcept(updatedTrie1.RootHash())
+	require.Error(t, err)
+
+	ret, err = forest.GetTrie(updatedTrie2.RootHash())
+	require.NoError(t, err)
+	require.Equal(t, ret, updatedTrie2)
+
+	_, err = forest.GetTrie(updatedTrie1.RootHash())
+	require.Error(t, err)
+
+	// test purge when only a single target trie exist there
+	err = forest.PurgeCacheExcept(updatedTrie2.RootHash())
+	require.NoError(t, err)
+	require.Equal(t, 1, forest.tries.Count())
+}

--- a/ledger/complete/payloadless/trieCache.go
+++ b/ledger/complete/payloadless/trieCache.go
@@ -1,0 +1,144 @@
+package mtrie
+
+import (
+	"sync"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
+)
+
+type OnTreeEvictedFunc func(tree *trie.MTrie)
+
+// TrieCache caches tries into memory, it acts as a fifo queue
+// so when it reaches to the capacity it would evict the oldest trie
+// from the cache.
+//
+// Under the hood it uses a circular buffer
+// of mtrie pointers and a map of rootHash to cache index for fast lookup
+type TrieCache struct {
+	tries         []*trie.MTrie
+	lookup        map[ledger.RootHash]int // index to item
+	lock          sync.RWMutex
+	capacity      int
+	tail          int // element index to write to
+	count         int // number of elements (count <= capacity)
+	onTreeEvicted OnTreeEvictedFunc
+}
+
+// NewTrieCache returns a new TrieCache with given capacity.
+func NewTrieCache(capacity uint, onTreeEvicted OnTreeEvictedFunc) *TrieCache {
+	return &TrieCache{
+		tries:         make([]*trie.MTrie, capacity),
+		lookup:        make(map[ledger.RootHash]int, capacity),
+		lock:          sync.RWMutex{},
+		capacity:      int(capacity),
+		tail:          0,
+		count:         0,
+		onTreeEvicted: onTreeEvicted,
+	}
+}
+
+// Purge removes all mtries stored in the buffer
+func (tc *TrieCache) Purge() {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
+
+	if tc.count == 0 {
+		return
+	}
+
+	toEvict := 0
+	for i := 0; i < tc.capacity; i++ {
+		toEvict = (tc.tail + i) % tc.capacity
+		if tc.onTreeEvicted != nil {
+			if tc.tries[toEvict] != nil {
+				tc.onTreeEvicted(tc.tries[toEvict])
+			}
+		}
+		tc.tries[toEvict] = nil
+	}
+	tc.tail = 0
+	tc.count = 0
+	tc.lookup = make(map[ledger.RootHash]int, tc.capacity)
+}
+
+// Tries returns elements in queue, starting from the oldest element
+// to the newest element.
+func (tc *TrieCache) Tries() []*trie.MTrie {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
+
+	if tc.count == 0 {
+		return nil
+	}
+
+	tries := make([]*trie.MTrie, tc.count)
+
+	if tc.tail >= tc.count { // Data isn't wrapped around the slice.
+		head := tc.tail - tc.count
+		copy(tries, tc.tries[head:tc.tail])
+	} else { // q.tail < q.count, data is wrapped around the slice.
+		// This branch isn't used until TrieQueue supports Pop (removing oldest element).
+		// At this time, there is no reason to implement Pop, so this branch is here to prevent future bug.
+		head := tc.capacity - tc.count + tc.tail
+		n := copy(tries, tc.tries[head:])
+		copy(tries[n:], tc.tries[:tc.tail])
+	}
+
+	return tries
+}
+
+// Push pushes trie to queue.  If queue is full, it overwrites the oldest element.
+func (tc *TrieCache) Push(t *trie.MTrie) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
+
+	// if its full
+	if tc.count == tc.capacity {
+		oldtrie := tc.tries[tc.tail]
+		if tc.onTreeEvicted != nil {
+			tc.onTreeEvicted(oldtrie)
+		}
+		delete(tc.lookup, oldtrie.RootHash())
+		tc.count-- // so when we increment at the end of method we don't go beyond capacity
+	}
+	tc.tries[tc.tail] = t
+	tc.lookup[t.RootHash()] = tc.tail
+	tc.tail = (tc.tail + 1) % tc.capacity
+	tc.count++
+}
+
+// LastAddedTrie returns the last trie added to the cache
+func (tc *TrieCache) LastAddedTrie() *trie.MTrie {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
+
+	if tc.count == 0 {
+		return nil
+	}
+	indx := tc.tail - 1
+	if indx < 0 {
+		indx = tc.capacity - 1
+	}
+	return tc.tries[indx]
+}
+
+// Get returns the trie by rootHash, if not exist will return nil and false
+func (tc *TrieCache) Get(rootHash ledger.RootHash) (*trie.MTrie, bool) {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
+
+	idx, found := tc.lookup[rootHash]
+	if !found {
+		return nil, false
+	}
+	return tc.tries[idx], true
+}
+
+// Count returns number of items stored in the cache
+func (tc *TrieCache) Count() int {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
+
+	return tc.count
+}

--- a/ledger/complete/payloadless/trieCache.go
+++ b/ledger/complete/payloadless/trieCache.go
@@ -1,13 +1,12 @@
-package mtrie
+package payloadless
 
 import (
 	"sync"
 
 	"github.com/onflow/flow-go/ledger"
-	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 )
 
-type OnTreeEvictedFunc func(tree *trie.MTrie)
+type OnTreeEvictedFunc func(tree *MTrie)
 
 // TrieCache caches tries into memory, it acts as a fifo queue
 // so when it reaches to the capacity it would evict the oldest trie
@@ -16,7 +15,7 @@ type OnTreeEvictedFunc func(tree *trie.MTrie)
 // Under the hood it uses a circular buffer
 // of mtrie pointers and a map of rootHash to cache index for fast lookup
 type TrieCache struct {
-	tries         []*trie.MTrie
+	tries         []*MTrie
 	lookup        map[ledger.RootHash]int // index to item
 	lock          sync.RWMutex
 	capacity      int
@@ -28,7 +27,7 @@ type TrieCache struct {
 // NewTrieCache returns a new TrieCache with given capacity.
 func NewTrieCache(capacity uint, onTreeEvicted OnTreeEvictedFunc) *TrieCache {
 	return &TrieCache{
-		tries:         make([]*trie.MTrie, capacity),
+		tries:         make([]*MTrie, capacity),
 		lookup:        make(map[ledger.RootHash]int, capacity),
 		lock:          sync.RWMutex{},
 		capacity:      int(capacity),
@@ -64,7 +63,7 @@ func (tc *TrieCache) Purge() {
 
 // Tries returns elements in queue, starting from the oldest element
 // to the newest element.
-func (tc *TrieCache) Tries() []*trie.MTrie {
+func (tc *TrieCache) Tries() []*MTrie {
 	tc.lock.RLock()
 	defer tc.lock.RUnlock()
 
@@ -72,7 +71,7 @@ func (tc *TrieCache) Tries() []*trie.MTrie {
 		return nil
 	}
 
-	tries := make([]*trie.MTrie, tc.count)
+	tries := make([]*MTrie, tc.count)
 
 	if tc.tail >= tc.count { // Data isn't wrapped around the slice.
 		head := tc.tail - tc.count
@@ -89,7 +88,7 @@ func (tc *TrieCache) Tries() []*trie.MTrie {
 }
 
 // Push pushes trie to queue.  If queue is full, it overwrites the oldest element.
-func (tc *TrieCache) Push(t *trie.MTrie) {
+func (tc *TrieCache) Push(t *MTrie) {
 	tc.lock.Lock()
 	defer tc.lock.Unlock()
 
@@ -109,7 +108,7 @@ func (tc *TrieCache) Push(t *trie.MTrie) {
 }
 
 // LastAddedTrie returns the last trie added to the cache
-func (tc *TrieCache) LastAddedTrie() *trie.MTrie {
+func (tc *TrieCache) LastAddedTrie() *MTrie {
 	tc.lock.RLock()
 	defer tc.lock.RUnlock()
 
@@ -124,7 +123,7 @@ func (tc *TrieCache) LastAddedTrie() *trie.MTrie {
 }
 
 // Get returns the trie by rootHash, if not exist will return nil and false
-func (tc *TrieCache) Get(rootHash ledger.RootHash) (*trie.MTrie, bool) {
+func (tc *TrieCache) Get(rootHash ledger.RootHash) (*MTrie, bool) {
 	tc.lock.RLock()
 	defer tc.lock.RUnlock()
 

--- a/ledger/complete/payloadless/trieCache_test.go
+++ b/ledger/complete/payloadless/trieCache_test.go
@@ -1,4 +1,4 @@
-package mtrie
+package payloadless
 
 // test addition
 // test under capacity
@@ -13,8 +13,6 @@ import (
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/hash"
-	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
-	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -30,7 +28,7 @@ func TestTrieCache(t *testing.T) {
 	require.Equal(t, 0, len(tc.lookup))
 
 	// savedTries contains all tries that are pushed to queue
-	var savedTries []*trie.MTrie
+	var savedTries []*MTrie
 
 	// Push tries to queue to fill out capacity
 	for i := 0; i < capacity; i++ {
@@ -104,7 +102,7 @@ func TestPurge(t *testing.T) {
 	require.NoError(t, err)
 
 	called := 0
-	tc := NewTrieCache(capacity, func(tree *trie.MTrie) {
+	tc := NewTrieCache(capacity, func(tree *MTrie) {
 		switch called {
 		case 0:
 			require.Equal(t, trie1, tree)
@@ -135,7 +133,7 @@ func TestEvictCallBack(t *testing.T) {
 	require.NoError(t, err)
 
 	called := false
-	tc := NewTrieCache(capacity, func(tree *trie.MTrie) {
+	tc := NewTrieCache(capacity, func(tree *MTrie) {
 		called = true
 		require.Equal(t, trie1, tree)
 	})
@@ -172,7 +170,7 @@ func TestConcurrentAccess(t *testing.T) {
 	require.Equal(t, worker, tc.Count())
 }
 
-func randomMTrie() (*trie.MTrie, error) {
+func randomMTrie() (*MTrie, error) {
 	var randomPath ledger.Path
 	_, err := rand.Read(randomPath[:])
 	if err != nil {
@@ -185,7 +183,7 @@ func randomMTrie() (*trie.MTrie, error) {
 		return nil, err
 	}
 
-	root := node.NewNode(256, nil, nil, randomPath, nil, randomHashValue)
+	root := NewNode(256, nil, nil, randomPath, nil, randomHashValue)
 
-	return trie.NewMTrie(root, 1, 1)
+	return NewMTrie(root, 1)
 }

--- a/ledger/complete/payloadless/trieCache_test.go
+++ b/ledger/complete/payloadless/trieCache_test.go
@@ -1,0 +1,191 @@
+package mtrie
+
+// test addition
+// test under capacity
+// test on capacity
+// test across boundry
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/hash"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestTrieCache(t *testing.T) {
+	const capacity = 10
+
+	tc := NewTrieCache(capacity, nil)
+	require.Equal(t, 0, tc.Count())
+
+	tries := tc.Tries()
+	require.Equal(t, 0, len(tries))
+	require.Equal(t, 0, tc.Count())
+	require.Equal(t, 0, len(tc.lookup))
+
+	// savedTries contains all tries that are pushed to queue
+	var savedTries []*trie.MTrie
+
+	// Push tries to queue to fill out capacity
+	for i := 0; i < capacity; i++ {
+		trie, err := randomMTrie()
+		require.NoError(t, err)
+
+		tc.Push(trie)
+
+		savedTries = append(savedTries, trie)
+
+		tr := tc.Tries()
+		require.Equal(t, savedTries, tr)
+		require.Equal(t, len(savedTries), tc.Count())
+		require.Equal(t, len(savedTries), len(tc.lookup))
+
+		retTrie, found := tc.Get(trie.RootHash())
+		require.Equal(t, retTrie, trie)
+		require.True(t, found)
+
+		// check last added trie functionality
+		retTrie = tc.LastAddedTrie()
+		require.Equal(t, retTrie, trie)
+	}
+
+	// Push more tries to queue to overwrite older elements
+	for i := 0; i < capacity; i++ {
+		trie, err := randomMTrie()
+		require.NoError(t, err)
+
+		tc.Push(trie)
+
+		savedTries = append(savedTries, trie)
+
+		tr := tc.Tries()
+		require.Equal(t, capacity, len(tr))
+
+		// After queue reaches capacity in previous loop,
+		// queue overwrites older elements with new insertions,
+		// and element count is its capacity value.
+		// savedTries contains all elements inserted from previous loop and current loop, so
+		// tr (queue snapshot) matches the last C elements in savedTries (where C is capacity).
+		require.Equal(t, savedTries[len(savedTries)-capacity:], tr)
+		require.Equal(t, capacity, tc.Count())
+		require.Equal(t, capacity, len(tc.lookup))
+
+		// check the trie is lookable
+		retTrie, found := tc.Get(trie.RootHash())
+		require.Equal(t, retTrie, trie)
+		require.True(t, found)
+
+		// check the last evicted value is not kept
+		retTrie, found = tc.Get(savedTries[len(savedTries)-capacity-1].RootHash())
+		require.Nil(t, retTrie)
+		require.False(t, found)
+
+		// check last added trie functionality
+		retTrie = tc.LastAddedTrie()
+		require.Equal(t, retTrie, trie)
+	}
+
+}
+
+func TestPurge(t *testing.T) {
+	const capacity = 5
+
+	trie1, err := randomMTrie()
+	require.NoError(t, err)
+	trie2, err := randomMTrie()
+	require.NoError(t, err)
+	trie3, err := randomMTrie()
+	require.NoError(t, err)
+
+	called := 0
+	tc := NewTrieCache(capacity, func(tree *trie.MTrie) {
+		switch called {
+		case 0:
+			require.Equal(t, trie1, tree)
+		case 1:
+			require.Equal(t, trie2, tree)
+		case 2:
+			require.Equal(t, trie3, tree)
+		}
+		called++
+
+	})
+	tc.Push(trie1)
+	tc.Push(trie2)
+	tc.Push(trie3)
+
+	tc.Purge()
+	require.Equal(t, 0, tc.Count())
+	require.Equal(t, 0, tc.tail)
+	require.Equal(t, 0, len(tc.lookup))
+
+	require.Equal(t, 3, called)
+}
+
+func TestEvictCallBack(t *testing.T) {
+	const capacity = 2
+
+	trie1, err := randomMTrie()
+	require.NoError(t, err)
+
+	called := false
+	tc := NewTrieCache(capacity, func(tree *trie.MTrie) {
+		called = true
+		require.Equal(t, trie1, tree)
+	})
+	tc.Push(trie1)
+
+	trie2, err := randomMTrie()
+	require.NoError(t, err)
+	tc.Push(trie2)
+
+	trie3, err := randomMTrie()
+	require.NoError(t, err)
+	tc.Push(trie3)
+
+	require.True(t, called)
+}
+
+func TestConcurrentAccess(t *testing.T) {
+
+	const worker = 50
+	const capacity = 100 // large enough to not worry evicts
+
+	tc := NewTrieCache(capacity, nil)
+
+	unittest.Concurrently(worker, func(i int) {
+		trie, err := randomMTrie()
+		require.NoError(t, err)
+		tc.Push(trie)
+
+		ret, found := tc.Get(trie.RootHash())
+		require.True(t, found)
+		require.Equal(t, trie, ret)
+	})
+
+	require.Equal(t, worker, tc.Count())
+}
+
+func randomMTrie() (*trie.MTrie, error) {
+	var randomPath ledger.Path
+	_, err := rand.Read(randomPath[:])
+	if err != nil {
+		return nil, err
+	}
+
+	var randomHashValue hash.Hash
+	_, err = rand.Read(randomHashValue[:])
+	if err != nil {
+		return nil, err
+	}
+
+	root := node.NewNode(256, nil, nil, randomPath, nil, randomHashValue)
+
+	return trie.NewMTrie(root, 1, 1)
+}


### PR DESCRIPTION
This PR adds Payloadless forest.

Strategy: same copy-then-modify pattern as Spec 001 (mtrie/forest.go → payloadless/forest.go).
[**See spec**](https://app.notion.com/p/flowfoundation/Payloadless-Implementation-Specs-3741aee12324808ba62ac2bd372143d0?source=copy_link#3741aee123248025abe7c172e8c830c5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a payloadless in-memory forest that stores leaf hashes for trie updates and reads.
  * Added path checks, single and batch leaf-hash retrieval, proofs, trie management, root-hash tracking, and cache purging.
  * Added capacity-based caching with automatic eviction and metrics support.
  * Added validation for missing tries, invalid updates, failed additions, and inconsistent root hashes.

* **Quality Improvements**
  * Added comprehensive coverage for updates, reads, forks, deduplication, proofs, cache behavior, and concurrent access.
  * Verified equivalent results between regular and payloadless forests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->