### PR TITLE
[CI] Debug claude-review-fvm failures: full output + artifact upload

### DIFF
--- a/.github/workflows/claude-review-fvm.yml
+++ b/.github/workflows/claude-review-fvm.yml
@@ -57,6 +57,13 @@ jobs:
           # anthropic_workspace_id intentionally omitted: the federation
           # rule is scoped to a single (default) workspace.
 
+          # TEMPORARY DEBUG: surface Claude's full output to diagnose the
+          # recurring `is_error:true` / num_turns:1 / $0 failures. The
+          # action's own warning applies: this logs ALL Claude messages
+          # (including tool results), publicly visible in the Actions log.
+          # Remove once the root cause is identified.
+          show_full_output: true
+
           # Model intentionally not pinned — the action's default tracks
           # Anthropic's current recommended model. Pin with
           # `--model <id>` here if reproducibility matters more.
@@ -81,3 +88,15 @@ jobs:
               findings format. Do not approve or request changes — the
               workflow's tool allowlist omits `gh pr review`, so approval is
               impossible at the tool level regardless.
+
+      # TEMPORARY DEBUG: persist the raw execution output so the actual
+      # error message survives the runner (it is otherwise only written to
+      # the runner's temp dir and lost). Runs even when the review step
+      # fails. Remove together with show_full_output above.
+      - name: Upload Claude execution output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output
+          path: /home/runner/work/_temp/claude-execution-output.json
+          if-no-files-found: warn


### PR DESCRIPTION
## Problem

`claude-review-fvm` has failed on every run since it started triggering (5/5, across multiple FVM PRs). Every failure has the identical signature:

```
result: subtype "success", is_error: true, num_turns: 1, total_cost_usd: 0 (~3 min)
##[error] Claude result reported subtype success with is_error:true
```

The actual error message is invisible: the action hides Claude's output ("full output hidden for security"), and the raw output written to `/home/runner/work/_temp/claude-execution-output.json` is lost when the runner exits. Re-running with Actions debug logging does not help — it only adds runner-internal `##[debug]` lines.

## Changes

Two **temporary** debugging additions to `.github/workflows/claude-review-fvm.yml`:

1. `show_full_output: true` on the claude-code-action step — prints Claude's messages to the log so the real error is visible (the action warns this echoes all messages incl. tool results; acceptable here for a public repo, to be removed after diagnosis).
2. An `actions/upload-artifact@v4` step (`if: always()`) that uploads `claude-execution-output.json` as the `claude-execution-output` artifact, so the raw error survives the runner even on failure.

The model is intentionally **not** pinned — first gather the actual error, then decide.

Both additions are marked `TEMPORARY DEBUG` and should be reverted once the root cause is identified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787934535&installation_model_id=15376&pr_number=8630&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8630&signature=2b1b1a7811ddc631b02f7d3ae59b2bf18a9df7e2539f2d79a2e6abca31d59823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated review diagnostics by exposing complete execution details in workflow logs.
  * Added artifact uploads for review output to support troubleshooting.
  * Added warnings when expected diagnostic output is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->