### PR TITLE
Handle all errors in RegisterStore.onBlockFinalized

### DIFF
--- a/engine/execution/storehouse/register_store.go
+++ b/engine/execution/storehouse/register_store.go
@@ -192,11 +192,20 @@ func (r *RegisterStore) onBlockFinalized() error {
 		// next block is not finalized yet
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("cannot get finalized block ID at height %v: %w", next, err)
+	}
 
 	regs, err := r.memStore.GetUpdatedRegisters(next, blockID)
 	if errors.Is(err, ErrNotExecuted) {
 		// next block is not executed yet
 		return nil
+	}
+	if err != nil {
+		// any other error is an exception, we must not proceed to store
+		// a nil register list to the disk store, which would incorrectly
+		// index the height with no register updates
+		return fmt.Errorf("cannot get updated registers for block %v at height %v: %w", blockID, next, err)
 	}
 
 	// TODO: append WAL

--- a/engine/execution/storehouse/register_store_test.go
+++ b/engine/execution/storehouse/register_store_test.go
@@ -5,9 +5,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/engine/execution"
+	executionMock "github.com/onflow/flow-go/engine/execution/mock"
 	"github.com/onflow/flow-go/engine/execution/storehouse"
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/model/flow"
@@ -582,5 +584,64 @@ func TestRegisterStoreConcurrentFinalizeAndExecute(t *testing.T) {
 
 		// after all heights are executed and finalized, the LastFinalizedAndExecutedHeight should be the last height
 		require.Equal(t, endHeight, rs.LastFinalizedAndExecutedHeight())
+	})
+}
+
+// OnBlockFinalized must return an exception (instead of storing registers to the
+// disk store) when the finalized reader fails with a non-NotFound error, or when
+// the in memory store fails with a non-ErrNotExecuted error. Storing in those cases
+// would incorrectly index the height with no register updates.
+func TestRegisterStoreOnBlockFinalizedErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	rootHeight := uint64(10)
+	rootID := unittest.IdentifierFixture()
+
+	t.Run("finalized reader exception", func(t *testing.T) {
+		diskStore := executionMock.NewOnDiskRegisterStore(t)
+		// called twice by NewRegisterStore's syncDiskStore
+		diskStore.On("LatestHeight").Return(rootHeight).Twice()
+		// called once by onBlockFinalized
+		diskStore.On("LatestHeight").Return(rootHeight).Once()
+
+		finalized := executionMock.NewFinalizedReader(t)
+		// called by NewRegisterStore to initialize the memStore
+		finalized.On("FinalizedBlockIDAtHeight", rootHeight).Return(rootID, nil).Once()
+		// the finalized reader returns an exception for the next height
+		finalized.On("FinalizedBlockIDAtHeight", rootHeight+1).
+			Return(flow.Identifier{}, fmt.Errorf("db exception")).Once()
+
+		rs, err := storehouse.NewRegisterStore(diskStore, nil, finalized, unittest.Logger(), storehouse.NewNoopNotifier())
+		require.NoError(t, err)
+
+		err = rs.OnBlockFinalized()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot get finalized block ID at height")
+
+		// no registers should be stored to the disk store
+		diskStore.AssertNotCalled(t, "Store", mock.Anything, mock.Anything)
+	})
+
+	t.Run("mem store exception", func(t *testing.T) {
+		diskStore := executionMock.NewOnDiskRegisterStore(t)
+		// called twice by NewRegisterStore's syncDiskStore, initializing the memStore at rootHeight
+		diskStore.On("LatestHeight").Return(rootHeight).Twice()
+		// simulate an inconsistent state where the disk store falls behind the memStore's
+		// pruned height, so that GetUpdatedRegisters fails with a non-ErrNotExecuted error
+		diskStore.On("LatestHeight").Return(rootHeight - 5).Once()
+
+		finalized := executionMock.NewFinalizedReader(t)
+		finalized.On("FinalizedBlockIDAtHeight", rootHeight).Return(rootID, nil).Once()
+		finalized.On("FinalizedBlockIDAtHeight", rootHeight-4).Return(unittest.IdentifierFixture(), nil).Once()
+
+		rs, err := storehouse.NewRegisterStore(diskStore, nil, finalized, unittest.Logger(), storehouse.NewNoopNotifier())
+		require.NoError(t, err)
+
+		err = rs.OnBlockFinalized()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot get updated registers")
+
+		// nil registers must not be stored to the disk store
+		diskStore.AssertNotCalled(t, "Store", mock.Anything, mock.Anything)
 	})
 }


### PR DESCRIPTION
Improve error handling in RegisterStore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during block finalization.
  * Prevents invalid register data from being written when finalized block information or in-memory updates cannot be retrieved.
  * Provides clearer error reporting for inconsistent or unavailable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->