### PR TITLE
[Testing] Restore exact EVM updated-register count assertion

### DIFF
--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -2,6 +2,7 @@ package evm_test
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -2943,12 +2944,9 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 				assert.Len(t, output.Events, 3)
-				// This transaction must update state. The exact number of updated registers varies
-				// slightly between runs: the test environment uses a random block ID, which selects
-				// the UUID partition register (`uuid` vs `uuid_N`) and thereby also the atree slab
-				// layout. Hence, we only check that state was updated at all - in contrast to
-				// `dryCall` below, which must not update any registers.
-				assert.NotEmpty(t, state.UpdatedRegisterIDs())
+				// this transaction must update state - in contrast to the dry-run call below,
+				// which must not update any registers
+				assertUpdatedRegisterCount(t, ctx, state, 13)
 				assert.Equal(
 					t,
 					flow.EventType("A.f8d6e0586b0a20c7.EVM.TransactionExecuted"),
@@ -3096,12 +3094,9 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 				assert.Len(t, output.Events, 3)
-				// This transaction must update state. The exact number of updated registers varies
-				// slightly between runs: the test environment uses a random block ID, which selects
-				// the UUID partition register (`uuid` vs `uuid_N`) and thereby also the atree slab
-				// layout. Hence, we only check that state was updated at all - in contrast to
-				// `dryCall` below, which must not update any registers.
-				assert.NotEmpty(t, state.UpdatedRegisterIDs())
+				// this transaction must update state - in contrast to the dry-run call below,
+				// which must not update any registers
+				assertUpdatedRegisterCount(t, ctx, state, 13)
 				assert.Equal(
 					t,
 					flow.EventType("A.f8d6e0586b0a20c7.EVM.TransactionExecuted"),
@@ -7187,6 +7182,25 @@ func getEVMAccountNonce(
 	val, ok := output.Value.(cadence.UInt64)
 	require.True(t, ok)
 	return uint64(val)
+}
+
+// assertUpdatedRegisterCount asserts that the execution updated exactly the expected number of
+// registers. `countNonZeroPartition` is the expected count for a block whose ID selects a
+// non-zero UUID partition (see `environment.uuidPartition` with txnIndex 0, as used by these
+// tests): such blocks use a fresh `uuid_N` register. A block selecting partition 0 (probability
+// 1/256) reuses the legacy `uuid` register instead, updating one register fewer.
+func assertUpdatedRegisterCount(
+	t *testing.T,
+	ctx fvm.Context,
+	state *snapshot.ExecutionSnapshot,
+	countNonZeroPartition int,
+) {
+	expected := countNonZeroPartition
+	blockID := ctx.BlockHeader.ID()
+	if sha256.Sum256(blockID[:])[0] == 0 {
+		expected--
+	}
+	assert.Len(t, state.UpdatedRegisterIDs(), expected)
 }
 
 func RunWithNewEnvironment(


### PR DESCRIPTION
Follow-up to #8626, which relaxed `assert.Len(state.UpdatedRegisterIDs(), 13)` to
`NotEmpty` in the COA `dryCall` tests because the count varied between runs — losing the
ability to catch write-amplification regressions.

The variance is now fully characterized: the test env uses a random block ID, and
`environment.uuidPartition` (= `sha256(blockID)[0]` at txnIndex 0) selects the UUID
register. Partition 0 (probability 1/256) reuses the legacy `uuid` register → 12 updated
registers; all other partitions create a fresh `uuid_N` register → 13. This 1-in-256 case
is what made the original exact assertion flaky.

This PR restores an exact assertion via a small helper that computes the expected count
(12 or 13) from the block ID, keeping the fixture's full randomness. Both branches
verified: 15 random-block runs and 3 runs with partition 0 forced, all with `-race`.

Test-only change; no production code touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787932903&installation_model_id=15376&pr_number=8629&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8629&signature=4ffa1c1485b72e0c8a937f12b222a7b0b3809898e7d88f7c89ed74639f3dca80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of COA transaction register updates, including rare partitioning edge cases.
  - Ensured register-count assertions accurately reflect all expected updates.

- **Tests**
  - Added coverage for deterministic register selection and transaction outcomes.
  - Updated transaction checks to verify the expected number of modified registers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->