### PR TITLE
[Storehouse] Verify entries on same-height Registers.Store

### DIFF
--- a/storage/pebble/registers.go
+++ b/storage/pebble/registers.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/storage"
 )
 
@@ -162,8 +163,14 @@ func (s *Registers) Store(
 func (s *Registers) verifyStoredEntries(entries flow.RegisterEntries, height uint64) error {
 	for _, entry := range entries {
 		stored, err := s.Get(entry.Key, height)
+		if errors.Is(err, storage.ErrNotFound) {
+			// a missing entry means divergence from what was previously stored.
+			// Do not wrap storage.ErrNotFound: Store's caller must not mistake
+			// this for a benign "not found" from Get.
+			return fmt.Errorf("register %v was not stored at height %d", entry.Key, height)
+		}
 		if err != nil {
-			return fmt.Errorf("cannot verify stored register %v at height %d: %w", entry.Key, height, err)
+			return irrecoverable.NewExceptionf("cannot verify stored register %v at height %d: %w", entry.Key, height, err)
 		}
 		if !bytes.Equal(stored, entry.Value) {
 			return fmt.Errorf("register %v at height %d was already stored with a different value", entry.Key, height)

--- a/storage/pebble/registers.go
+++ b/storage/pebble/registers.go
@@ -1,6 +1,7 @@
 package pebble
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -118,8 +119,9 @@ func (s *Registers) Store(
 	// Upon restart, it may be in a state where registers are indexed in pebble for the latest height
 	// but the remaining execution data in badger is not, so we skip the indexing step without throwing an error
 	if height == latestHeight {
-		// already updated
-		return nil
+		// already updated, but verify the entries match what was stored,
+		// so that divergent data is not silently dropped
+		return s.verifyStoredEntries(entries, height)
 	}
 
 	nextHeight := latestHeight + 1
@@ -149,6 +151,24 @@ func (s *Registers) Store(
 
 	s.latestHeight.Store(height)
 
+	return nil
+}
+
+// verifyStoredEntries checks that each of the given entries matches the value already
+// stored at the given height. It is used when Store is called again for the latest height,
+// which can happen when an execution node restarts and re-indexes a height whose registers
+// were already indexed. A mismatch means the previously stored value would be silently
+// kept while the caller assumes the new value was stored, so it must be an error.
+func (s *Registers) verifyStoredEntries(entries flow.RegisterEntries, height uint64) error {
+	for _, entry := range entries {
+		stored, err := s.Get(entry.Key, height)
+		if err != nil {
+			return fmt.Errorf("cannot verify stored register %v at height %d: %w", entry.Key, height, err)
+		}
+		if !bytes.Equal(stored, entry.Value) {
+			return fmt.Errorf("register %v at height %d was already stored with a different value", entry.Key, height)
+		}
+	}
 	return nil
 }
 

--- a/storage/pebble/registers_test.go
+++ b/storage/pebble/registers_test.go
@@ -86,6 +86,25 @@ func TestRegisters_Store(t *testing.T) {
 		err = r.Store(entries, height2)
 		require.NoError(t, err)
 
+		// same height with a conflicting value must fail instead of being silently dropped
+		conflicting := flow.RegisterEntries{
+			{Key: key1, Value: []byte("different")},
+		}
+		err = r.Store(conflicting, height2)
+		require.Error(t, err)
+
+		// same height with a register that was not stored must fail
+		notStored := flow.RegisterEntries{
+			{Key: flow.RegisterID{Owner: "owner", Key: "key2"}, Value: []byte("value2")},
+		}
+		err = r.Store(notStored, height2)
+		require.Error(t, err)
+
+		// the originally stored value is unchanged
+		value1, err := r.Get(key1, height2)
+		require.NoError(t, err)
+		require.Equal(t, expectedValue1, value1)
+
 		// out of range
 		height4 := uint64(4)
 		err = r.Store(entries, height4)

--- a/storage/pebble/registers_test.go
+++ b/storage/pebble/registers_test.go
@@ -93,12 +93,14 @@ func TestRegisters_Store(t *testing.T) {
 		err = r.Store(conflicting, height2)
 		require.Error(t, err)
 
-		// same height with a register that was not stored must fail
+		// same height with a register that was not stored must fail,
+		// and the failure must not be detectable as storage.ErrNotFound
 		notStored := flow.RegisterEntries{
 			{Key: flow.RegisterID{Owner: "owner", Key: "key2"}, Value: []byte("value2")},
 		}
 		err = r.Store(notStored, height2)
 		require.Error(t, err)
+		require.NotErrorIs(t, err, storage.ErrNotFound)
 
 		// the originally stored value is unchanged
 		value1, err := r.Get(key1, height2)


### PR DESCRIPTION
Improving error handling in Registers.Store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added integrity checks when saving register data at an existing height.
  * Conflicting values or unexpected registers now return an error instead of being silently accepted.
  * Preserved previously stored values when a conflicting update is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->