### PR TITLE
[CI] Pass custom linter binary to Lint jobs via artifact instead of cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           name: custom-gcl
           path: tools/custom-gcl
-          retention-days: 1
           if-no-files-found: error
           # Allow "Re-run all jobs": the previous attempt's artifact still exists on the run,
           # and without this the upload would fail with a name conflict.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,26 +44,34 @@ jobs:
         id: cache-linter
         uses: actions/cache@v5
         with:
-          # Key should change whenever implementation (tools/structwrite), or compilation config (.custom-gcl.yml) changes
-          # When the key is different, it is a cache miss, and the custom linter binary is recompiled
-          # We include the SHA in the hash key because:
-          #    - cache keys are branch/reference-scoped, with some exceptions (see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)
-          #    - (we believe) cache keys for a repo share one namespace (sort of implied by https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#matching-a-cache-key)
-          #    - (we believe) the same cache being written by two different branches may cause contention,
-          #       as a result of the shared namespace and branch-scoped permissions
-          key: custom-linter-${{ env.GO_VERSION }}-${{ runner.os }}-${{ hashFiles('.custom-gcl.yml', 'tools/structwrite/**') }}-${{ github.sha }}
-          # If a matching cache item from a different branch exists, and we have permission to access it, use it.
-          restore-keys: |
-            custom-linter-${{ env.GO_VERSION }}-${{ runner.os }}-${{ hashFiles('.custom-gcl.yml', 'tools/structwrite/**') }}
+          # The cache is only a build accelerator: on a hit we skip rebuilding the custom linter
+          # binary (which takes ~30 minutes). The binary is passed to the lint jobs via an
+          # artifact (see below), so a failed cache save or restore only costs a rebuild on a
+          # future run - it never fails the workflow.
+          # Key changes whenever the implementation (tools/structwrite) or the compilation
+          # config (.custom-gcl.yml) changes, causing a miss and a recompilation.
+          key: custom-linter-${{ env.GO_VERSION }}-${{ runner.os }}-${{ hashFiles('.custom-gcl.yml', 'tools/structwrite/**') }}
           path: tools/custom-gcl # path defined in .custom-gcl.yml
-          lookup-only: 'true'    # if already cached, don't download here
-      # We install the non-custom golangci-lint binary using the golangci-lint action.
-      - name: Install golangci-lint
+      # The golangci-lint action detects .custom-gcl.yml and builds the custom linter binary.
+      - name: Install golangci-lint and build custom linter binary
         if: steps.cache-linter.outputs.cache-hit != 'true'
         uses: golangci/golangci-lint-action@v9
         with:
           install-only: true
           version: v2.7.1
+      # The artifact (not the cache) is how the binary reaches the lint jobs: artifacts are
+      # guaranteed within a run (a failed upload fails this job), while cache saves are
+      # best-effort and can fail silently, which previously hard-failed the lint jobs.
+      - name: Upload custom linter binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: custom-gcl
+          path: tools/custom-gcl
+          retention-days: 1
+          if-no-files-found: error
+          # Allow "Re-run all jobs": the previous attempt's artifact still exists on the run,
+          # and without this the upload would fail with a name conflict.
+          overwrite: true
 
   golangci:
     strategy:
@@ -87,20 +95,13 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: true
-    - name: Restore custom linter binary from cache
-      id: cache-linter
-      uses: actions/cache@v5
+    # The build-linter job uploads the custom linter binary as an artifact, which is guaranteed
+    # to exist within this run (unlike a cache entry, which is best-effort).
+    - name: Download custom linter binary
+      uses: actions/download-artifact@v8
       with:
-        # See "Cache custom linter binary" job for information about the key structure
-        key: custom-linter-${{ env.GO_VERSION }}-${{ runner.os }}-${{ hashFiles('.custom-gcl.yml', 'tools/structwrite/**') }}-${{ github.sha }}
-        # If a matching cache item from a different branch exists, and we have permission to access it, use it.
-        restore-keys: |
-          custom-linter-${{ env.GO_VERSION }}-${{ runner.os }}-${{ hashFiles('.custom-gcl.yml', 'tools/structwrite/**') }}
-        path: tools/custom-gcl
-        # We are using the cache to share data between the build-linter job and the 3 lint jobs
-        # If there is a cache miss, it likely means either the build-linter job failed or the cache entry was evicted
-        # We expect this to happen very infrequently. If it does happen, the workflow needs to be manually retried.
-        fail-on-cache-miss: 'true'
+        name: custom-gcl
+        path: tools/
     - name: Run go generate
       run: go generate ./...
       working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
## Motivation

The `Lint` jobs randomly fail with `Failed to restore cache entry. Exiting as fail-on-cache-miss is set`
([example run](https://github.com/onflow/flow-go/actions/runs/29854898925)).

The custom linter binary is handed from `build-linter` to the 3 `Lint` jobs through the **actions cache**,
which is best-effort by contract: in the linked run the cache backend returned HTTP 500 on every save
attempt, `build-linter` stayed green (save failures are warnings), and the Lint jobs hard-failed on the
guaranteed cache miss. Worse, **"Re-run failed jobs" can never recover** — the green build job is
skipped, so nothing repopulates the cache.

```mermaid
flowchart LR
    subgraph before ["Before"]
        B1["build-linter<br/>builds binary (~30 min)"] -. "cache save<br/>best-effort, can fail silently" .-> C1[("actions cache")]
        C1 -- "restore with<br/>fail-on-cache-miss" --> L1["Lint ×3<br/>❌ hard fail on miss"]
    end
```

```mermaid
flowchart LR
    subgraph after ["After"]
        B2["build-linter<br/>builds only on cache miss"] == "artifact<br/>guaranteed within the run" ==> L2["Lint ×3<br/>✅ always gets the binary"]
        B2 -. "cache<br/>build accelerator only" .-> C2[("actions cache")]
        C2 -. "restore on hit<br/>(skip 30 min build)" .-> B2
    end
```

## Changes

- `build-linter` uploads `tools/custom-gcl` as a workflow **artifact** — guaranteed within a run
  (a failed upload fails the job, unlike a cache save), with `overwrite: true` so "Re-run all jobs" works.
- The `Lint` jobs download the artifact instead of restoring from cache; `fail-on-cache-miss` is gone.
  Re-running only failed Lint jobs now works too, since the artifact from the same run is still there.
- The cache remains purely as a build accelerator, and its key drops the per-commit `github.sha`
  suffix — one entry per toolchain/source hash instead of one per commit, so far less eviction pressure.

A cache backend outage now costs at most a rebuild on a future run, never a red CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of automated code-quality checks by ensuring the custom linting tool is always available within the same workflow run.
  * Reduced CI failures caused by missing or outdated cached linting binaries by switching from cache restore behavior to artifact-based handoff between jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->