### PR TITLE
Support batch-wise comparison for blocks in the `‎compare-cadence-vm` tool

### DIFF
--- a/cmd/util/cmd/compare-cadence-vm/cmd.go
+++ b/cmd/util/cmd/compare-cadence-vm/cmd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -43,6 +44,9 @@ var (
 	flagParallel            int
 	flagSubscribe           bool
 	flagSubscriptionDelay   time.Duration
+	flagBatchSize           int
+	flagProgressFile        string
+	flagResume              bool
 )
 
 var Cmd = &cobra.Command{
@@ -83,9 +87,17 @@ func init() {
 	Cmd.Flags().BoolVar(&flagSubscribe, "subscribe", false, "subscribe to new sealed blocks and compare them as they arrive")
 
 	Cmd.Flags().DurationVar(&flagSubscriptionDelay, "subscription-delay", 1*time.Minute, "delay after receiving a new sealed block before comparing it")
+
+	Cmd.Flags().IntVar(&flagBatchSize, "batch-size", 0, "number of blocks to compare per batch. the progress is recorded after each batch, so that an interrupted run can be resumed (default: 0, compare all blocks in a single batch)")
+
+	Cmd.Flags().StringVar(&flagProgressFile, "progress-file", "", "path of the file which records the progress (default: a file named after the compared blocks, in the current directory)")
+
+	Cmd.Flags().BoolVar(&flagResume, "resume", false, "continue the run recorded in the progress file, repeating only the batch which was interrupted. all other flags must be the same as in the interrupted run")
 }
 
 func run(_ *cobra.Command, args []string) {
+
+	validateBatchingFlags()
 
 	chainID := flow.ChainID(flagChain)
 	chain := chainID.Chain()
@@ -215,75 +227,238 @@ reconnect:
 	}
 }
 
+// validateBatchingFlags checks the flags which control batching and resumption.
+func validateBatchingFlags() {
+	if flagBatchSize < 0 {
+		log.Fatal().Msgf("--batch-size must not be negative, but is %d", flagBatchSize)
+	}
+
+	if flagSubscribe && (flagBatchSize != 0 || flagProgressFile != "" || flagResume) {
+		log.Fatal().Msg("--batch-size, --progress-file, and --resume can not be used with --subscribe")
+	}
+}
+
+type block struct {
+	id     flow.Identifier
+	header *flow.Header
+}
+
+// blockLoader fetches the headers of the blocks of a run, in the order in which they are compared.
+//
+// The blocks of a run are either the explicitly provided block IDs,
+// or the block with the provided ID and its ancestors, when a block count is provided.
+//
+// NOT CONCURRENCY SAFE!
+type blockLoader struct {
+	flowClient *client.Client
+
+	// explicitBlockIDs are the blocks to compare, if they were provided explicitly.
+	// It is empty if the blocks are instead determined by following the parent of each block.
+	explicitBlockIDs []flow.Identifier
+
+	// nextBlockID is the ID of the first block which was not loaded yet.
+	// It is the zero identifier once all blocks of the run were loaded.
+	nextBlockID flow.Identifier
+
+	// loadedBlockCount is the number of blocks which were loaded so far.
+	loadedBlockCount int
+}
+
+// loadNextBlocks fetches the headers of the next count blocks.
+func (l *blockLoader) loadNextBlocks(count int) []block {
+
+	var headerProgress util.LogProgressFunc[int]
+	if len(l.explicitBlockIDs) == 0 {
+		headerProgress = util.LogProgress(
+			log.Logger,
+			util.NewLogProgressConfig(
+				"fetching block headers",
+				count,
+				1*time.Second,
+				100/5, // log every 5%
+			),
+		)
+	}
+
+	blocks := make([]block, 0, count)
+
+	for i := 0; i < count; i++ {
+		if l.nextBlockID == flow.ZeroID {
+			log.Fatal().Msgf("no block left to compare, but %d more were requested", count-i)
+		}
+
+		blockID := l.nextBlockID
+		header := debug_tx.FetchBlockHeader(blockID, l.flowClient)
+
+		blocks = append(blocks, block{
+			id:     blockID,
+			header: header,
+		})
+
+		l.loadedBlockCount++
+		l.advance(header)
+
+		if headerProgress != nil {
+			headerProgress(1)
+		}
+	}
+
+	return blocks
+}
+
+// advance moves the loader to the block which follows the given just loaded block header.
+func (l *blockLoader) advance(header *flow.Header) {
+	if len(l.explicitBlockIDs) == 0 {
+		l.nextBlockID = header.ParentID
+		return
+	}
+
+	if l.loadedBlockCount >= len(l.explicitBlockIDs) {
+		l.nextBlockID = flow.ZeroID
+		return
+	}
+
+	l.nextBlockID = l.explicitBlockIDs[l.loadedBlockCount]
+}
+
 func compareBlocks(
 	blockIDs []flow.Identifier,
 	flowClient *client.Client,
 	remoteClient debug.RemoteClient,
 	chain flow.Chain,
 ) {
-	type block struct {
-		id     flow.Identifier
-		header *flow.Header
-	}
+	followsParents := flagBlockCount != 1
 
-	var blocks []block
-
-	if flagBlockCount != 1 {
+	totalBlockCount := len(blockIDs)
+	if followsParents {
 		if len(blockIDs) > 1 {
 			log.Fatal().Msg("either provide a single block ID and use --block-count, or provide multiple block IDs and do not use --block-count")
 		}
 
-		blockHeaderProgress := util.LogProgress(
-			log.Logger,
-			util.NewLogProgressConfig(
-				"fetching block headers",
-				flagBlockCount,
-				1*time.Second,
-				100/5, // log every 5%
-			),
-		)
+		totalBlockCount = flagBlockCount
+	}
 
-		blockID := blockIDs[0]
-		for i := 0; i < flagBlockCount; i++ {
-			header := debug_tx.FetchBlockHeader(blockID, flowClient)
+	// A run without an explicit batch size compares all blocks in a single batch.
+	batchSize := flagBatchSize
+	if batchSize == 0 {
+		batchSize = totalBlockCount
+	}
 
-			blocks = append(blocks, block{
-				id:     blockID,
-				header: header,
-			})
+	config := runConfig{
+		Chain:        flagChain,
+		BlockIDs:     blockIDStrings(blockIDs),
+		BlockCount:   flagBlockCount,
+		ComputeLimit: flagComputeLimit,
+	}
 
-			blockHeaderProgress(1)
+	progressFilePath := resolveProgressFilePath(blockIDs[0], totalBlockCount)
+	if progressFilePath != "" {
+		log.Info().Msgf("Recording the progress of this run in %s", progressFileLocation(progressFilePath))
+	}
 
-			blockID = header.ParentID
+	progress := startRunProgress(progressFilePath, config, totalBlockCount, blockIDs[0])
+
+	loader := &blockLoader{
+		flowClient:       flowClient,
+		loadedBlockCount: progress.CompletedBlockCount,
+	}
+	if !followsParents {
+		loader.explicitBlockIDs = blockIDs
+	}
+
+	completedBlockCount := progress.CompletedBlockCount
+	stats := progress.Stats
+
+	if completedBlockCount < totalBlockCount {
+		nextBlockID, err := progress.nextBlockID()
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to determine the block to continue at")
 		}
-
-	} else {
-		for _, blockID := range blockIDs {
-			header := debug_tx.FetchBlockHeader(blockID, flowClient)
-
-			blocks = append(blocks, block{
-				id:     blockID,
-				header: header,
-			})
-		}
+		loader.nextBlockID = nextBlockID
 	}
 
 	blockProgress := util.LogProgress(
 		log.Logger,
 		util.NewLogProgressConfig(
 			"executing blocks",
-			flagBlockCount,
+			totalBlockCount,
 			1*time.Second,
 			100/5, // log every 5%
 		),
 	)
 
-	var (
-		blocksMismatched int64
-		blocksMatched    int64
-		txMismatched     int64
-		txMatched        int64
-	)
+	if completedBlockCount >= totalBlockCount {
+		log.Info().Msgf("All %d blocks of this run were already compared", totalBlockCount)
+	} else if completedBlockCount > 0 {
+		log.Info().Msgf(
+			"Continuing at block %s: %d of %d blocks were already compared",
+			loader.nextBlockID,
+			completedBlockCount,
+			totalBlockCount,
+		)
+
+		blockProgress(completedBlockCount)
+	}
+
+	for completedBlockCount < totalBlockCount {
+		batchBlockCount := min(batchSize, totalBlockCount-completedBlockCount)
+
+		log.Info().Msgf(
+			"Comparing blocks %d to %d of %d, starting at block %s ...",
+			completedBlockCount+1,
+			completedBlockCount+batchBlockCount,
+			totalBlockCount,
+			loader.nextBlockID,
+		)
+
+		blocks := loader.loadNextBlocks(batchBlockCount)
+
+		stats.add(compareBatch(
+			blocks,
+			flowClient,
+			remoteClient,
+			chain,
+			blockProgress,
+		))
+
+		completedBlockCount += batchBlockCount
+
+		if progressFilePath != "" {
+			progress.CompletedBlockCount = completedBlockCount
+			progress.NextBlockID = blockIDString(loader.nextBlockID)
+			progress.Stats = stats
+
+			if err := writeRunProgress(progressFilePath, progress); err != nil {
+				// The batch was compared, but its progress was not recorded.
+				// Continuing would record the following batches as if this batch had been recorded,
+				// so the run stops instead, and repeats this batch when it is resumed.
+				log.Fatal().Err(err).Msgf(
+					"failed to record the progress after comparing %d blocks",
+					completedBlockCount,
+				)
+			}
+		}
+
+		// Report the results so far, so that a long run which is interrupted
+		// still reported the results of all batches it completed.
+		if completedBlockCount < totalBlockCount {
+			logStats(stats)
+		}
+	}
+
+	logStats(stats)
+}
+
+// compareBatch compares the given blocks and returns their combined results.
+func compareBatch(
+	blocks []block,
+	flowClient *client.Client,
+	remoteClient debug.RemoteClient,
+	chain flow.Chain,
+	blockProgress util.LogProgressFunc[int],
+) runStats {
+
+	var stats runStats
 
 	g, _ := errgroup.WithContext(context.Background())
 	g.SetLimit(flagParallel)
@@ -299,12 +474,12 @@ func compareBlocks(
 				chain,
 			)
 
-			atomic.AddInt64(&txMismatched, int64(result.mismatches))
-			atomic.AddInt64(&txMatched, int64(result.matches))
+			atomic.AddInt64(&stats.TransactionsMismatched, int64(result.mismatches))
+			atomic.AddInt64(&stats.TransactionsMatched, int64(result.matches))
 			if result.mismatches > 0 {
-				atomic.AddInt64(&blocksMismatched, 1)
+				atomic.AddInt64(&stats.BlocksMismatched, 1)
 			} else {
-				atomic.AddInt64(&blocksMatched, 1)
+				atomic.AddInt64(&stats.BlocksMatched, 1)
 			}
 
 			blockProgress(1)
@@ -317,8 +492,126 @@ func compareBlocks(
 		log.Fatal().Err(err).Msg("failed to compare blocks")
 	}
 
-	log.Info().Msgf("Compared %d blocks: %d matched, %d mismatched", blocksMatched+blocksMismatched, blocksMatched, blocksMismatched)
-	log.Info().Msgf("Compared %d transactions: %d matched, %d mismatched", txMatched+txMismatched, txMatched, txMismatched)
+	return stats
+}
+
+// resolveProgressFilePath returns the path of the file which records the progress of the run,
+// or the empty string if the run does not record its progress.
+//
+// A run which compares all blocks in a single batch has no intermediate progress to record,
+// so it only records its progress if a progress file was requested explicitly.
+func resolveProgressFilePath(firstBlockID flow.Identifier, totalBlockCount int) string {
+	if flagProgressFile != "" {
+		return flagProgressFile
+	}
+
+	if flagBatchSize == 0 && !flagResume {
+		return ""
+	}
+
+	return defaultProgressFileName(firstBlockID, totalBlockCount)
+}
+
+// defaultProgressFileName returns the name of the progress file for a run
+// which did not request a particular one.
+//
+// The name is derived from the compared blocks, so that resuming the same run
+// finds the progress file of that run in the directory the command is run in.
+func defaultProgressFileName(firstBlockID flow.Identifier, totalBlockCount int) string {
+	return fmt.Sprintf(
+		"compare-cadence-vm-%s-%d.progress.json",
+		firstBlockID.String()[:16],
+		totalBlockCount,
+	)
+}
+
+// progressFileLocation returns the absolute path of the progress file, for reporting it to the user.
+// It falls back to the given path if the absolute path can not be determined.
+func progressFileLocation(path string) string {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return absolutePath
+}
+
+// startRunProgress returns the progress which the run continues from.
+//
+// A run which is not resumed refuses to discard the progress of a previous run,
+// and records that it has not compared any block yet, so that a progress file which can not be
+// written is reported before any block is compared, instead of after the first batch.
+func startRunProgress(
+	progressFilePath string,
+	config runConfig,
+	totalBlockCount int,
+	firstBlockID flow.Identifier,
+) runProgress {
+
+	if flagResume {
+		progress, err := readRunProgress(progressFilePath)
+		if err != nil {
+			log.Fatal().Err(err).Msgf(
+				"failed to read the progress file %s. run without --resume to start a new run",
+				progressFileLocation(progressFilePath),
+			)
+		}
+
+		if err := progress.validate(config, totalBlockCount); err != nil {
+			log.Fatal().Err(err).Msg("failed to resume the recorded run")
+		}
+
+		return progress
+	}
+
+	progress := newRunProgress(config, firstBlockID)
+
+	if progressFilePath == "" {
+		return progress
+	}
+
+	exists, err := runProgressExists(progressFilePath)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to check for an existing progress file")
+	}
+	if exists {
+		log.Fatal().Msgf(
+			"progress file %s already exists. use --resume to continue the recorded run, or remove the file to start over",
+			progressFileLocation(progressFilePath),
+		)
+	}
+
+	if err := writeRunProgress(progressFilePath, progress); err != nil {
+		log.Fatal().Err(err).Msgf(
+			"failed to create the progress file %s",
+			progressFileLocation(progressFilePath),
+		)
+	}
+
+	return progress
+}
+
+// blockIDStrings returns the hexadecimal representations of the given block IDs.
+func blockIDStrings(blockIDs []flow.Identifier) []string {
+	strs := make([]string, 0, len(blockIDs))
+	for _, blockID := range blockIDs {
+		strs = append(strs, blockID.String())
+	}
+	return strs
+}
+
+func logStats(stats runStats) {
+	log.Info().Msgf(
+		"Compared %d blocks: %d matched, %d mismatched",
+		stats.BlocksMatched+stats.BlocksMismatched,
+		stats.BlocksMatched,
+		stats.BlocksMismatched,
+	)
+	log.Info().Msgf(
+		"Compared %d transactions: %d matched, %d mismatched",
+		stats.TransactionsMatched+stats.TransactionsMismatched,
+		stats.TransactionsMatched,
+		stats.TransactionsMismatched,
+	)
 }
 
 type blockResult struct {

--- a/cmd/util/cmd/compare-cadence-vm/cmd.go
+++ b/cmd/util/cmd/compare-cadence-vm/cmd.go
@@ -92,7 +92,7 @@ func init() {
 
 	Cmd.Flags().StringVar(&flagProgressFile, "progress-file", "", "path of the file which records the progress (default: a file named after the compared blocks, in the current directory)")
 
-	Cmd.Flags().BoolVar(&flagResume, "resume", false, "continue the run recorded in the progress file, repeating only the batch which was interrupted. all other flags must be the same as in the interrupted run")
+	Cmd.Flags().BoolVar(&flagResume, "resume", false, "continue the run recorded in the progress file, repeating only the batch which was interrupted. all other flags except --batch-size must be the same as in the interrupted run")
 }
 
 func run(_ *cobra.Command, args []string) {
@@ -262,6 +262,9 @@ type blockLoader struct {
 
 	// loadedBlockCount is the number of blocks which were loaded so far.
 	loadedBlockCount int
+
+	// totalBlockCount determines when nextBlockID is cleared after the final block is loaded.
+	totalBlockCount int
 }
 
 // loadNextBlocks fetches the headers of the next count blocks.
@@ -306,15 +309,17 @@ func (l *blockLoader) loadNextBlocks(count int) []block {
 	return blocks
 }
 
-// advance moves the loader to the block which follows the given just loaded block header.
+// advance moves the loader to the next block in the run.
+// It clears nextBlockID once the requested number of blocks has been loaded;
+// otherwise, it selects either the loaded block's parent or the next explicit block ID.
 func (l *blockLoader) advance(header *flow.Header) {
-	if len(l.explicitBlockIDs) == 0 {
-		l.nextBlockID = header.ParentID
+	if l.loadedBlockCount >= l.totalBlockCount {
+		l.nextBlockID = flow.ZeroID
 		return
 	}
 
-	if l.loadedBlockCount >= len(l.explicitBlockIDs) {
-		l.nextBlockID = flow.ZeroID
+	if len(l.explicitBlockIDs) == 0 {
+		l.nextBlockID = header.ParentID
 		return
 	}
 
@@ -361,6 +366,7 @@ func compareBlocks(
 	loader := &blockLoader{
 		flowClient:       flowClient,
 		loadedBlockCount: progress.CompletedBlockCount,
+		totalBlockCount:  totalBlockCount,
 	}
 	if !followsParents {
 		loader.explicitBlockIDs = blockIDs

--- a/cmd/util/cmd/compare-cadence-vm/cmd.go
+++ b/cmd/util/cmd/compare-cadence-vm/cmd.go
@@ -413,12 +413,28 @@ func compareBlocks(
 
 		blocks := loader.loadNextBlocks(batchBlockCount)
 
+		// Report the progress within the batch, in addition to the progress of the whole run.
+		// A run with a single batch would report the same progress twice.
+		var batchProgress util.LogProgressFunc[int]
+		if batchBlockCount < totalBlockCount {
+			batchProgress = util.LogProgress(
+				log.Logger,
+				util.NewLogProgressConfig(
+					"executing blocks in current batch",
+					batchBlockCount,
+					1*time.Second,
+					100/5, // log every 5%
+				),
+			)
+		}
+
 		stats.add(compareBatch(
 			blocks,
 			flowClient,
 			remoteClient,
 			chain,
 			blockProgress,
+			batchProgress,
 		))
 
 		completedBlockCount += batchBlockCount
@@ -450,12 +466,16 @@ func compareBlocks(
 }
 
 // compareBatch compares the given blocks and returns their combined results.
+//
+// Each compared block is reported to the progress of the whole run,
+// and to the progress within the batch, if there is more than one batch.
 func compareBatch(
 	blocks []block,
 	flowClient *client.Client,
 	remoteClient debug.RemoteClient,
 	chain flow.Chain,
-	blockProgress util.LogProgressFunc[int],
+	overallProgress util.LogProgressFunc[int],
+	batchProgress util.LogProgressFunc[int],
 ) runStats {
 
 	var stats runStats
@@ -482,7 +502,10 @@ func compareBatch(
 				atomic.AddInt64(&stats.BlocksMatched, 1)
 			}
 
-			blockProgress(1)
+			overallProgress(1)
+			if batchProgress != nil {
+				batchProgress(1)
+			}
 
 			return nil
 		})

--- a/cmd/util/cmd/compare-cadence-vm/progress.go
+++ b/cmd/util/cmd/compare-cadence-vm/progress.go
@@ -1,0 +1,252 @@
+package compare_cadence_vm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// progressVersion is the schema version of the progress file.
+// It is increased whenever the format changes in a way that makes older files unusable.
+const progressVersion = 1
+
+// runConfig captures the flags that determine which blocks a run compares, and how it compares them.
+// A run may only resume from a progress file that was written by a run with an equal configuration,
+// because the recorded number of compared blocks is otherwise meaningless.
+//
+// The batch size is deliberately not part of the configuration: the progress is recorded as a
+// number of compared blocks, which a run with a different batch size continues from just as well.
+type runConfig struct {
+	Chain        string   `json:"chain"`
+	BlockIDs     []string `json:"block_ids"`
+	BlockCount   int      `json:"block_count"`
+	ComputeLimit uint64   `json:"compute_limit"`
+}
+
+// equals returns true if both configurations compare the same blocks in the same way.
+// The configurations can not be compared with the equality operator, because they contain a slice.
+func (c runConfig) equals(other runConfig) bool {
+	return c.Chain == other.Chain &&
+		c.BlockCount == other.BlockCount &&
+		c.ComputeLimit == other.ComputeLimit &&
+		slices.Equal(c.BlockIDs, other.BlockIDs)
+}
+
+// runStats are the comparison results accumulated over all completed batches of a run.
+type runStats struct {
+	BlocksMatched          int64 `json:"blocks_matched"`
+	BlocksMismatched       int64 `json:"blocks_mismatched"`
+	TransactionsMatched    int64 `json:"transactions_matched"`
+	TransactionsMismatched int64 `json:"transactions_mismatched"`
+}
+
+// add adds the results of another batch or run.
+func (s *runStats) add(other runStats) {
+	s.BlocksMatched += other.BlocksMatched
+	s.BlocksMismatched += other.BlocksMismatched
+	s.TransactionsMatched += other.TransactionsMatched
+	s.TransactionsMismatched += other.TransactionsMismatched
+}
+
+// runProgress is the persisted state of a batched comparison run.
+//
+// It is only written once all blocks of a batch have been compared. A run that is interrupted
+// while comparing a batch therefore resumes at the first block of that batch, and never skips
+// a block that has not been compared.
+type runProgress struct {
+	Version int       `json:"version"`
+	Config  runConfig `json:"config"`
+
+	// CompletedBlockCount is the number of blocks that all completed batches compared.
+	CompletedBlockCount int `json:"completed_block_count"`
+
+	// NextBlockID is the ID of the first block of the next batch,
+	// and is empty once all blocks of the run have been compared.
+	NextBlockID string `json:"next_block_id"`
+
+	Stats runStats `json:"stats"`
+}
+
+// newRunProgress returns the progress of a run that has not compared any block yet.
+func newRunProgress(config runConfig, firstBlockID flow.Identifier) runProgress {
+	return runProgress{
+		Version:     progressVersion,
+		Config:      config,
+		NextBlockID: blockIDString(firstBlockID),
+	}
+}
+
+// validate checks that the progress was written by an equivalent run and describes a state
+// that the current run can continue from.
+//
+// No error returns are expected during normal operation.
+func (p runProgress) validate(config runConfig, totalBlockCount int) error {
+	if p.Version != progressVersion {
+		return fmt.Errorf(
+			"progress file has version %d, but this version of the tool writes version %d",
+			p.Version,
+			progressVersion,
+		)
+	}
+
+	if !p.Config.equals(config) {
+		return fmt.Errorf("progress file was written by a run with a different configuration")
+	}
+
+	if p.CompletedBlockCount < 0 || p.CompletedBlockCount > totalBlockCount {
+		return fmt.Errorf(
+			"progress file reports %d compared blocks, which is outside the %d blocks of this run",
+			p.CompletedBlockCount,
+			totalBlockCount,
+		)
+	}
+
+	if p.CompletedBlockCount == totalBlockCount {
+		return nil
+	}
+
+	if _, err := p.nextBlockID(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// nextBlockID returns the ID of the first block of the next batch.
+//
+// No error returns are expected during normal operation.
+func (p runProgress) nextBlockID() (flow.Identifier, error) {
+	if p.NextBlockID == "" {
+		return flow.ZeroID, fmt.Errorf("progress file does not contain the ID of the next block")
+	}
+
+	blockID, err := flow.HexStringToIdentifier(p.NextBlockID)
+	if err != nil {
+		return flow.ZeroID, fmt.Errorf("progress file contains an invalid next block ID: %w", err)
+	}
+
+	return blockID, nil
+}
+
+// blockIDString returns the hexadecimal representation of the block ID,
+// and the empty string for the zero identifier, which indicates that no block is left to compare.
+func blockIDString(blockID flow.Identifier) string {
+	if blockID == flow.ZeroID {
+		return ""
+	}
+	return blockID.String()
+}
+
+// runProgressExists returns true if a progress file exists at the given path.
+//
+// No error returns are expected during normal operation.
+func runProgressExists(path string) (bool, error) {
+	_, err := os.Lstat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("failed to check progress file %s: %w", path, err)
+}
+
+// readRunProgress reads the progress file.
+//
+// No error returns are expected during normal operation.
+func readRunProgress(path string) (progress runProgress, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return runProgress{}, fmt.Errorf("failed to open progress file: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
+
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&progress); err != nil {
+		return runProgress{}, fmt.Errorf("failed to decode progress file: %w", err)
+	}
+
+	// A progress file that contains more than one JSON value was not written by this tool,
+	// so the decoded value can not be trusted.
+	if err := decoder.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return runProgress{}, fmt.Errorf("progress file contains more than the expected progress")
+	}
+
+	return progress, nil
+}
+
+// writeRunProgress replaces the progress file with the given progress.
+//
+// The progress is first written to a temporary file in the same directory, which is then renamed,
+// so that an interrupted write can not truncate or corrupt previously recorded progress.
+//
+// No error returns are expected during normal operation.
+func writeRunProgress(path string, progress runProgress) (err error) {
+	directoryPath := filepath.Dir(path)
+
+	file, err := os.CreateTemp(directoryPath, "."+filepath.Base(path)+".*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary progress file: %w", err)
+	}
+	temporaryPath := file.Name()
+
+	fileClosed := false
+	defer func() {
+		if !fileClosed {
+			err = errors.Join(err, file.Close())
+		}
+		// The temporary file only exists if it was not renamed, i.e. if writing failed.
+		removeErr := os.Remove(temporaryPath)
+		if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, removeErr)
+		}
+	}()
+
+	if err := file.Chmod(0644); err != nil {
+		return fmt.Errorf("failed to set permissions of temporary progress file: %w", err)
+	}
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(progress); err != nil {
+		return fmt.Errorf("failed to encode progress: %w", err)
+	}
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to flush temporary progress file: %w", err)
+	}
+
+	closeErr := file.Close()
+	fileClosed = true
+	if closeErr != nil {
+		return fmt.Errorf("failed to close temporary progress file: %w", closeErr)
+	}
+
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("failed to replace progress file: %w", err)
+	}
+
+	// Flush the rename, so that the progress survives a crash of the machine.
+	directory, err := os.Open(directoryPath)
+	if err != nil {
+		return fmt.Errorf("failed to open directory of progress file: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, directory.Close())
+	}()
+
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("failed to flush directory of progress file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/util/cmd/compare-cadence-vm/progress.go
+++ b/cmd/util/cmd/compare-cadence-vm/progress.go
@@ -66,8 +66,9 @@ type runProgress struct {
 	// CompletedBlockCount is the number of blocks that all completed batches compared.
 	CompletedBlockCount int `json:"completed_block_count"`
 
-	// NextBlockID is the ID of the first block of the next batch,
-	// and is empty once all blocks of the run have been compared.
+	// NextBlockID is the ID of the first block of the next batch.
+	// In follow-parents mode, it is the next ancestor only while the run has blocks remaining;
+	// it is empty once all blocks of the run have been compared.
 	NextBlockID string `json:"next_block_id"`
 
 	Stats runStats `json:"stats"`

--- a/cmd/util/cmd/compare-cadence-vm/progress_test.go
+++ b/cmd/util/cmd/compare-cadence-vm/progress_test.go
@@ -179,12 +179,18 @@ func TestBlockLoaderAdvance(t *testing.T) {
 		header := unittest.BlockHeaderFixture()
 
 		loader := &blockLoader{
-			nextBlockID: header.ID(),
+			nextBlockID:     header.ID(),
+			totalBlockCount: 2,
 		}
 		loader.loadedBlockCount++
 		loader.advance(header)
 
 		assert.Equal(t, header.ParentID, loader.nextBlockID)
+
+		loader.loadedBlockCount++
+		loader.advance(unittest.BlockHeaderFixture())
+
+		assert.Equal(t, flow.ZeroID, loader.nextBlockID)
 	})
 
 	t.Run("explicit block IDs", func(t *testing.T) {
@@ -195,6 +201,7 @@ func TestBlockLoaderAdvance(t *testing.T) {
 		loader := &blockLoader{
 			explicitBlockIDs: blockIDs,
 			nextBlockID:      blockIDs[0],
+			totalBlockCount:  len(blockIDs),
 		}
 
 		// The parent of the loaded block must be ignored, the explicit blocks are unrelated.

--- a/cmd/util/cmd/compare-cadence-vm/progress_test.go
+++ b/cmd/util/cmd/compare-cadence-vm/progress_test.go
@@ -1,0 +1,304 @@
+package compare_cadence_vm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func testRunConfig(blockIDs ...flow.Identifier) runConfig {
+	return runConfig{
+		Chain:        string(flow.Mainnet),
+		BlockIDs:     blockIDStrings(blockIDs),
+		BlockCount:   100,
+		ComputeLimit: 9999,
+	}
+}
+
+func TestWriteAndReadRunProgress(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "progress.json")
+
+	startBlockID := unittest.IdentifierFixture()
+	nextBlockID := unittest.IdentifierFixture()
+
+	progress := newRunProgress(testRunConfig(startBlockID), startBlockID)
+	progress.CompletedBlockCount = 10
+	progress.NextBlockID = nextBlockID.String()
+	progress.Stats = runStats{
+		BlocksMatched:          9,
+		BlocksMismatched:       1,
+		TransactionsMatched:    40,
+		TransactionsMismatched: 2,
+	}
+
+	require.NoError(t, writeRunProgress(path, progress))
+
+	read, err := readRunProgress(path)
+	require.NoError(t, err)
+	assert.Equal(t, progress, read)
+
+	// Writing again must replace the previously recorded progress.
+	progress.CompletedBlockCount = 20
+	require.NoError(t, writeRunProgress(path, progress))
+
+	read, err = readRunProgress(path)
+	require.NoError(t, err)
+	assert.Equal(t, progress, read)
+
+	// Writing must not leave temporary files behind.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, filepath.Base(path), entries[0].Name())
+}
+
+func TestReadRunProgressRejectsUnexpectedContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown field", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "progress.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"version": 1, "unexpected": 1}`), 0644))
+
+		_, err := readRunProgress(path)
+		require.ErrorContains(t, err, "failed to decode progress file")
+	})
+
+	t.Run("trailing value", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "progress.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"version": 1}{"version": 1}`), 0644))
+
+		_, err := readRunProgress(path)
+		require.ErrorContains(t, err, "more than the expected progress")
+	})
+}
+
+func TestValidateRunProgress(t *testing.T) {
+	t.Parallel()
+
+	startBlockID := unittest.IdentifierFixture()
+	nextBlockID := unittest.IdentifierFixture()
+	config := testRunConfig(startBlockID)
+
+	newProgress := func() runProgress {
+		progress := newRunProgress(config, startBlockID)
+		progress.CompletedBlockCount = 10
+		progress.NextBlockID = nextBlockID.String()
+		return progress
+	}
+
+	t.Run("resumable", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, newProgress().validate(config, 100))
+	})
+
+	t.Run("completed run", func(t *testing.T) {
+		t.Parallel()
+
+		progress := newProgress()
+		progress.CompletedBlockCount = 100
+		progress.NextBlockID = ""
+
+		require.NoError(t, progress.validate(config, 100))
+	})
+
+	t.Run("different version", func(t *testing.T) {
+		t.Parallel()
+
+		progress := newProgress()
+		progress.Version = progressVersion + 1
+
+		require.ErrorContains(t, progress.validate(config, 100), "version")
+	})
+
+	t.Run("different compute limit", func(t *testing.T) {
+		t.Parallel()
+
+		otherConfig := config
+		otherConfig.ComputeLimit = config.ComputeLimit + 1
+
+		require.ErrorContains(t, newProgress().validate(otherConfig, 100), "different configuration")
+	})
+
+	t.Run("different block IDs", func(t *testing.T) {
+		t.Parallel()
+
+		otherConfig := config
+		otherConfig.BlockIDs = blockIDStrings([]flow.Identifier{unittest.IdentifierFixture()})
+
+		require.ErrorContains(t, newProgress().validate(otherConfig, 100), "different configuration")
+	})
+
+	t.Run("more compared blocks than the run has", func(t *testing.T) {
+		t.Parallel()
+
+		progress := newProgress()
+		progress.CompletedBlockCount = 101
+
+		require.ErrorContains(t, progress.validate(config, 100), "outside the 100 blocks")
+	})
+
+	t.Run("missing next block ID", func(t *testing.T) {
+		t.Parallel()
+
+		progress := newProgress()
+		progress.NextBlockID = ""
+
+		require.ErrorContains(t, progress.validate(config, 100), "does not contain the ID of the next block")
+	})
+
+	t.Run("invalid next block ID", func(t *testing.T) {
+		t.Parallel()
+
+		progress := newProgress()
+		progress.NextBlockID = "not-a-block-ID"
+
+		require.ErrorContains(t, progress.validate(config, 100), "invalid next block ID")
+	})
+}
+
+func TestBlockLoaderAdvance(t *testing.T) {
+	t.Parallel()
+
+	t.Run("follows parents", func(t *testing.T) {
+		t.Parallel()
+
+		header := unittest.BlockHeaderFixture()
+
+		loader := &blockLoader{
+			nextBlockID: header.ID(),
+		}
+		loader.loadedBlockCount++
+		loader.advance(header)
+
+		assert.Equal(t, header.ParentID, loader.nextBlockID)
+	})
+
+	t.Run("explicit block IDs", func(t *testing.T) {
+		t.Parallel()
+
+		blockIDs := unittest.IdentifierListFixture(2)
+
+		loader := &blockLoader{
+			explicitBlockIDs: blockIDs,
+			nextBlockID:      blockIDs[0],
+		}
+
+		// The parent of the loaded block must be ignored, the explicit blocks are unrelated.
+		header := unittest.BlockHeaderFixture()
+
+		loader.loadedBlockCount++
+		loader.advance(header)
+		assert.Equal(t, blockIDs[1], loader.nextBlockID)
+
+		loader.loadedBlockCount++
+		loader.advance(header)
+		assert.Equal(t, flow.ZeroID, loader.nextBlockID)
+	})
+}
+
+func TestResolveProgressFilePath(t *testing.T) {
+	// The resolved path depends on the flags, which are package level variables,
+	// so these cases must not run in parallel.
+
+	blockID := unittest.IdentifierFixture()
+	defaultName := defaultProgressFileName(blockID, 100)
+
+	tests := []struct {
+		name         string
+		progressFile string
+		batchSize    int
+		resume       bool
+		expected     string
+	}{
+		{
+			name:         "explicit progress file",
+			progressFile: "/tmp/progress.json",
+			expected:     "/tmp/progress.json",
+		},
+		{
+			name:      "batched run without progress file",
+			batchSize: 10,
+			expected:  defaultName,
+		},
+		{
+			name:     "resumed run without progress file",
+			resume:   true,
+			expected: defaultName,
+		},
+		{
+			name:         "explicit progress file takes precedence",
+			progressFile: "/tmp/progress.json",
+			batchSize:    10,
+			expected:     "/tmp/progress.json",
+		},
+		{
+			// A run which compares all blocks in a single batch has no progress to record.
+			name:     "single batch without progress file",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			previousProgressFile := flagProgressFile
+			previousBatchSize := flagBatchSize
+			previousResume := flagResume
+			t.Cleanup(func() {
+				flagProgressFile = previousProgressFile
+				flagBatchSize = previousBatchSize
+				flagResume = previousResume
+			})
+
+			flagProgressFile = test.progressFile
+			flagBatchSize = test.batchSize
+			flagResume = test.resume
+
+			assert.Equal(t, test.expected, resolveProgressFilePath(blockID, 100))
+		})
+	}
+}
+
+func TestDefaultProgressFileName(t *testing.T) {
+	t.Parallel()
+
+	blockID := unittest.IdentifierFixture()
+
+	name := defaultProgressFileName(blockID, 100)
+
+	// The name must identify the run, so that the run resumes from its own progress file.
+	assert.Equal(
+		t,
+		fmt.Sprintf("compare-cadence-vm-%s-100.progress.json", blockID.String()[:16]),
+		name,
+	)
+
+	// The name must be a file in the directory the command is run in.
+	assert.Equal(t, name, filepath.Base(name))
+
+	assert.NotEqual(t, name, defaultProgressFileName(blockID, 200))
+	assert.NotEqual(t, name, defaultProgressFileName(unittest.IdentifierFixture(), 100))
+}
+
+func TestBlockIDString(t *testing.T) {
+	t.Parallel()
+
+	blockID := unittest.IdentifierFixture()
+	assert.Equal(t, blockID.String(), blockIDString(blockID))
+
+	// The zero identifier means that no block is left to compare.
+	assert.Equal(t, "", blockIDString(flow.ZeroID))
+}


### PR DESCRIPTION
Thanks @turbolent for the great idea!

### Problem

`compare-cadence-vm` fetches all block headers upfront and compares every block in a single pass. When comparing tens of thousands of blocks, any interruption (e.g: a network failure) would loses the entire run, which then has to restart from the first block.

### Changes

Introduces a `--batch-size` flag, that allows comparing blocks in batches, with each batch fetching only its own headers. After a batch completes, the progress (number of compared blocks, ID of the next block, and cumulative match/mismatch counts) is recorded to a progress file, so an interrupted run can be resumed with `--resume` and only repeats the batch it was in.

- Progress is recorded only after a batch fully completes, so a block is never recorded as compared unless it was.
`--progress-file` is optional. It defaults to a name derived from the compared blocks, created in the current directory, and its absolute path is logged at start. The name is deterministic, so `--resume` finds it without extra flags.
- The file is written atomically (temporary file, rename, fsync) and created at start-up, so an unwritable path is reported before any block is compared rather than after the first batch.
- Resuming validates the recorded configuration (chain, block IDs, block count, compute limit) and refuses to continue a different run. Starting a fresh run refuses to overwrite an existing progress file. Batch size is deliberately not part of that check, so a run may be resumed with a different batch size.
- Without `--batch-size`, behaviour is unchanged: all blocks in one batch, and no progress file unless one is requested explicitly.
- The new flags cannot be used in the `--subscribe` mode.

### Usage

```bash
./util compare-cadence-vm \
    --chain flow-mainnet \
    --access-address <AN> \
    --block-ids <start-block-id> \
    --block-count 1000 \
    --batch-size 100
```
Rerun the same command with `--resume` appended to continue after a failure. It is valid to use a different `--batch-size` on the resumption.

### Sample

A sample `progress` file looks like:
```json
{
  "version": 1,
  "config": {
    "chain": "flow-mainnet",
    "block_ids": [
      "3df75dc2767261760da3eded705525be1d36c84d55d6c2ac51350c860e6032c8"
    ],
    "block_count": 100,
    "batch_size": 10,
    "compute_limit": 9999
  },
  "completed_block_count": 40,
  "next_block_id": "ca5d3d6bedb10946e648414a7169ed93f164756e80b9da9f9ea79a7155b24d54",
  "stats": {
    "blocks_matched": 40,
    "blocks_mismatched": 0,
    "transactions_matched": 63,
    "transactions_mismatched": 0
  }
}
```