### PR TITLE
Kan/fvm claude reviewer

### DIFF
--- a/.claude/skills/fvm-review/SKILL.md
+++ b/.claude/skills/fvm-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: fvm-review
+description: Reviews a pull request that modifies the Flow Virtual Machine (fvm/**) on onflow/flow-go. Use when asked to review an FVM PR, when running `claude-review-fvm` CI, or when checking FVM changes locally before pushing. Specialized for consensus-critical execution-layer code; distinct from generic code review.
+---
+
+# FVM PR Review
+
+You are reviewing a pull request on **onflow/flow-go** that modifies the Flow
+Virtual Machine (`fvm/**`), the execution layer of a byzantine-fault-tolerant
+blockchain. Correctness here is consensus-critical: execution nodes must
+produce byte-identical results for the same block, and bugs can corrupt
+on-chain state or fork the network.
+
+## Scope
+
+Review ONLY the PR's own changes. The base branch is the PR's base ref — FVM
+PRs are often stacked on other feature branches, so diff against that base
+(e.g. `git diff origin/<base-ref>...HEAD`), never against master. Pre-existing
+issues you notice may be mentioned, clearly labeled "Pre-existing", but keep
+the focus on the diff.
+
+## Read first
+
+- `AGENTS.md` at the repo root — high-assurance conventions. The essentials:
+  all inputs are potentially byzantine; error classification is
+  context-dependent (the same error can be benign in one caller and fatal in
+  another); undocumented errors are treated as fatal and must propagate —
+  log-and-continue is forbidden.
+- `fvm/README.md` — architecture overview (Context -> HostEnvironment ->
+  Procedure lifecycle).
+- `fvm/errors/codes.go` and `fvm/errors/errors.go` — FVM's own error taxonomy.
+  NOTE: `fvm/` does NOT use the sentinel-error model from the rest of the
+  repo. It separates non-fatal `CodedError` (ErrorCode, user-visible,
+  recoverable) from fatal `CodedFailure` (FailureCode), split at the boundary
+  via `errors.SplitErrorTypes`.
+
+## FVM-specific bug classes to check
+
+These are the failure modes that have actually bitten this codebase. Check
+the diff against each:
+
+1. **Execution-result determinism / HCU discipline.** Anything that changes
+   observable execution behavior — error messages included in transaction
+   results, metering amounts, emitted events, enforced limits — changes
+   execution results and requires a coordinated height upgrade (HCU) to
+   deploy. If the diff changes such behavior, the PR description must
+   acknowledge it. Flag silent behavior changes loudly.
+
+2. **Cache-state independence.** Program loads and other derived-data
+   computations (`fvm/storage/derived`) must charge identical computation
+   warm or cold. A transaction must never be charged differently because
+   another transaction warmed the cache first. Look for meter state leaking
+   into or out of cached snapshots.
+
+3. **Metering scope semantics** (`fvm/meter`, `fvm/storage/state`).
+   `RunWithMeteringDisabled` suppresses accumulation AND limit enforcement.
+   Watch the boundaries: the interaction meter counts only the first read of
+   a register (later reads are free cache hits), so reads/writes inside a
+   disabled scope change what later metered reads cost. Nested transaction
+   merges (`ExecutionState.Merge`) decide whose meter absorbs the charges —
+   check every Begin/Commit/Restart pairing, especially error paths where
+   nested transactions unwind. `RunWithMeteringDisabled` takes a closure, so
+   errors escape via captured variables
+   (`RunWithMeteringDisabled(func() { err = foo() })`) — check every such site
+   for shadowed or stale `err` and for a missing error check immediately after
+   the closure returns.
+
+4. **Error taxonomy discipline** (`fvm/errors`). A `CodedFailure` must always
+   propagate as a failure — flag any callsite that downgrades one to a benign
+   error, and any re-wrap of a `CodedError` into a `CodedFailure` (or vice
+   versa) without justification. Error CODES are an external contract —
+   downstream systems index on them; never renumber or reuse. Error MESSAGES
+   are part of the execution result — changing one is a behavior change (see
+   #1). In `fvm/evm`, the EVM error path has its own semantics:
+   `errors.NewEVMError` wraps non-fatal EVM errors as user errors, and
+   `IsEVMError` / `IsFailure` classification at that boundary must be
+   preserved.
+
+5. **Transaction pipeline invariants** (`transactionInvoker.go` and friends).
+   Order matters: signature verification → sequence number → payer balance
+   check (unmetered) → body (metered, inside a nested transaction) → storage
+   limit checks → fee deduction (unmetered). Fee deduction and other
+   system-critical unmetered scopes must never be able to fail on a metering
+   limit. The error-execution path must leave the nested transaction stack
+   consistent.
+
+6. **Service-account special cases.** Several limits are not enforced when
+   the payer is the service account. Changes to limit enforcement must
+   preserve these exemptions — and must not accidentally widen them.
+
+7. **SPoCK sensitivity** (`fvm/storage/state` `spockState`). Execution
+   snapshots feed SPoCK proofs. Any nondeterminism in the read/write set —
+   map iteration order reaching the ledger, time, randomness — breaks
+   verification.
+
+## What NOT to spend turns on
+
+- Style, formatting, import ordering — CI and CodeRabbit already cover these.
+- Refactors out of the PR's scope.
+- Test-only changes to assertions that keep the same coverage.
+
+## Submitting your findings
+
+Post exactly ONE comment on the PR via `gh pr comment`, with:
+
+- First line: a one-sentence verdict ("No concerns from this review" or
+  "N findings, M of them important").
+- Findings grouped by severity: **Important** (would be a bug in production),
+  **Nit** (worth fixing, not blocking), **Pre-existing** (not introduced by
+  this PR).
+- Every finding cites `file:line` and states the concrete failure scenario —
+  not "this could be a problem" but "if X happens, Y breaks because Z".
+- At most 5 nits; summarize the rest in one line if there are more.
+- If you verified something subtle and found it correct, say so in one line —
+  knowing what was checked has value.
+
+When running in CI trial mode, do not approve or request changes. Findings
+only. (The workflow's tool allowlist omits `gh pr review`, so approval is
+impossible at the tool level regardless of this instruction.)

--- a/.github/workflows/claude-review-fvm.yml
+++ b/.github/workflows/claude-review-fvm.yml
@@ -1,0 +1,117 @@
+name: claude-review-fvm
+
+# Runs Claude Code on pull requests that modify fvm/** and posts a review.
+#
+# Authentication uses Workload Identity Federation against the Anthropic
+# API — no ANTHROPIC_API_KEY secret is required. The federation rule ID,
+# service account ID, and organization ID below are identifiers, not
+# credentials, and can safely live in the workflow file.
+#
+# The Claude GitHub App (https://github.com/apps/claude) must be installed
+# on this repository — that is what lets Claude post reviews as
+# claude[bot] (distinct from github-actions[bot]).
+#
+# The prompt currently runs in "comment only" mode as a trial. Claude will
+# post COMMENTED reviews with findings but will NOT approve or request
+# changes. Once we have calibrated trust in the reviewer, flip the final
+# stanza of the prompt to allow APPROVED / REQUEST_CHANGES — see the
+# comment near the end of the prompt block below.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'fvm/**'
+
+permissions:
+  contents: read
+  pull-requests: write   # required for Claude to submit reviews
+  id-token: write        # required for WIF: fetching the GitHub OIDC token
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          # Workload Identity Federation — no static credentials.
+          anthropic_federation_rule_id: fdrl_01UXEriP26j1qgPvpAvVyYoE
+          anthropic_service_account_id: svac_01RutNzF7FBxds8FhTHZ2BTY
+          anthropic_organization_id: 23ff619e-5bf0-4e8d-936b-87274460531a
+          # anthropic_workspace_id intentionally omitted: the federation
+          # rule is scoped to a single (default) workspace.
+
+          claude_args: |
+            --model claude-sonnet-4-5
+            --max-turns 20
+            --allowedTools "Bash(gh pr *),Bash(gh api *),Bash(git *),Read,Grep,Glob"
+
+          prompt: |
+            You are reviewing PR #${{ github.event.pull_request.number }} on
+            onflow/flow-go. It modifies FVM code (fvm/**) in a high-assurance
+            byzantine-fault-tolerant blockchain implementation.
+
+            Before analyzing the diff, read:
+              - AGENTS.md at the repo root for project conventions
+              - Any CLAUDE.md files under the paths this PR touches
+
+            Focus your review on:
+
+            1. Correctness under byzantine inputs. All external inputs are
+               potentially adversarial. Look for unchecked assumptions.
+
+            2. Error handling per the repo's contract. Benign errors are
+               typed sentinels documented on the function; unexpected errors
+               are exceptions that must propagate (never swallowed, never
+               "best-effort"). Flag any callsite that logs-and-continues on
+               an undocumented error, or that treats a documented sentinel
+               inconsistently with its context (the same error type can be
+               benign in one caller and an exception in another).
+
+            3. GoDoc completeness on public methods. Every method that
+               returns an error must document expected benign errors under
+               "Expected error returns during normal operation" — or state
+               "No error returns are expected during normal operation."
+               Missing or misleading contracts are review-worthy.
+
+            4. Consensus determinism. Metering totals, execution snapshots,
+               and observable side effects must be identical across nodes
+               regardless of cache state, scheduling, or timing. Flag
+               anything that could diverge between warm and cold caches or
+               between concurrent and sequential execution.
+
+            5. Ledger interaction and metering semantics. Reads and writes
+               inside RunWithMeteringDisabled scopes have subtle effects on
+               later metered reads via the interaction meter's read cache.
+               Flag cross-boundary behavior that isn't covered by a test.
+
+            6. Test coverage of the observable contract, especially where
+               behavior changes are subtle (new sentinel error kinds, new
+               metering rules, changed merge semantics).
+
+            Use `gh pr view` and `gh api` for context you can't get from the
+            checkout. Cite file:line for every concern.
+
+            # === Review submission ===
+            #
+            # Trial mode: post ONLY a COMMENTED review, regardless of what
+            # you find. Do NOT approve, do NOT request changes.
+            #
+            # Once the team has calibrated trust in this reviewer, this
+            # stanza will change to allow APPROVE and REQUEST_CHANGES. When
+            # that happens the rule will be: approve only if you found no
+            # important findings; request changes if you found any; comment
+            # if you are uncertain. Not yet.
+            #
+            # For now: submit exactly one COMMENTED review via
+            # `gh pr review --comment`, with a review body that leads with a
+            # short summary and then lists findings in file:line order.
+            # Group findings by severity (Important / Nit / Pre-existing).
+            # If you found nothing worth flagging, still post a comment
+            # saying so — this gives the humans a signal that Claude ran
+            # and had no concerns.

--- a/.github/workflows/claude-review-fvm.yml
+++ b/.github/workflows/claude-review-fvm.yml
@@ -16,9 +16,10 @@ name: claude-review-fvm
 # `gh pr review`, so approval is impossible at the tool level regardless
 # of the prompt. To promote Claude to a real reviewer later:
 #   1. add `Bash(gh pr review:*)` to --allowedTools
-#   2. replace the "Submitting your findings" section of the prompt with
-#      review-submission rules (approve only when no important findings,
-#      request changes when there are, comment when uncertain)
+#   2. update the "Submitting your findings" section of the `fvm-review`
+#      skill (`.claude/skills/fvm-review/SKILL.md`) with review-submission
+#      rules (approve only when no important findings, request changes when
+#      there are, comment when uncertain)
 # ───────────────────────────────────────────────────────────────────────
 
 on:
@@ -45,6 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false   # don't leave GITHUB_TOKEN in git config
 
       - uses: anthropics/claude-code-action@v1
         with:
@@ -64,126 +66,18 @@ jobs:
 
           prompt: |
             You are reviewing pull request #${{ github.event.pull_request.number }}
-            on onflow/flow-go. It modifies the Flow Virtual Machine (fvm/**),
-            the execution layer of a byzantine-fault-tolerant blockchain.
-            Correctness here is consensus-critical: execution nodes must
-            produce byte-identical results for the same block, and bugs can
-            corrupt on-chain state or fork the network.
+            on onflow/flow-go. It modifies the Flow Virtual Machine (fvm/**).
 
-            ## Scope
+            Run the `fvm-review` skill (`.claude/skills/fvm-review/SKILL.md`)
+            to perform the review. The skill holds the FVM-specific review
+            doctrine: the bug classes to check, the error-taxonomy rules, the
+            scope guidance, and the findings format. Apply it to this PR.
 
-            Review ONLY this PR's own changes. The base branch is
-            `${{ github.event.pull_request.base.ref }}` — FVM PRs are often
-            stacked on other feature branches, so diff against that base
-            (e.g. `git diff origin/${{ github.event.pull_request.base.ref }}...HEAD`),
-            never against master. Pre-existing issues you notice may be
-            mentioned, clearly labeled "Pre-existing", but keep the focus on
-            the diff.
-
-            ## Read first
-
-            - AGENTS.md at the repo root — high-assurance conventions. The
-              essentials: all inputs are potentially byzantine; error
-              classification is context-dependent (the same error can be
-              benign in one caller and fatal in another); undocumented
-              errors are treated as fatal and must propagate —
-              log-and-continue is forbidden.
-            - fvm/README.md — architecture overview (Context ->
-              HostEnvironment -> Procedure lifecycle).
-            - fvm/errors/codes.go and fvm/errors/errors.go — FVM's own
-              error taxonomy. NOTE: fvm/ does NOT use the sentinel-error
-              model from the rest of the repo. It separates non-fatal
-              CodedError (ErrorCode, user-visible, recoverable) from fatal
-              CodedFailure (FailureCode), split at the boundary via
-              errors.SplitErrorTypes.
-
-            ## FVM-specific bug classes to check
-
-            These are the failure modes that have actually bitten this
-            codebase. Check the diff against each:
-
-            1. Execution-result determinism / HCU discipline. Anything that
-               changes observable execution behavior — error messages
-               included in transaction results, metering amounts, emitted
-               events, enforced limits — changes execution results and
-               requires a coordinated height upgrade (HCU) to deploy. If the
-               diff changes such behavior, the PR description must
-               acknowledge it. Flag silent behavior changes loudly.
-
-            2. Cache-state independence. Program loads and other derived-data
-               computations (fvm/storage/derived) must charge identical
-               computation warm or cold. A transaction must never be charged
-               differently because another transaction warmed the cache
-               first. Look for meter state leaking into or out of cached
-               snapshots.
-
-            3. Metering scope semantics (fvm/meter, fvm/storage/state).
-               RunWithMeteringDisabled suppresses accumulation AND limit
-               enforcement. Watch the boundaries: the interaction meter
-               counts only the first read of a register (later reads are
-               free cache hits), so reads/writes inside a disabled scope
-               change what later metered reads cost. Nested transaction
-               merges (ExecutionState.Merge) decide whose meter absorbs the
-               charges — check every Begin/Commit/Restart pairing,
-               especially error paths where nested transactions unwind.
-               RunWithMeteringDisabled takes a closure, so errors escape via
-               captured variables (`RunWithMeteringDisabled(func() { err = foo() })`)
-               — check every such site for shadowed or stale `err` and for a
-               missing error check immediately after the closure returns.
-
-            4. Error taxonomy discipline (fvm/errors). A CodedFailure must
-               always propagate as a failure — flag any callsite that
-               downgrades one to a benign error, and any re-wrap of a
-               CodedError into a CodedFailure (or vice versa) without
-               justification. Error CODES are an external contract —
-               downstream systems index on them; never renumber or reuse.
-               Error MESSAGES are part of the execution result — changing
-               one is a behavior change (see #1). In fvm/evm, the EVM error
-               path has its own semantics: errors.NewEVMError wraps
-               non-fatal EVM errors as user errors, and IsEVMError /
-               IsFailure classification at that boundary must be preserved.
-
-            5. Transaction pipeline invariants (transactionInvoker.go and
-               friends). Order matters: signature verification → sequence
-               number → payer balance check (unmetered) → body (metered,
-               inside a nested transaction) → storage limit checks → fee
-               deduction (unmetered). Fee deduction and other system-critical
-               unmetered scopes must never be able to fail on a metering
-               limit. The error-execution path must leave the nested
-               transaction stack consistent.
-
-            6. Service-account special cases. Several limits are not
-               enforced when the payer is the service account. Changes to
-               limit enforcement must preserve these exemptions — and must
-               not accidentally widen them.
-
-            7. SPoCK sensitivity (fvm/storage/state spockState). Execution
-               snapshots feed SPoCK proofs. Any nondeterminism in the
-               read/write set — map iteration order reaching the ledger,
-               time, randomness — breaks verification.
-
-            ## What NOT to spend turns on
-
-            - Style, formatting, import ordering — CI and CodeRabbit
-              already cover these.
-            - Refactors out of the PR's scope.
-            - Test-only changes to assertions that keep the same coverage.
-
-            ## Submitting your findings
-
-            Post exactly ONE comment on the PR via `gh pr comment`, with:
-
-            - First line: a one-sentence verdict ("No concerns from this
-              review" or "N findings, M of them important").
-            - Findings grouped by severity: Important (would be a bug in
-              production), Nit (worth fixing, not blocking), Pre-existing
-              (not introduced by this PR).
-            - Every finding cites file:line and states the concrete failure
-              scenario — not "this could be a problem" but "if X happens, Y
-              breaks because Z".
-            - At most 5 nits; summarize the rest in one line if there are
-              more.
-            - If you verified something subtle and found it correct, say so
-              in one line — knowing what was checked has value.
-
-            Do not approve or request changes. Findings only.
+            Runtime context for this run:
+            - PR number: ${{ github.event.pull_request.number }}
+            - Base ref (diff against this, not master):
+              ${{ github.event.pull_request.base.ref }}
+            - Submission: post exactly one `gh pr comment` with the skill's
+              findings format. Do not approve or request changes — the
+              workflow's tool allowlist omits `gh pr review`, so approval is
+              impossible at the tool level regardless.

--- a/.github/workflows/claude-review-fvm.yml
+++ b/.github/workflows/claude-review-fvm.yml
@@ -8,14 +8,18 @@ name: claude-review-fvm
 # credentials, and can safely live in the workflow file.
 #
 # The Claude GitHub App (https://github.com/apps/claude) must be installed
-# on this repository — that is what lets Claude post reviews as
-# claude[bot] (distinct from github-actions[bot]).
+# on this repository — that is what lets Claude post as claude[bot].
 #
-# The prompt currently runs in "comment only" mode as a trial. Claude will
-# post COMMENTED reviews with findings but will NOT approve or request
-# changes. Once we have calibrated trust in the reviewer, flip the final
-# stanza of the prompt to allow APPROVED / REQUEST_CHANGES — see the
-# comment near the end of the prompt block below.
+# ── TRIAL MODE ─────────────────────────────────────────────────────────
+# Claude currently posts findings as a plain PR comment (`gh pr comment`)
+# and cannot approve: the tool allowlist below does not include
+# `gh pr review`, so approval is impossible at the tool level regardless
+# of the prompt. To promote Claude to a real reviewer later:
+#   1. add `Bash(gh pr review:*)` to --allowedTools
+#   2. replace the "Submitting your findings" section of the prompt with
+#      review-submission rules (approve only when no important findings,
+#      request changes when there are, comment when uncertain)
+# ───────────────────────────────────────────────────────────────────────
 
 on:
   pull_request:
@@ -25,13 +29,18 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write   # required for Claude to submit reviews
+  pull-requests: write   # required for Claude to post comments
   id-token: write        # required for WIF: fetching the GitHub OIDC token
+
+concurrency:
+  group: claude-review-fvm-${{ github.event.pull_request.number }}
+  cancel-in-progress: true   # a new push supersedes the in-flight review
 
 jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,72 +55,135 @@ jobs:
           # anthropic_workspace_id intentionally omitted: the federation
           # rule is scoped to a single (default) workspace.
 
+          # Model intentionally not pinned — the action's default tracks
+          # Anthropic's current recommended model. Pin with
+          # `--model <id>` here if reproducibility matters more.
           claude_args: |
-            --model claude-sonnet-4-5
-            --max-turns 20
-            --allowedTools "Bash(gh pr *),Bash(gh api *),Bash(git *),Read,Grep,Glob"
+            --max-turns 30
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
 
           prompt: |
-            You are reviewing PR #${{ github.event.pull_request.number }} on
-            onflow/flow-go. It modifies FVM code (fvm/**) in a high-assurance
-            byzantine-fault-tolerant blockchain implementation.
+            You are reviewing pull request #${{ github.event.pull_request.number }}
+            on onflow/flow-go. It modifies the Flow Virtual Machine (fvm/**),
+            the execution layer of a byzantine-fault-tolerant blockchain.
+            Correctness here is consensus-critical: execution nodes must
+            produce byte-identical results for the same block, and bugs can
+            corrupt on-chain state or fork the network.
 
-            Before analyzing the diff, read:
-              - AGENTS.md at the repo root for project conventions
-              - Any CLAUDE.md files under the paths this PR touches
+            ## Scope
 
-            Focus your review on:
+            Review ONLY this PR's own changes. The base branch is
+            `${{ github.event.pull_request.base.ref }}` — FVM PRs are often
+            stacked on other feature branches, so diff against that base
+            (e.g. `git diff origin/${{ github.event.pull_request.base.ref }}...HEAD`),
+            never against master. Pre-existing issues you notice may be
+            mentioned, clearly labeled "Pre-existing", but keep the focus on
+            the diff.
 
-            1. Correctness under byzantine inputs. All external inputs are
-               potentially adversarial. Look for unchecked assumptions.
+            ## Read first
 
-            2. Error handling per the repo's contract. Benign errors are
-               typed sentinels documented on the function; unexpected errors
-               are exceptions that must propagate (never swallowed, never
-               "best-effort"). Flag any callsite that logs-and-continues on
-               an undocumented error, or that treats a documented sentinel
-               inconsistently with its context (the same error type can be
-               benign in one caller and an exception in another).
+            - AGENTS.md at the repo root — high-assurance conventions. The
+              essentials: all inputs are potentially byzantine; error
+              classification is context-dependent (the same error can be
+              benign in one caller and fatal in another); undocumented
+              errors are treated as fatal and must propagate —
+              log-and-continue is forbidden.
+            - fvm/README.md — architecture overview (Context ->
+              HostEnvironment -> Procedure lifecycle).
+            - fvm/errors/codes.go and fvm/errors/errors.go — FVM's own
+              error taxonomy. NOTE: fvm/ does NOT use the sentinel-error
+              model from the rest of the repo. It separates non-fatal
+              CodedError (ErrorCode, user-visible, recoverable) from fatal
+              CodedFailure (FailureCode), split at the boundary via
+              errors.SplitErrorTypes.
 
-            3. GoDoc completeness on public methods. Every method that
-               returns an error must document expected benign errors under
-               "Expected error returns during normal operation" — or state
-               "No error returns are expected during normal operation."
-               Missing or misleading contracts are review-worthy.
+            ## FVM-specific bug classes to check
 
-            4. Consensus determinism. Metering totals, execution snapshots,
-               and observable side effects must be identical across nodes
-               regardless of cache state, scheduling, or timing. Flag
-               anything that could diverge between warm and cold caches or
-               between concurrent and sequential execution.
+            These are the failure modes that have actually bitten this
+            codebase. Check the diff against each:
 
-            5. Ledger interaction and metering semantics. Reads and writes
-               inside RunWithMeteringDisabled scopes have subtle effects on
-               later metered reads via the interaction meter's read cache.
-               Flag cross-boundary behavior that isn't covered by a test.
+            1. Execution-result determinism / HCU discipline. Anything that
+               changes observable execution behavior — error messages
+               included in transaction results, metering amounts, emitted
+               events, enforced limits — changes execution results and
+               requires a coordinated height upgrade (HCU) to deploy. If the
+               diff changes such behavior, the PR description must
+               acknowledge it. Flag silent behavior changes loudly.
 
-            6. Test coverage of the observable contract, especially where
-               behavior changes are subtle (new sentinel error kinds, new
-               metering rules, changed merge semantics).
+            2. Cache-state independence. Program loads and other derived-data
+               computations (fvm/storage/derived) must charge identical
+               computation warm or cold. A transaction must never be charged
+               differently because another transaction warmed the cache
+               first. Look for meter state leaking into or out of cached
+               snapshots.
 
-            Use `gh pr view` and `gh api` for context you can't get from the
-            checkout. Cite file:line for every concern.
+            3. Metering scope semantics (fvm/meter, fvm/storage/state).
+               RunWithMeteringDisabled suppresses accumulation AND limit
+               enforcement. Watch the boundaries: the interaction meter
+               counts only the first read of a register (later reads are
+               free cache hits), so reads/writes inside a disabled scope
+               change what later metered reads cost. Nested transaction
+               merges (ExecutionState.Merge) decide whose meter absorbs the
+               charges — check every Begin/Commit/Restart pairing,
+               especially error paths where nested transactions unwind.
+               RunWithMeteringDisabled takes a closure, so errors escape via
+               captured variables (`RunWithMeteringDisabled(func() { err = foo() })`)
+               — check every such site for shadowed or stale `err` and for a
+               missing error check immediately after the closure returns.
 
-            # === Review submission ===
-            #
-            # Trial mode: post ONLY a COMMENTED review, regardless of what
-            # you find. Do NOT approve, do NOT request changes.
-            #
-            # Once the team has calibrated trust in this reviewer, this
-            # stanza will change to allow APPROVE and REQUEST_CHANGES. When
-            # that happens the rule will be: approve only if you found no
-            # important findings; request changes if you found any; comment
-            # if you are uncertain. Not yet.
-            #
-            # For now: submit exactly one COMMENTED review via
-            # `gh pr review --comment`, with a review body that leads with a
-            # short summary and then lists findings in file:line order.
-            # Group findings by severity (Important / Nit / Pre-existing).
-            # If you found nothing worth flagging, still post a comment
-            # saying so — this gives the humans a signal that Claude ran
-            # and had no concerns.
+            4. Error taxonomy discipline (fvm/errors). A CodedFailure must
+               always propagate as a failure — flag any callsite that
+               downgrades one to a benign error, and any re-wrap of a
+               CodedError into a CodedFailure (or vice versa) without
+               justification. Error CODES are an external contract —
+               downstream systems index on them; never renumber or reuse.
+               Error MESSAGES are part of the execution result — changing
+               one is a behavior change (see #1). In fvm/evm, the EVM error
+               path has its own semantics: errors.NewEVMError wraps
+               non-fatal EVM errors as user errors, and IsEVMError /
+               IsFailure classification at that boundary must be preserved.
+
+            5. Transaction pipeline invariants (transactionInvoker.go and
+               friends). Order matters: signature verification → sequence
+               number → payer balance check (unmetered) → body (metered,
+               inside a nested transaction) → storage limit checks → fee
+               deduction (unmetered). Fee deduction and other system-critical
+               unmetered scopes must never be able to fail on a metering
+               limit. The error-execution path must leave the nested
+               transaction stack consistent.
+
+            6. Service-account special cases. Several limits are not
+               enforced when the payer is the service account. Changes to
+               limit enforcement must preserve these exemptions — and must
+               not accidentally widen them.
+
+            7. SPoCK sensitivity (fvm/storage/state spockState). Execution
+               snapshots feed SPoCK proofs. Any nondeterminism in the
+               read/write set — map iteration order reaching the ledger,
+               time, randomness — breaks verification.
+
+            ## What NOT to spend turns on
+
+            - Style, formatting, import ordering — CI and CodeRabbit
+              already cover these.
+            - Refactors out of the PR's scope.
+            - Test-only changes to assertions that keep the same coverage.
+
+            ## Submitting your findings
+
+            Post exactly ONE comment on the PR via `gh pr comment`, with:
+
+            - First line: a one-sentence verdict ("No concerns from this
+              review" or "N findings, M of them important").
+            - Findings grouped by severity: Important (would be a bug in
+              production), Nit (worth fixing, not blocking), Pre-existing
+              (not introduced by this PR).
+            - Every finding cites file:line and states the concrete failure
+              scenario — not "this could be a problem" but "if X happens, Y
+              breaks because Z".
+            - At most 5 nits; summarize the rest in one line if there are
+              more.
+            - If you verified something subtle and found it correct, say so
+              in one line — knowing what was checked has value.
+
+            Do not approve or request changes. Findings only.


### PR DESCRIPTION
   Adds a workflow that runs Claude Code on every PR touching `fvm/**` and posts its findings as a PR comment. Companion to the branch-protection ruleset PR — that one makes room for an AI reviewer to eventually count as one of the two      
 required approvals on FVM-only changes; this one is the reviewer.                                                                                                                                                                               
                                                                                                                                                                                                                                                 
   It starts in trial mode, deliberately. Claude posts a single findings comment per run (grouped by severity, file:line citations, capped nits) and cannot approve or request changes — not just by prompt, but structurally: the tool          
 allowlist doesn't include `gh pr review`, so an approval is impossible regardless of what the model decides. Once we've watched it on enough real FVM PRs to trust the signal, promoting it is a two-line change (add `Bash(gh pr review:*)` to 
 the allowlist, swap the submission stanza of the prompt) — documented in a comment at the top of the workflow.                                                                                                                                  
                                                                                                                                                                                                                                                 
   The review prompt is specialized for this codebase rather than generic. It points Claude at `AGENTS.md`, `fvm/README.md`, and the `fvm/errors` taxonomy (CodedError vs CodedFailure — fvm does not use the sentinel model the rest of the     
 repo does), and names the bug classes that have actually bitten us: execution-result determinism and HCU discipline, warm/cold cache-state independence in derived-data metering, `RunWithMeteringDisabled` boundary semantics and              
 nested-transaction merge/unwind pairing, error-code stability, transaction pipeline phase invariants, service-account exemptions, and SPoCK sensitivity. It diffs against the PR's base ref rather than master, since FVM PRs are frequently    
 stacked. Style and formatting are explicitly out of scope — CI and CodeRabbit already cover those.                                                                                                                                              
                                                                                                                                                                                                                                                 
   Authentication uses Workload Identity Federation: the workflow exchanges its GitHub OIDC token for a short-lived Anthropic token at runtime, so there is no `ANTHROPIC_API_KEY` secret to store or rotate. The IDs in the workflow file are   
 identifiers, not credentials. The federation rule (scoped to `repo:onflow/flow-go:`) and the Claude GitHub App installation are already in place, so this should work on the first FVM PR after merge.                                          
                                                                                                                                                                                                                                                 
   Cost controls: runs are capped at 30 minutes and 30 turns, a new push cancels the in-flight review for that PR, and draft PRs are skipped until marked ready. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request reviews for changes in the FVM area.
  * Reviews run only on eligible (non-draft) pull request updates and post a single, severity-grouped comment with findings.
  * Review guidance focuses on consensus-critical determinism and metering/transaction invariants, including strict guidance on error classifications and CI “trial” reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->