### PR TITLE
adding backward compatibility for v0.49.1 and v0.49.2 (#8567)

### DIFF
--- a/engine/common/version/version_control.go
+++ b/engine/common/version/version_control.go
@@ -68,6 +68,9 @@ var defaultCompatibilityOverrides = map[string]struct{}{
 	"0.46.1":  {}, // mainnet, testnet
 	"0.47.0":  {}, // mainnet, testnet
 	"0.48.0":  {}, // mainnet, testnet
+	"0.49.0":  {}, // mainnet, testnet
+	"0.49.1":  {}, // mainnet, testnet
+	"0.49.2":  {}, // mainnet, testnet
 }
 
 // VersionControl manages the version control system for the node.


### PR DESCRIPTION
git cherry-pick [e05f8a31aa9fd163b7ce5f5a5072ec11bcf2db48](https://github.com/onflow/flow-go/commit/e05f8a31aa9fd163b7ce5f5a5072ec11bcf2db48)

and resolved conflicts on `version_control.go`

Original PR on v0.49: https://github.com/onflow/flow-go/pull/8567