### PR TITLE
[FVM] Unify FVM limit exceeded errors into LimitExceededError

### DIFF
--- a/fvm/environment/event_emitter.go
+++ b/fvm/environment/event_emitter.go
@@ -44,6 +44,12 @@ type EventEmitter interface {
 	// This will encode the cadence event
 	//
 	// Note that the script variant will return OperationNotSupportedError.
+	//
+	// Expected error returns during normal operation:
+	//   - [errors.EventEncodingError] if the event cannot be encoded
+	//   - [errors.LimitExceededError] with [errors.LimitKindComputation] or
+	//     [errors.LimitKindEvent] if a metering limit is exceeded. Event byte
+	//     size limits are not enforced when the payer is the service account.
 	EmitEvent(event cadence.Event) error
 
 	Events() flow.EventsList

--- a/fvm/environment/meter.go
+++ b/fvm/environment/meter.go
@@ -105,6 +105,11 @@ var MainnetExecutionEffortWeights = meter.ExecutionEffortWeights{
 }
 
 type Meter interface {
+	// Gauge provides MeterComputation and MeterMemory. Both may return
+	// [errors.LimitExceededError] when the corresponding metering limit is
+	// exceeded. In script environments, MeterComputation may additionally
+	// return [errors.ScriptExecutionTimedOutError] or
+	// [errors.ScriptExecutionCancelledError].
 	common.Gauge
 
 	// MeteringResult returns the metering totals accumulated so far.
@@ -112,6 +117,11 @@ type Meter interface {
 
 	ComputationRemaining(kind common.ComputationKind) uint64
 
+	// MeterEmittedEvent captures the byte size of an emitted event.
+	//
+	// Expected error returns during normal operation:
+	//   - [errors.LimitExceededError] with [errors.LimitKindEvent] if the
+	//     event byte size limit is exceeded
 	MeterEmittedEvent(byteSize uint64) error
 
 	RunWithMeteringDisabled(f func())
@@ -153,6 +163,15 @@ func NewCancellableMeter(
 	}
 }
 
+// MeterComputation checks for script cancellation and timeout before
+// delegating to the embedded meter.
+//
+// Expected error returns during normal operation:
+//   - [errors.ScriptExecutionTimedOutError] if the script exceeded its
+//     allotted execution time
+//   - [errors.ScriptExecutionCancelledError] if the script's context was
+//     cancelled
+//   - [errors.LimitExceededError] if a metering limit is exceeded
 func (meter *cancellableMeter) MeterComputation(usage common.ComputationUsage) error {
 	// this method is called on every unit of operation, so
 	// checking the context here is the most likely would capture

--- a/fvm/errors/errors_test.go
+++ b/fvm/errors/errors_test.go
@@ -388,6 +388,80 @@ func TestFindFailure(t *testing.T) {
 	}
 }
 
+func TestIsLimitExceededError(t *testing.T) {
+	baseErr := fmt.Errorf("base error")
+	limitErr := NewLimitExceededError(LimitKindComputation, 100)
+
+	tests := []struct {
+		name     string
+		err      error
+		kinds    []LimitKind
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "plain error",
+			err:      baseErr,
+			expected: false,
+		},
+		{
+			name:     "other coded error",
+			err:      NewScriptExecutionTimedOutError(),
+			expected: false,
+		},
+		{
+			name:     "limit exceeded error without kind filter",
+			err:      limitErr,
+			expected: true,
+		},
+		{
+			name:     "wrapped limit exceeded error without kind filter",
+			err:      fmt.Errorf("wrapped: %w", limitErr),
+			expected: true,
+		},
+		{
+			name:     "matching kind",
+			err:      limitErr,
+			kinds:    []LimitKind{LimitKindComputation},
+			expected: true,
+		},
+		{
+			name:     "non-matching kind",
+			err:      limitErr,
+			kinds:    []LimitKind{LimitKindMemory},
+			expected: false,
+		},
+		{
+			name:     "one of multiple kinds matches",
+			err:      fmt.Errorf("wrapped: %w", limitErr),
+			kinds:    []LimitKind{LimitKindMemory, LimitKindComputation},
+			expected: true,
+		},
+		{
+			name:     "none of multiple kinds matches",
+			err:      limitErr,
+			kinds:    []LimitKind{LimitKindMemory, LimitKindLedgerInteraction, LimitKindEvent},
+			expected: false,
+		},
+		{
+			name:     "plain error with kind filter",
+			err:      baseErr,
+			kinds:    []LimitKind{LimitKindComputation},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsLimitExceededError(tc.err, tc.kinds...))
+		})
+	}
+}
+
 func createCheckerErr(errs []error) error {
 	return runtime.Error{
 		Err: cadenceErr.ExternalError{

--- a/fvm/errors/errors_test.go
+++ b/fvm/errors/errors_test.go
@@ -388,9 +388,33 @@ func TestFindFailure(t *testing.T) {
 	}
 }
 
+func TestNewLimitExceededError(t *testing.T) {
+	tests := []struct {
+		kind         LimitKind
+		expectedCode ErrorCode
+	}{
+		{LimitKindComputation, ErrCodeComputationLimitExceededError},
+		{LimitKindMemory, ErrCodeMemoryLimitExceededError},
+		{LimitKindLedgerInteraction, ErrCodeLedgerInteractionLimitExceededError},
+		{LimitKindEvent, ErrCodeEventLimitExceededError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.kind.String(), func(t *testing.T) {
+			err := NewLimitExceededError(tc.kind, 101, 100)
+
+			assert.Equal(t, tc.kind, err.LimitKind())
+			assert.Equal(t, uint64(101), err.Used())
+			assert.Equal(t, uint64(100), err.Limit())
+			assert.Equal(t, tc.expectedCode, err.Code())
+			assert.Contains(t, err.Error(), "used: 101, limit: 100")
+		})
+	}
+}
+
 func TestIsLimitExceededError(t *testing.T) {
 	baseErr := fmt.Errorf("base error")
-	limitErr := NewLimitExceededError(LimitKindComputation, 100)
+	limitErr := NewLimitExceededError(LimitKindComputation, 101, 100)
 
 	tests := []struct {
 		name     string

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -173,19 +173,26 @@ func (kind LimitKind) errorCode() ErrorCode {
 type LimitExceededError struct {
 	codedError
 	kind  LimitKind
+	used  uint64
 	limit uint64
 }
 
-// NewLimitExceededError constructs a new LimitExceededError for the given
-// limit kind.
-func NewLimitExceededError(kind LimitKind, limit uint64) LimitExceededError {
+// NewLimitExceededError constructs a new LimitExceededError.
+//
+// INVARIANT: used > limit. Only construct this error after a meter has
+// recorded usage exceeding the limit, never from "is enough left?"
+// pre-checks (e.g. the EVM gas pre-check), which must use their own error
+// types.
+func NewLimitExceededError(kind LimitKind, used uint64, limit uint64) LimitExceededError {
 	return LimitExceededError{
 		codedError: NewCodedError(
 			kind.errorCode(),
-			"%s limit exceeded (limit: %d)",
+			"%s limit exceeded (used: %d, limit: %d)",
 			kind,
+			used,
 			limit),
 		kind:  kind,
+		used:  used,
 		limit: limit,
 	}
 }
@@ -193,6 +200,13 @@ func NewLimitExceededError(kind LimitKind, limit uint64) LimitExceededError {
 // LimitKind returns which metering limit was exceeded.
 func (err LimitExceededError) LimitKind() LimitKind {
 	return err.kind
+}
+
+// Used returns the metered usage at the moment the limit was exceeded. It is
+// always greater than Limit, but since metering aborts on the first detected
+// excess, it does not reflect the execution's total demand.
+func (err LimitExceededError) Used() uint64 {
+	return err.used
 }
 
 // Limit returns the limit that was exceeded.

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime"
@@ -204,6 +205,20 @@ func AsLimitExceededError(err error) (LimitExceededError, bool) {
 	var limitErr LimitExceededError
 	ok := As(err, &limitErr)
 	return limitErr, ok
+}
+
+// IsLimitExceededError reports whether err's chain contains a
+// LimitExceededError. If any kinds are provided, the error's kind must match
+// one of them.
+func IsLimitExceededError(err error, kinds ...LimitKind) bool {
+	limitErr, ok := AsLimitExceededError(err)
+	if !ok {
+		return false
+	}
+	if len(kinds) == 0 {
+		return true
+	}
+	return slices.Contains(kinds, limitErr.kind)
 }
 
 // NewStorageCapacityExceededError constructs a new CodedError which indicates

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -1,6 +1,8 @@
 package errors
 
 import (
+	"fmt"
+
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime"
 
@@ -117,32 +119,91 @@ func NewExecutionVersionProviderFailure(
 		"Failure in execution version provider")
 }
 
-// NewComputationLimitExceededError constructs a new CodedError which indicates
-// that computation has exceeded its limit.
-func NewComputationLimitExceededError(limit uint64) CodedError {
-	return NewCodedError(
-		ErrCodeComputationLimitExceededError,
-		"computation exceeds limit (%d)",
-		limit)
+// LimitKind identifies which metering limit was exceeded.
+type LimitKind uint8
+
+const (
+	// LimitKindComputation is the computation (execution effort) limit.
+	LimitKindComputation LimitKind = iota + 1
+	// LimitKindMemory is the memory limit.
+	LimitKindMemory
+	// LimitKindLedgerInteraction is the ledger interaction limit
+	// (total bytes read from and written to storage).
+	LimitKindLedgerInteraction
+	// LimitKindEvent is the total emitted event byte size limit.
+	LimitKindEvent
+)
+
+func (kind LimitKind) String() string {
+	switch kind {
+	case LimitKindComputation:
+		return "computation"
+	case LimitKindMemory:
+		return "memory"
+	case LimitKindLedgerInteraction:
+		return "ledger interaction"
+	case LimitKindEvent:
+		return "event byte size"
+	default:
+		panic(fmt.Sprintf("unknown limit kind: %d", uint8(kind)))
+	}
 }
 
-// IsComputationLimitExceededError returns true if error has this code.
-func IsComputationLimitExceededError(err error) bool {
-	return HasErrorCode(err, ErrCodeComputationLimitExceededError)
+// errorCode returns the ErrorCode associated with the limit kind.
+// Each kind keeps its own distinct, externally visible error code.
+func (kind LimitKind) errorCode() ErrorCode {
+	switch kind {
+	case LimitKindComputation:
+		return ErrCodeComputationLimitExceededError
+	case LimitKindMemory:
+		return ErrCodeMemoryLimitExceededError
+	case LimitKindLedgerInteraction:
+		return ErrCodeLedgerInteractionLimitExceededError
+	case LimitKindEvent:
+		return ErrCodeEventLimitExceededError
+	default:
+		panic(fmt.Sprintf("unknown limit kind: %d", uint8(kind)))
+	}
 }
 
-// NewMemoryLimitExceededError constructs a new CodedError which indicates
-// that execution has exceeded its memory limits.
-func NewMemoryLimitExceededError(limit uint64) CodedError {
-	return NewCodedError(
-		ErrCodeMemoryLimitExceededError,
-		"memory usage exceeds limit (%d)",
-		limit)
+// LimitExceededError is a CodedError which indicates that execution has
+// exceeded one of its metering limits. The exceeded limit is identified by
+// LimitKind. Each kind retains its own distinct error code.
+type LimitExceededError struct {
+	codedError
+	kind  LimitKind
+	limit uint64
 }
 
-// IsMemoryLimitExceededError returns true if error has this code.
-func IsMemoryLimitExceededError(err error) bool {
-	return HasErrorCode(err, ErrCodeMemoryLimitExceededError)
+// NewLimitExceededError constructs a new LimitExceededError for the given
+// limit kind.
+func NewLimitExceededError(kind LimitKind, limit uint64) LimitExceededError {
+	return LimitExceededError{
+		codedError: NewCodedError(
+			kind.errorCode(),
+			"%s limit exceeded (limit: %d)",
+			kind,
+			limit),
+		kind:  kind,
+		limit: limit,
+	}
+}
+
+// LimitKind returns which metering limit was exceeded.
+func (err LimitExceededError) LimitKind() LimitKind {
+	return err.kind
+}
+
+// Limit returns the limit that was exceeded.
+func (err LimitExceededError) Limit() uint64 {
+	return err.limit
+}
+
+// AsLimitExceededError returns the LimitExceededError in err's chain, if any.
+func AsLimitExceededError(err error) (LimitExceededError, bool) {
+	var limitErr LimitExceededError
+	ok := As(err, &limitErr)
+	return limitErr, ok
 }
 
 // NewStorageCapacityExceededError constructs a new CodedError which indicates
@@ -164,18 +225,6 @@ func NewStorageCapacityExceededError(
 
 func IsStorageCapacityExceededError(err error) bool {
 	return HasErrorCode(err, ErrCodeStorageCapacityExceeded)
-}
-
-// NewEventLimitExceededError constructs a CodedError which indicates that the
-// transaction has produced events with size more than limit.
-func NewEventLimitExceededError(
-	totalByteSize uint64,
-	limit uint64) CodedError {
-	return NewCodedError(
-		ErrCodeEventLimitExceededError,
-		"total event byte size (%d) exceeds limit (%d)",
-		totalByteSize,
-		limit)
 }
 
 // NewStateKeySizeLimitError constructs a CodedError which indicates that the
@@ -214,24 +263,6 @@ func NewStateValueSizeLimitError(
 		valueStr,
 		size,
 		limit)
-}
-
-// NewLedgerInteractionLimitExceededError constructs a CodeError. It is
-// returned when a tx hits the maximum ledger interaction limit.
-func NewLedgerInteractionLimitExceededError(
-	used uint64,
-	limit uint64,
-) CodedError {
-	return NewCodedError(
-		ErrCodeLedgerInteractionLimitExceededError,
-		"max interaction with storage has exceeded the limit "+
-			"(used: %d bytes, limit %d bytes)",
-		used,
-		limit)
-}
-
-func IsLedgerInteractionLimitExceededError(err error) bool {
-	return HasErrorCode(err, ErrCodeLedgerInteractionLimitExceededError)
 }
 
 // NewOperationNotSupportedError construct a new CodedError. It is generated

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -177,6 +177,8 @@ type LimitExceededError struct {
 	limit uint64
 }
 
+var _ CodedError = (*LimitExceededError)(nil)
+
 // NewLimitExceededError constructs a new LimitExceededError.
 //
 // INVARIANT: used > limit. Only construct this error after a meter has

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1225,9 +1225,10 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 					snapshotTree)
 				require.NoError(t, err)
 
-				require.True(
+				unittest.RequireLimitExceededError(
 					t,
-					errors.IsLedgerInteractionLimitExceededError(output.Err))
+					output.Err,
+					errors.LimitKindLedgerInteraction)
 			}))
 
 	t.Run("Using to much interaction but not failing because of service account", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1228,7 +1228,8 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				unittest.RequireLimitExceededError(
 					t,
 					output.Err,
-					errors.LimitKindLedgerInteraction)
+					errors.LimitKindLedgerInteraction,
+					500_000)
 			}))
 
 	t.Run("Using to much interaction but not failing because of service account", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -1227,7 +1227,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 				require.NoError(t, err)
 				require.Greater(t, output.MemoryEstimate, uint64(highWeight))
 
-				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindMemory)
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindMemory, 10_000_000_000)
 			},
 		))
 
@@ -1351,7 +1351,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 				// There are 100 breaks and each break uses 1_000_000 memory
 				require.Greater(t, output.MemoryEstimate, uint64(100_000_000))
 
-				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindMemory)
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindMemory, 100_000_000)
 			},
 		))
 

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -828,7 +828,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			tryToTransfer: transferAmount,
 			gasLimit:      uint64(2),
 			checkResult: func(t *testing.T, balanceBefore uint64, balanceAfter uint64, output fvm.ProcedureOutput) {
-				require.ErrorContains(t, output.Err, "computation exceeds limit (2)")
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindComputation, 2)
 
 				var deposits []flow.Event
 				var withdraws []flow.Event
@@ -1162,7 +1162,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 					snapshotTree)
 				require.NoError(t, err)
 
-				require.True(t, errors.IsComputationLimitExceededError(output.Err))
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindComputation)
 			},
 		))
 
@@ -1227,7 +1227,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 				require.NoError(t, err)
 				require.Greater(t, output.MemoryEstimate, uint64(highWeight))
 
-				require.True(t, errors.IsMemoryLimitExceededError(output.Err))
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindMemory)
 			},
 		))
 
@@ -1351,7 +1351,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 				// There are 100 breaks and each break uses 1_000_000 memory
 				require.Greater(t, output.MemoryEstimate, uint64(100_000_000))
 
-				require.True(t, errors.IsMemoryLimitExceededError(output.Err))
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindMemory)
 			},
 		))
 
@@ -1393,7 +1393,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 					snapshotTree)
 				require.NoError(t, err)
 
-				require.True(t, errors.IsComputationLimitExceededError(output.Err))
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindComputation)
 			},
 		))
 
@@ -1436,7 +1436,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 					snapshotTree)
 				require.NoError(t, err)
 
-				require.True(t, errors.IsComputationLimitExceededError(output.Err))
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindComputation)
 			},
 		))
 
@@ -1478,7 +1478,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 					snapshotTree)
 				require.NoError(t, err)
 
-				require.True(t, errors.IsComputationLimitExceededError(output.Err))
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindComputation)
 			},
 		))
 
@@ -1558,7 +1558,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 					snapshotTree)
 				require.NoError(t, err)
 
-				require.ErrorContains(t, output.Err, "computation exceeds limit (997)")
+				unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindComputation, 997)
 				// expected computation used is still number of loops + 1 (from the storage limit check).
 				require.Equal(t, loops+executionEffortNeededToCheckStorage, output.ComputationUsed)
 
@@ -2332,8 +2332,7 @@ func TestScriptExecutionLimit(t *testing.T) {
 					_, output, err := vm.Run(scriptCtx, script, snapshotTree)
 					require.NoError(t, err)
 					require.Error(t, output.Err)
-					require.True(t, errors.IsComputationLimitExceededError(output.Err))
-					require.ErrorContains(t, output.Err, "computation exceeds limit (10000)")
+					unittest.RequireLimitExceededError(t, output.Err, errors.LimitKindComputation, 10000)
 					require.GreaterOrEqual(t, output.ComputationUsed, uint64(10000))
 					require.GreaterOrEqual(t, output.MemoryEstimate, uint64(456687216))
 				},

--- a/fvm/meter/computation_meter.go
+++ b/fvm/meter/computation_meter.go
@@ -99,7 +99,8 @@ func (m *ComputationMeter) MeterComputation(usage common.ComputationUsage) error
 	}
 	m.computationUsed += w * intensity
 	if m.computationUsed > m.params.computationLimit {
-		return errors.NewComputationLimitExceededError(
+		return errors.NewLimitExceededError(
+			errors.LimitKindComputation,
 			uint64(m.params.TotalComputationLimit()))
 	}
 	return nil

--- a/fvm/meter/computation_meter.go
+++ b/fvm/meter/computation_meter.go
@@ -87,7 +87,11 @@ func NewComputationMeter(params ComputationMeterParameters) ComputationMeter {
 	}
 }
 
-// MeterComputation captures computation usage and returns an error if it goes beyond the limit
+// MeterComputation captures computation usage.
+//
+// Expected error returns during normal operation:
+//   - [errors.LimitExceededError] with [errors.LimitKindComputation] if the
+//     total weighted computation usage exceeds the computation limit
 func (m *ComputationMeter) MeterComputation(usage common.ComputationUsage) error {
 	kind := usage.Kind
 	intensity := usage.Intensity

--- a/fvm/meter/computation_meter.go
+++ b/fvm/meter/computation_meter.go
@@ -103,9 +103,16 @@ func (m *ComputationMeter) MeterComputation(usage common.ComputationUsage) error
 	}
 	m.computationUsed += w * intensity
 	if m.computationUsed > m.params.computationLimit {
+		// Round the used amount up so it stays strictly greater than the
+		// limit; truncating the internal precision could make them equal.
+		usedCeil := m.computationUsed >> MeterExecutionInternalPrecisionBytes
+		if usedCeil<<MeterExecutionInternalPrecisionBytes < m.computationUsed {
+			usedCeil++
+		}
 		return errors.NewLimitExceededError(
 			errors.LimitKindComputation,
-			uint64(m.params.TotalComputationLimit()))
+			usedCeil,
+			m.params.TotalComputationLimit())
 	}
 	return nil
 }

--- a/fvm/meter/event_meter.go
+++ b/fvm/meter/event_meter.go
@@ -47,6 +47,7 @@ func (m *EventMeter) MeterEmittedEvent(byteSize uint64) error {
 	if m.totalEmittedEventBytes > m.params.eventEmitByteLimit {
 		return errors.NewLimitExceededError(
 			errors.LimitKindEvent,
+			m.totalEmittedEventBytes,
 			m.params.eventEmitByteLimit)
 	}
 	return nil

--- a/fvm/meter/event_meter.go
+++ b/fvm/meter/event_meter.go
@@ -40,8 +40,8 @@ func (m *EventMeter) MeterEmittedEvent(byteSize uint64) error {
 	m.totalEmittedEventBytes += byteSize
 
 	if m.totalEmittedEventBytes > m.params.eventEmitByteLimit {
-		return errors.NewEventLimitExceededError(
-			m.totalEmittedEventBytes,
+		return errors.NewLimitExceededError(
+			errors.LimitKindEvent,
 			m.params.eventEmitByteLimit)
 	}
 	return nil

--- a/fvm/meter/event_meter.go
+++ b/fvm/meter/event_meter.go
@@ -36,6 +36,11 @@ func NewEventMeter(params EventMeterParameters) EventMeter {
 	}
 }
 
+// MeterEmittedEvent captures the byte size of an emitted event.
+//
+// Expected error returns during normal operation:
+//   - [errors.LimitExceededError] with [errors.LimitKindEvent] if the total
+//     byte size of emitted events exceeds the event byte size limit
 func (m *EventMeter) MeterEmittedEvent(byteSize uint64) error {
 	m.totalEmittedEventBytes += byteSize
 

--- a/fvm/meter/interaction_meter.go
+++ b/fvm/meter/interaction_meter.go
@@ -133,6 +133,7 @@ func (m *InteractionMeter) checkStorageInteractionLimit(enforceLimit bool) error
 		m.TotalBytesOfStorageInteractions() > m.params.storageInteractionLimit {
 		return errors.NewLimitExceededError(
 			errors.LimitKindLedgerInteraction,
+			m.TotalBytesOfStorageInteractions(),
 			m.params.storageInteractionLimit)
 	}
 	return nil

--- a/fvm/meter/interaction_meter.go
+++ b/fvm/meter/interaction_meter.go
@@ -123,8 +123,9 @@ func (m *InteractionMeter) replaceWrite(
 func (m *InteractionMeter) checkStorageInteractionLimit(enforceLimit bool) error {
 	if enforceLimit &&
 		m.TotalBytesOfStorageInteractions() > m.params.storageInteractionLimit {
-		return errors.NewLedgerInteractionLimitExceededError(
-			m.TotalBytesOfStorageInteractions(), m.params.storageInteractionLimit)
+		return errors.NewLimitExceededError(
+			errors.LimitKindLedgerInteraction,
+			m.params.storageInteractionLimit)
 	}
 	return nil
 }

--- a/fvm/meter/interaction_meter.go
+++ b/fvm/meter/interaction_meter.go
@@ -50,8 +50,12 @@ func NewInteractionMeter(params InteractionMeterParameters) InteractionMeter {
 	}
 }
 
-// MeterStorageRead captures storage read bytes count and returns an error
-// if it goes beyond the total interaction limit and limit is enforced
+// MeterStorageRead captures storage read bytes count.
+//
+// Expected error returns during normal operation:
+//   - [errors.LimitExceededError] with [errors.LimitKindLedgerInteraction] if
+//     the total bytes of storage interactions (reads + writes) exceeds the
+//     storage interaction limit and enforceLimit is true
 func (m *InteractionMeter) MeterStorageRead(
 	storageKey flow.RegisterID,
 	value flow.RegisterValue,
@@ -68,11 +72,15 @@ func (m *InteractionMeter) MeterStorageRead(
 	return m.checkStorageInteractionLimit(enforceLimit)
 }
 
-// MeterStorageWrite captures storage written bytes count and returns an error
-// if it goes beyond the total interaction limit and limit is enforced.
+// MeterStorageWrite captures storage written bytes count.
 // If a key is written multiple times, only the last write is counted.
 // If a key is written before it has been read, next time it will be read it will be from the view,
 // not from storage, so count it as read 0.
+//
+// Expected error returns during normal operation:
+//   - [errors.LimitExceededError] with [errors.LimitKindLedgerInteraction] if
+//     the total bytes of storage interactions (reads + writes) exceeds the
+//     storage interaction limit and enforceLimit is true
 func (m *InteractionMeter) MeterStorageWrite(
 	storageKey flow.RegisterID,
 	value flow.RegisterValue,

--- a/fvm/meter/memory_meter.go
+++ b/fvm/meter/memory_meter.go
@@ -366,6 +366,7 @@ func (m *MemoryMeter) MeterMemory(usage common.MemoryUsage) error {
 	if m.memoryEstimate > m.params.memoryLimit {
 		return errors.NewLimitExceededError(
 			errors.LimitKindMemory,
+			m.memoryEstimate,
 			m.params.TotalMemoryLimit())
 	}
 	return nil

--- a/fvm/meter/memory_meter.go
+++ b/fvm/meter/memory_meter.go
@@ -348,7 +348,11 @@ func NewMemoryMeter(params MemoryMeterParameters) MemoryMeter {
 	return m
 }
 
-// MeterMemory captures memory usage and returns an error if it goes beyond the limit
+// MeterMemory captures memory usage.
+//
+// Expected error returns during normal operation:
+//   - [errors.LimitExceededError] with [errors.LimitKindMemory] if the total
+//     weighted memory estimate exceeds the memory limit
 func (m *MemoryMeter) MeterMemory(usage common.MemoryUsage) error {
 	kind := usage.Kind
 	amount := usage.Amount

--- a/fvm/meter/memory_meter.go
+++ b/fvm/meter/memory_meter.go
@@ -360,7 +360,9 @@ func (m *MemoryMeter) MeterMemory(usage common.MemoryUsage) error {
 	}
 	m.memoryEstimate += w * amount
 	if m.memoryEstimate > m.params.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.params.TotalMemoryLimit())
+		return errors.NewLimitExceededError(
+			errors.LimitKindMemory,
+			m.params.TotalMemoryLimit())
 	}
 	return nil
 }

--- a/fvm/meter/meter_test.go
+++ b/fvm/meter/meter_test.go
@@ -949,3 +949,83 @@ func TestEventLimits(t *testing.T) {
 		require.Equal(t, testSize1+testSize2, meter1.TotalEmittedEventBytes())
 	})
 }
+
+// TestLimitExceededErrorUsedExceedsLimit checks that every meter reports a
+// used amount strictly greater than the exceeded limit (the
+// [errors.NewLimitExceededError] invariant).
+func TestLimitExceededErrorUsedExceedsLimit(t *testing.T) {
+	// RequireLimitExceededError also checks used > limit.
+	requireUsedAndLimit := func(
+		t *testing.T,
+		err error,
+		kind errors.LimitKind,
+		expectedUsed, expectedLimit uint64,
+	) {
+		unittest.RequireLimitExceededError(t, err, kind, expectedLimit)
+		limitErr, ok := errors.AsLimitExceededError(err)
+		require.True(t, ok)
+		require.Equal(t, expectedUsed, limitErr.Used())
+	}
+
+	t.Run("computation", func(t *testing.T) {
+		m := meter.NewMeter(
+			meter.DefaultParameters().
+				WithComputationLimit(10).
+				WithComputationWeights(map[common.ComputationKind]uint64{
+					0: 1 << meter.MeterExecutionInternalPrecisionBytes,
+				}),
+		)
+
+		err := m.MeterComputation(common.ComputationUsage{Kind: 0, Intensity: 12})
+		requireUsedAndLimit(t, err, errors.LimitKindComputation, 12, 10)
+	})
+
+	t.Run("computation - used rounds up", func(t *testing.T) {
+		// With a sub-unit weight the internally used amount (limit + 1/65536
+		// units) would truncate to the limit itself; it must round up instead.
+		m := meter.NewMeter(
+			meter.DefaultParameters().
+				WithComputationLimit(10).
+				WithComputationWeights(map[common.ComputationKind]uint64{0: 1}),
+		)
+
+		err := m.MeterComputation(common.ComputationUsage{
+			Kind:      0,
+			Intensity: 10<<meter.MeterExecutionInternalPrecisionBytes + 1,
+		})
+		requireUsedAndLimit(t, err, errors.LimitKindComputation, 11, 10)
+	})
+
+	t.Run("memory", func(t *testing.T) {
+		m := meter.NewMeter(
+			meter.DefaultParameters().
+				WithMemoryLimit(10).
+				WithMemoryWeights(map[common.MemoryKind]uint64{0: 1}),
+		)
+
+		err := m.MeterMemory(common.MemoryUsage{Kind: 0, Amount: 12})
+		requireUsedAndLimit(t, err, errors.LimitKindMemory, 12, 10)
+	})
+
+	t.Run("ledger interaction", func(t *testing.T) {
+		key := flow.NewRegisterID(flow.EmptyAddress, "1")
+		value := []byte{0x1, 0x2, 0x3}
+		size := meter.GetStorageKeyValueSizeForTesting(key, value)
+
+		m := meter.NewMeter(
+			meter.DefaultParameters().WithStorageInteractionLimit(size - 1),
+		)
+
+		err := m.MeterStorageRead(key, value, true)
+		requireUsedAndLimit(t, err, errors.LimitKindLedgerInteraction, size, size-1)
+	})
+
+	t.Run("event", func(t *testing.T) {
+		m := meter.NewMeter(
+			meter.DefaultParameters().WithEventEmitByteLimit(10),
+		)
+
+		err := m.MeterEmittedEvent(12)
+		requireUsedAndLimit(t, err, errors.LimitKindEvent, 12, 10)
+	})
+}

--- a/fvm/meter/meter_test.go
+++ b/fvm/meter/meter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestWeightedComputationMetering(t *testing.T) {
@@ -72,8 +73,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 			},
 		)
 		require.Error(t, err)
-		require.True(t, errors.IsComputationLimitExceededError(err))
-		require.Equal(t, err.Error(), errors.NewComputationLimitExceededError(10).Error())
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindComputation, 10)
 
 		err = m.MeterMemory(
 			common.MemoryUsage{
@@ -100,8 +100,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 			},
 		)
 		require.Error(t, err)
-		require.True(t, errors.IsMemoryLimitExceededError(err))
-		require.Equal(t, err.Error(), errors.NewMemoryLimitExceededError(10).Error())
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindMemory, 10)
 	})
 
 	t.Run("meter computation and memory with weights", func(t *testing.T) {
@@ -271,8 +270,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 			},
 		)
 		require.Error(t, err)
-		require.True(t, errors.IsComputationLimitExceededError(err))
-		require.Equal(t, err.Error(), errors.NewComputationLimitExceededError(9).Error())
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindComputation, 9)
 	})
 
 	t.Run("merge meters - ignore limits", func(t *testing.T) {
@@ -341,7 +339,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				Intensity: 0,
 			},
 		)
-		require.True(t, errors.IsComputationLimitExceededError(err))
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindComputation)
 	})
 
 	t.Run("merge meters - large values - memory", func(t *testing.T) {
@@ -379,8 +377,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 			},
 		)
 		require.Error(t, err)
-		require.True(t, errors.IsMemoryLimitExceededError(err))
-		require.Equal(t, err.Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindMemory, math.MaxUint32)
 	})
 
 	t.Run("add intensity - test limits - computation", func(t *testing.T) {
@@ -489,7 +486,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				Intensity: 1,
 			},
 		)
-		require.True(t, errors.IsComputationLimitExceededError(err))
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindComputation)
 		reset()
 		err = m.MeterComputation(
 			common.ComputationUsage{
@@ -497,7 +494,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				Intensity: 1 << meter.MeterExecutionInternalPrecisionBytes,
 			},
 		)
-		require.True(t, errors.IsComputationLimitExceededError(err))
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindComputation)
 		reset()
 		err = m.MeterComputation(
 			common.ComputationUsage{
@@ -505,7 +502,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				Intensity: math.MaxUint32,
 			},
 		)
-		require.True(t, errors.IsComputationLimitExceededError(err))
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindComputation)
 	})
 
 	t.Run("add intensity - test limits - memory", func(t *testing.T) {
@@ -604,7 +601,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				Amount: math.MaxUint32,
 			},
 		)
-		require.True(t, errors.IsMemoryLimitExceededError(err))
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindMemory)
 
 		reset()
 		err = m.MeterMemory(
@@ -613,7 +610,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				Amount: 1,
 			},
 		)
-		require.True(t, errors.IsMemoryLimitExceededError(err))
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindMemory)
 		reset()
 		err = m.MeterMemory(
 			common.MemoryUsage{
@@ -621,7 +618,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				Amount: 1,
 			},
 		)
-		require.True(t, errors.IsMemoryLimitExceededError(err))
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindMemory)
 		reset()
 		err = m.MeterMemory(
 			common.MemoryUsage{
@@ -629,7 +626,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				Amount: math.MaxUint32,
 			},
 		)
-		require.True(t, errors.IsMemoryLimitExceededError(err))
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindMemory)
 	})
 }
 
@@ -734,11 +731,7 @@ func TestStorageLimits(t *testing.T) {
 
 		err := meter1.MeterStorageRead(key1, val1, true /* enforced */)
 
-		ledgerInteractionLimitExceedError := errors.NewLedgerInteractionLimitExceededError(
-			meter.GetStorageKeyValueSizeForTesting(key1, val1),
-			testLimit,
-		)
-		require.ErrorAs(t, err, &ledgerInteractionLimitExceedError)
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindLedgerInteraction, testLimit)
 	})
 
 	t.Run("metering storage written - exceeding limit - not enforced", func(t *testing.T) {
@@ -765,11 +758,7 @@ func TestStorageLimits(t *testing.T) {
 
 		err := meter1.MeterStorageWrite(key1, val1, true /* enforced */)
 
-		ledgerInteractionLimitExceedError := errors.NewLedgerInteractionLimitExceededError(
-			meter.GetStorageKeyValueSizeForTesting(key1, val1),
-			testLimit,
-		)
-		require.ErrorAs(t, err, &ledgerInteractionLimitExceedError)
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindLedgerInteraction, testLimit)
 	})
 
 	t.Run("metering storage read and written - within limit", func(t *testing.T) {
@@ -842,11 +831,7 @@ func TestStorageLimits(t *testing.T) {
 
 		// write of key2
 		err = meter1.MeterStorageWrite(key2, val2, true)
-		ledgerInteractionLimitExceedError := errors.NewLedgerInteractionLimitExceededError(
-			size1+size2,
-			testLimit,
-		)
-		require.ErrorAs(t, err, &ledgerInteractionLimitExceedError)
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindLedgerInteraction, testLimit)
 	})
 
 	t.Run("merge storage metering", func(t *testing.T) {
@@ -939,10 +924,7 @@ func TestEventLimits(t *testing.T) {
 		require.Equal(t, testSize1, meter1.TotalEmittedEventBytes())
 
 		err = meter1.MeterEmittedEvent(testSize2)
-		eventLimitExceededError := errors.NewEventLimitExceededError(
-			testSize1+testSize2,
-			testEventLimit)
-		require.ErrorAs(t, err, &eventLimitExceededError)
+		unittest.RequireLimitExceededError(t, err, errors.LimitKindEvent, testEventLimit)
 	})
 
 	t.Run("merge event metering", func(t *testing.T) {

--- a/fvm/storage/state/execution_state.go
+++ b/fvm/storage/state/execution_state.go
@@ -167,7 +167,15 @@ func (state *ExecutionState) DropChanges() error {
 	return state.spockState.DropChanges()
 }
 
-// Get returns a register value given owner and key
+// Get returns a register value given owner and key. Limits are only enforced
+// when metering is enabled.
+//
+// Expected error returns during normal operation:
+//   - [errors.StateKeySizeLimitError] if the key exceeds the key size limit
+//   - [errors.LimitExceededError] with [errors.LimitKindLedgerInteraction] if
+//     the storage interaction limit is exceeded
+//
+// All other errors are exceptions (ledger failures, use after finalization).
 func (state *ExecutionState) Get(id flow.RegisterID) (flow.RegisterValue, error) {
 	if state.finalized {
 		return nil, fmt.Errorf("cannot Get on a finalized state")
@@ -193,7 +201,16 @@ func (state *ExecutionState) Get(id flow.RegisterID) (flow.RegisterValue, error)
 	return value, err
 }
 
-// Set updates state delta with a register update
+// Set updates state delta with a register update. Limits are only enforced
+// when metering is enabled.
+//
+// Expected error returns during normal operation:
+//   - [errors.StateKeySizeLimitError] or [errors.StateValueSizeLimitError] if
+//     the key or value exceeds its size limit
+//   - [errors.LimitExceededError] with [errors.LimitKindLedgerInteraction] if
+//     the storage interaction limit is exceeded
+//
+// All other errors are exceptions (ledger failures, use after finalization).
 func (state *ExecutionState) Set(id flow.RegisterID, value flow.RegisterValue) error {
 	if state.finalized {
 		return fmt.Errorf("cannot Set on a finalized state")
@@ -215,7 +232,14 @@ func (state *ExecutionState) Set(id flow.RegisterID, value flow.RegisterValue) e
 	return state.meter.MeterStorageWrite(id, value, state.meteringEnabled)
 }
 
-// MeterComputation meters computation usage
+// MeterComputation meters computation usage. It is a no-op if metering is
+// disabled.
+//
+// Expected error returns during normal operation:
+//   - [errors.LimitExceededError] with [errors.LimitKindComputation] if the
+//     computation limit is exceeded
+//
+// Returns an exception if called on a finalized state.
 func (state *ExecutionState) MeterComputation(usage common.ComputationUsage) error {
 	if state.finalized {
 		return fmt.Errorf("cannot MeterComputation on a finalized state")
@@ -255,7 +279,13 @@ func (state *ExecutionState) TotalComputationLimit() uint64 {
 	return state.meter.TotalComputationLimit()
 }
 
-// MeterMemory meters memory usage
+// MeterMemory meters memory usage. It is a no-op if metering is disabled.
+//
+// Expected error returns during normal operation:
+//   - [errors.LimitExceededError] with [errors.LimitKindMemory] if the memory
+//     limit is exceeded
+//
+// Returns an exception if called on a finalized state.
 func (state *ExecutionState) MeterMemory(usage common.MemoryUsage) error {
 	if state.finalized {
 		return fmt.Errorf("cannot MeterMemory on a finalized state")
@@ -283,6 +313,14 @@ func (state *ExecutionState) TotalMemoryLimit() uint {
 	return uint(state.meter.TotalMemoryLimit())
 }
 
+// MeterEmittedEvent captures the byte size of an emitted event. It is a no-op
+// if metering is disabled.
+//
+// Expected error returns during normal operation:
+//   - [errors.LimitExceededError] with [errors.LimitKindEvent] if the event
+//     byte size limit is exceeded
+//
+// Returns an exception if called on a finalized state.
 func (state *ExecutionState) MeterEmittedEvent(byteSize uint64) error {
 	if state.finalized {
 		return fmt.Errorf("cannot MeterEmittedEvent on a finalized state")

--- a/fvm/storage/state/transaction_state.go
+++ b/fvm/storage/state/transaction_state.go
@@ -20,18 +20,33 @@ func (id NestedTransactionId) StateForTestingOnly() *ExecutionState {
 }
 
 type Meter interface {
+	// MeterComputation captures computation usage.
+	//
+	// Expected error returns during normal operation:
+	//   - errors.LimitExceededError with errors.LimitKindComputation if the
+	//     computation limit is exceeded
 	MeterComputation(usage common.ComputationUsage) error
 	ComputationRemaining(kind common.ComputationKind) uint64
 	ComputationIntensities() meter.MeteredComputationIntensities
 	TotalComputationLimit() uint64
 	TotalComputationUsed() uint64
 
+	// MeterMemory captures memory usage.
+	//
+	// Expected error returns during normal operation:
+	//   - errors.LimitExceededError with errors.LimitKindMemory if the memory
+	//     limit is exceeded
 	MeterMemory(usage common.MemoryUsage) error
 	MemoryAmounts() meter.MeteredMemoryAmounts
 	TotalMemoryEstimate() uint64
 
 	InteractionUsed() uint64
 
+	// MeterEmittedEvent captures the byte size of an emitted event.
+	//
+	// Expected error returns during normal operation:
+	//   - errors.LimitExceededError with errors.LimitKindEvent if the event
+	//     byte size limit is exceeded
 	MeterEmittedEvent(byteSize uint64) error
 
 	// RunWithMeteringDisabled runs f with limits disabled
@@ -155,8 +170,27 @@ type NestedTransactionPreparer interface {
 		id NestedTransactionId,
 	) error
 
+	// Get returns a register value from the current (nested) transaction's
+	// view. Limits are only enforced when metering is enabled.
+	//
+	// Expected error returns during normal operation:
+	//   - errors.StateKeySizeLimitError if the key exceeds the key size limit
+	//   - errors.LimitExceededError with errors.LimitKindLedgerInteraction if
+	//     the storage interaction limit is exceeded
+	//
+	// All other errors are exceptions (e.g. ledger failures).
 	Get(id flow.RegisterID) (flow.RegisterValue, error)
 
+	// Set updates a register value in the current (nested) transaction's
+	// view. Limits are only enforced when metering is enabled.
+	//
+	// Expected error returns during normal operation:
+	//   - errors.StateKeySizeLimitError or errors.StateValueSizeLimitError if
+	//     the key or value exceeds its size limit
+	//   - errors.LimitExceededError with errors.LimitKindLedgerInteraction if
+	//     the storage interaction limit is exceeded
+	//
+	// All other errors are exceptions (e.g. ledger failures).
 	Set(id flow.RegisterID, value flow.RegisterValue) error
 
 	// BaseStorageSnapshot gives access to the storage snapshot as it was without changes

--- a/integration/internal/emulator/tests/script_test.go
+++ b/integration/internal/emulator/tests/script_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/stdlib"
 	emulator "github.com/onflow/flow-go/integration/internal/emulator"
 	flowgo "github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestExecuteScript(t *testing.T) {
@@ -193,7 +194,7 @@ func TestInfiniteScript(t *testing.T) {
 	result, err := b.ExecuteScript([]byte(code), nil)
 	require.NoError(t, err)
 
-	require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+	unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation)
 }
 
 func TestScriptExecutionLimit(t *testing.T) {
@@ -230,7 +231,7 @@ func TestScriptExecutionLimit(t *testing.T) {
 		result, err := b.ExecuteScript([]byte(code), nil)
 		require.NoError(t, err)
 
-		require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+		unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation)
 	})
 
 	t.Run("SufficientLimit", func(t *testing.T) {

--- a/integration/internal/emulator/tests/script_test.go
+++ b/integration/internal/emulator/tests/script_test.go
@@ -194,7 +194,7 @@ func TestInfiniteScript(t *testing.T) {
 	result, err := b.ExecuteScript([]byte(code), nil)
 	require.NoError(t, err)
 
-	unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation)
+	unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation, limit)
 }
 
 func TestScriptExecutionLimit(t *testing.T) {
@@ -231,7 +231,7 @@ func TestScriptExecutionLimit(t *testing.T) {
 		result, err := b.ExecuteScript([]byte(code), nil)
 		require.NoError(t, err)
 
-		unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation)
+		unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation, limit)
 	})
 
 	t.Run("SufficientLimit", func(t *testing.T) {

--- a/integration/internal/emulator/tests/transaction_test.go
+++ b/integration/internal/emulator/tests/transaction_test.go
@@ -1695,7 +1695,7 @@ func TestInfiniteTransaction(t *testing.T) {
 	result, err := b.ExecuteNextTransaction()
 	assert.NoError(t, err)
 
-	unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation)
+	unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation, limit)
 }
 
 func TestTransactionExecutionLimit(t *testing.T) {
@@ -1761,7 +1761,7 @@ func TestTransactionExecutionLimit(t *testing.T) {
 		result, err := b.ExecuteNextTransaction()
 		assert.NoError(t, err)
 
-		unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation)
+		unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation, limit)
 	})
 
 	t.Run("SufficientLimit", func(t *testing.T) {

--- a/integration/internal/emulator/tests/transaction_test.go
+++ b/integration/internal/emulator/tests/transaction_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/stdlib"
 	emulator "github.com/onflow/flow-go/integration/internal/emulator"
 	flowgo "github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func setupTransactionTests(t *testing.T, opts ...emulator.Option) (
@@ -1694,7 +1695,7 @@ func TestInfiniteTransaction(t *testing.T) {
 	result, err := b.ExecuteNextTransaction()
 	assert.NoError(t, err)
 
-	require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+	unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation)
 }
 
 func TestTransactionExecutionLimit(t *testing.T) {
@@ -1760,7 +1761,7 @@ func TestTransactionExecutionLimit(t *testing.T) {
 		result, err := b.ExecuteNextTransaction()
 		assert.NoError(t, err)
 
-		require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+		unittest.RequireLimitExceededError(t, result.Error, fvmerrors.LimitKindComputation)
 	})
 
 	t.Run("SufficientLimit", func(t *testing.T) {

--- a/utils/unittest/fvm.go
+++ b/utils/unittest/fvm.go
@@ -21,6 +21,9 @@ func EnsureEventsIndexSeq(t *testing.T, events []flow.Event, chainID flow.ChainI
 // RequireLimitExceededError fails the test unless err's chain contains a
 // [fvmerrors.LimitExceededError] with the given kind. If expectedLimit is
 // provided, the error's limit must match it.
+//
+// It also checks the [fvmerrors.NewLimitExceededError] invariant that the
+// used amount exceeds the limit.
 func RequireLimitExceededError(
 	t testing.TB,
 	err error,
@@ -33,6 +36,8 @@ func RequireLimitExceededError(
 	limitErr, ok := fvmerrors.AsLimitExceededError(err)
 	require.True(t, ok, "expected LimitExceededError, got: %v", err)
 	require.Equal(t, kind, limitErr.LimitKind())
+	require.Greater(t, limitErr.Used(), limitErr.Limit(),
+		"LimitExceededError invariant: used must exceed limit")
 	if len(expectedLimit) == 1 {
 		require.Equal(t, expectedLimit[0], limitErr.Limit())
 	}

--- a/utils/unittest/fvm.go
+++ b/utils/unittest/fvm.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	fvmerrors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -14,5 +15,25 @@ func EnsureEventsIndexSeq(t *testing.T, events []flow.Event, chainID flow.ChainI
 	for _, event := range events {
 		require.Equal(t, expectedEventIndex, event.EventIndex)
 		expectedEventIndex++
+	}
+}
+
+// RequireLimitExceededError fails the test unless err's chain contains a
+// [fvmerrors.LimitExceededError] with the given kind. If expectedLimit is
+// provided, the error's limit must match it.
+func RequireLimitExceededError(
+	t testing.TB,
+	err error,
+	kind fvmerrors.LimitKind,
+	expectedLimit ...uint64,
+) {
+	require.LessOrEqual(t, len(expectedLimit), 1,
+		"at most one expected limit may be provided")
+
+	limitErr, ok := fvmerrors.AsLimitExceededError(err)
+	require.True(t, ok, "expected LimitExceededError, got: %v", err)
+	require.Equal(t, kind, limitErr.LimitKind())
+	if len(expectedLimit) == 1 {
+		require.Equal(t, expectedLimit[0], limitErr.Limit())
 	}
 }


### PR DESCRIPTION
Replaces the 4 separate metering limit-exceeded errors (computation, memory, ledger interaction, event size) with a single `LimitExceededError` carrying a `LimitKind` enum, and documents expected metering errors on public methods in the propagation chain.

- Error codes have **not** changed.
- Error messages **have** changed (now unified, containing the used amount and the limit).
- An **HCU is needed** to deploy this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized limit-exceeded errors across computation, memory, event, and ledger interaction limits.
  * Limit errors now include the limit category (kind), plus “used” and configured “limit” values.
* **Bug Fixes**
  * Improved computation limit “used” reporting with correct precision/ceiling rounding.
* **Documentation**
  * Clarified expected normal-operation error behavior for metering, execution, and storage APIs (including timeout/cancellation and limit kinds).
* **Tests**
  * Added/updated assertions to validate limit kind, used/limit invariants, and wrapped error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->