### PR TITLE
Fix register lookup key owner parsing for addresses containing 0x2F

### DIFF
--- a/storage/pebble/lookup.go
+++ b/storage/pebble/lookup.go
@@ -118,8 +118,11 @@ func lookupKeyToRegisterID(lookupKey []byte) (uint64, flow.RegisterID, error) {
 		owner = string(lookupKey[:flow.AddressLength])
 		key = string(lookupKey[flow.AddressLength+1:])
 	case lookupKey[0] == '/':
+		// global registers have an empty owner
+		owner = ""
 		key = string(lookupKey[1:])
 	default:
+		// only the two cases above are valid; anything else is a malformed key
 		return 0, flow.RegisterID{},
 			fmt.Errorf("invalid lookup key format: cannot find owner/key separator")
 	}

--- a/storage/pebble/lookup.go
+++ b/storage/pebble/lookup.go
@@ -1,7 +1,6 @@
 package pebble
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -30,7 +29,11 @@ type lookupKey struct {
 //
 // Lookup keys are encoded as follows:
 // [codeRegister(1)] [owner] '/' [key] '/' [height(8)]
-// owner and key are variable length fields
+// owner and key are variable length fields.
+//
+// Note: owner must be either empty (global registers) or exactly flow.AddressLength bytes
+// (account registers). lookupKeyToRegisterID relies on this invariant to decode the owner,
+// since both owner and key may contain the '/' separator byte.
 func newLookupKey(height uint64, reg flow.RegisterID) *lookupKey {
 	key := lookupKey{
 		// 1 byte gaps for db prefix and '/' separators
@@ -102,16 +105,24 @@ func lookupKeyToRegisterID(lookupKey []byte) (uint64, flow.RegisterID, error) {
 
 	// 3. Get the owner and key
 	//
-	// we do this by getting everything before the first '/'. since the last '/' was already removed,
-	// all that's left is the key.
-	var found bool
-	ownerBytes, keyBytes, found := bytes.Cut(lookupKey, []byte("/"))
-	if !found {
-		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: cannot find first slash")
+	// What remains is [owner] '/' [key]. We cannot search for the separator: the owner is raw
+	// address bytes and may itself contain 0x2F ('/'). Instead, decode structurally: the owner
+	// is either exactly flow.AddressLength bytes (account registers) or empty (global registers).
+	//
+	// The account case is checked first so that addresses starting with 0x2F are not misparsed
+	// as global registers. This is unambiguous in practice: no global register key contains
+	// '/' at index flow.AddressLength-1.
+	var owner, key string
+	switch {
+	case len(lookupKey) > flow.AddressLength && lookupKey[flow.AddressLength] == '/':
+		owner = string(lookupKey[:flow.AddressLength])
+		key = string(lookupKey[flow.AddressLength+1:])
+	case lookupKey[0] == '/':
+		key = string(lookupKey[1:])
+	default:
+		return 0, flow.RegisterID{},
+			fmt.Errorf("invalid lookup key format: cannot find owner/key separator")
 	}
-
-	owner := string(ownerBytes)
-	key := string(keyBytes)
 
 	return height, flow.RegisterID{Owner: owner, Key: key}, nil
 }

--- a/storage/pebble/lookup_test.go
+++ b/storage/pebble/lookup_test.go
@@ -25,26 +25,26 @@ func Test_lookupKey_Bytes(t *testing.T) {
 		{
 			name:   "typical register at height 777",
 			height: 777,
-			owner:  "owner",
+			owner:  "owner678", // 8 bytes (flow.AddressLength)
 			key:    "key",
-			// [codeRegister] + "owner/key/" + ^777 as big-endian uint64
-			expectedBytes: append([]byte{codeRegister}, []byte("owner/key/\xff\xff\xff\xff\xff\xff\xfc\xf6")...),
+			// [codeRegister] + "owner678/key/" + ^777 as big-endian uint64
+			expectedBytes: append([]byte{codeRegister}, []byte("owner678/key/\xff\xff\xff\xff\xff\xff\xfc\xf6")...),
 		},
 		{
 			name:   "height 0 encodes as all 0xff",
 			height: 0,
-			owner:  "a",
+			owner:  "aaaaaaaa",
 			key:    "b",
 			// ^0 = MaxUint64 = 0xFFFFFFFFFFFFFFFF
-			expectedBytes: append([]byte{codeRegister}, []byte("a/b/\xff\xff\xff\xff\xff\xff\xff\xff")...),
+			expectedBytes: append([]byte{codeRegister}, []byte("aaaaaaaa/b/\xff\xff\xff\xff\xff\xff\xff\xff")...),
 		},
 		{
 			name:   "max height encodes as all 0x00",
 			height: math.MaxUint64,
-			owner:  "a",
+			owner:  "aaaaaaaa",
 			key:    "b",
 			// ^MaxUint64 = 0
-			expectedBytes: append([]byte{codeRegister}, []byte("a/b/\x00\x00\x00\x00\x00\x00\x00\x00")...),
+			expectedBytes: append([]byte{codeRegister}, []byte("aaaaaaaa/b/\x00\x00\x00\x00\x00\x00\x00\x00")...),
 		},
 		{
 			name:   "empty owner and key",
@@ -96,15 +96,23 @@ func Test_decodeKey_roundtrip(t *testing.T) {
 		owner  string
 		key    string
 	}{
-		{name: "key with slash", height: 10, owner: "owneraddress", key: "public/storage/hasslash-in-key"},
-		{name: "empty key", height: 10, owner: "owneraddress", key: ""},
+		{name: "key with slash", height: 10, owner: "owner678", key: "public/storage/hasslash-in-key"},
+		{name: "empty key", height: 10, owner: "owner678", key: ""},
 		{name: "empty owner", height: 10, owner: "", key: "somekey"},
 		{name: "empty owner and key", height: 10, owner: "", key: ""},
 		// Heights whose one's complement encoding contains 0x2F ('/'). These previously caused
 		// lookupKeyToRegisterID to misidentify the separator between key and height.
-		{name: "0x2F in height encoding: with owner and key", height: heightWith0x2FInEncoding, owner: "owneraddress", key: "code.Token"},
-		{name: "0x2F in height encoding: empty key", height: heightWith0x2FInEncoding, owner: "owneraddress", key: ""},
+		{name: "0x2F in height encoding: with owner and key", height: heightWith0x2FInEncoding, owner: "owner678", key: "code.Token"},
+		{name: "0x2F in height encoding: empty key", height: heightWith0x2FInEncoding, owner: "owner678", key: ""},
 		{name: "0x2F in height encoding: empty owner", height: heightWith0x2FInEncoding, owner: "", key: "code.Token"},
+		// Owners are raw address bytes and may contain 0x2F ('/'). These previously caused
+		// lookupKeyToRegisterID to split the owner at the first '/' byte (issue #8617).
+		{name: "0x2F in owner: first byte", height: 10, owner: "/abcdefg", key: "code.Token"},
+		{name: "0x2F in owner: middle byte", height: 10, owner: "ab/cdefg", key: "contract_names"},
+		{name: "0x2F in owner: last byte", height: 10, owner: "abcdefg/", key: "somekey"},
+		{name: "0x2F in owner: all bytes", height: 10, owner: "////////", key: "somekey"},
+		{name: "0x2F in owner: empty key", height: 10, owner: "ab/cdefg", key: ""},
+		{name: "0x2F in owner and height encoding", height: heightWith0x2FInEncoding, owner: "ab/cdefg", key: "code.Token"},
 	}
 
 	for _, c := range cases {
@@ -150,22 +158,31 @@ func Test_decodeKey_errors(t *testing.T) {
 			hasError: true,
 		},
 		{
-			// After stripping the prefix: {1,2,3,4,5,'/',7,8,9,10,11,12,13,14} (14 bytes).
-			// heightPos = 6, lookupKey[5] = '/' passes the separator check.
-			// The owner+key part {1,2,3,4,5} has no '/', so bytes.Cut fails.
-			name:     "no slash between owner and key",
+			// owner+key part {1,2,3,4,5} has no '/' at a valid owner boundary (0 or flow.AddressLength)
+			name:     "no owner/key separator",
 			key:      []byte{codeRegister, 1, 2, 3, 4, 5, '/', 7, 8, 9, 10, 11, 12, 13, 14},
 			hasError: true,
 		},
 		{
-			// After stripping the prefix: {1,2,3,'/',5,'/',7,8,9,10,11,12,13,14} (14 bytes).
-			// heightPos = 6, lookupKey[5] = '/', owner+key = {1,2,3,'/',5} has '/'.
-			name: "valid raw key",
-			key:  []byte{codeRegister, 1, 2, 3, '/', 5, '/', 7, 8, 9, 10, 11, 12, 13, 14},
+			// owner+key part {1,2,3,'/',5} has a '/', but not at a valid owner boundary
+			name:     "separator at wrong owner boundary",
+			key:      []byte{codeRegister, 1, 2, 3, '/', 5, '/', 7, 8, 9, 10, 11, 12, 13, 14},
+			hasError: true,
+		},
+		{
+			// owner is exactly flow.AddressLength (8) bytes followed by '/'; key is {9}.
+			name: "valid raw key with 8-byte owner",
+			key:  []byte{codeRegister, 1, 2, 3, 4, 5, 6, 7, 8, '/', 9, '/', 10, 11, 12, 13, 14, 15, 16, 17},
 		},
 		{
 			name: "valid encoded key",
-			key:  newLookupKey(uint64(0), flow.RegisterID{Owner: "owner", Key: "key"}).Bytes(),
+			key:  newLookupKey(uint64(0), flow.RegisterID{Owner: "owner678", Key: "key"}).Bytes(),
+		},
+		{
+			// owner is neither empty nor flow.AddressLength bytes, so it cannot be decoded
+			name:     "owner with invalid length",
+			key:      newLookupKey(uint64(0), flow.RegisterID{Owner: "owner", Key: "key"}).Bytes(),
+			hasError: true,
 		},
 	}
 

--- a/storage/pebble/registers_test.go
+++ b/storage/pebble/registers_test.go
@@ -560,6 +560,40 @@ func TestRegisters_ByKeyPrefix_GlobalRegisters(t *testing.T) {
 	})
 }
 
+// TestRegisters_ByKeyPrefix_OwnerContainsSlash verifies that ByKeyPrefix yields registers of
+// accounts whose raw address bytes contain 0x2F ('/'). Such accounts were previously skipped
+// because lookupKeyToRegisterID split the owner at the first '/' byte (issue #8617).
+func TestRegisters_ByKeyPrefix_OwnerContainsSlash(t *testing.T) {
+	t.Parallel()
+
+	// addresses with 0x2F ('/') at the first, a middle, and the last byte, plus one without
+	addrSlashFirst := flow.BytesToAddress([]byte{0x2f, 0xa2, 0xe8, 0x18, 0x5d, 0xf2, 0xd1, 0x4e})
+	addrSlashMiddle := flow.BytesToAddress([]byte{0x45, 0xa2, 0x2f, 0x85, 0xdf, 0xf2, 0xd1, 0x4e})
+	addrSlashLast := flow.BytesToAddress([]byte{0x45, 0xa2, 0xe8, 0x18, 0x5d, 0xf2, 0xd1, 0x2f})
+	addrPlain := flow.BytesToAddress([]byte{0x8e, 0x70, 0x02, 0x0e, 0x96, 0x5d, 0xf2, 0xea})
+
+	regs := map[flow.RegisterID]flow.RegisterValue{}
+	for i, addr := range []flow.Address{addrSlashFirst, addrSlashMiddle, addrSlashLast, addrPlain} {
+		regs[flow.ContractNamesRegisterID(addr)] = []byte(fmt.Sprintf("names%d", i))
+	}
+	// a global register (empty owner) must not disturb the scan
+	globalReg := flow.RegisterID{Owner: "", Key: flow.AddressStateKey}
+
+	RunWithRegistersStorageAtInitialHeights(t, 1, 1, func(r *Registers) {
+		entries := flow.RegisterEntries{{Key: globalReg, Value: []byte("global")}}
+		for reg, val := range regs {
+			entries = append(entries, flow.RegisterEntry{Key: reg, Value: val})
+		}
+		require.NoError(t, r.Store(entries, 2))
+
+		results := collectRegistersByKey(t, r.ByKeyPrefix(flow.ContractNamesKey, 2, nil))
+		assert.Len(t, results, len(regs))
+		for reg, val := range regs {
+			assert.Equal(t, val, results[reg], "missing or wrong value for owner %x", []byte(reg.Owner))
+		}
+	})
+}
+
 // collectRegistersByKey drains a ByKey iterator into a map keyed by register ID.
 func collectRegistersByKey(t *testing.T, iter storage.IndexIterator[flow.RegisterValue, flow.RegisterID]) map[flow.RegisterID]flow.RegisterValue {
 	t.Helper()


### PR DESCRIPTION
Closes: #8617

## Problem

`Registers.ByKeyPrefix` silently skipped all registers of any account whose 8-byte address contains `0x2F` (`'/'`) — ~3.1% of addresses. `lookupKeyToRegisterID` decoded the owner by cutting the key at the *first* `'/'` byte, which lands inside such addresses, producing a wrong `RegisterID` that derailed the scan's seek logic. This also caused `TestRegisters_ByKeyPrefix_ExactKey` to flake (~12% of runs).

## Fix

Decode the owner structurally instead of searching for the separator: the owner is either exactly `flow.AddressLength` (8) bytes (account registers) or empty (global registers). The account case is checked first so addresses *starting* with `0x2F` are not misparsed as global registers — unambiguous in practice, since no global register key contains `'/'` at index 7. Keys whose owner is neither empty nor 8 bytes now return an error instead of decoding garbage (no production writer produces such keys; only `ByKeyPrefix` parses keys, `Get`/`Store` are unaffected).

## Testing

- New roundtrip cases for `0x2F` at every owner position, plus a deterministic end-to-end regression test (`TestRegisters_ByKeyPrefix_OwnerContainsSlash`) with crafted addresses
- Repro loop from #8617: 300 runs, zero failures (was ~12% flake rate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoding of encoded lookup keys to correctly handle account owners containing the `/` byte.
  * Improved parsing of variable-length owner/key fields and delimiter handling, avoiding misinterpretation of separator bytes.

* **Tests**
  * Added/expanded test cases for lookup key encoding/decoding edge scenarios involving `/` in owner bytes and height encodings.
  * Added a test ensuring prefix-based register searches return correct results when owner bytes contain `/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->