### PR TITLE
[Testing] Add deterministic coverage for the EVM uuid partition-0 branch

### DIFF
--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -4030,94 +4030,123 @@ func TestDryRun(t *testing.T) {
 	// one tainted by the dry-run read) and complete successfully.
 	t.Run("test EVM.dryRun followed by EVM.run in same transaction", func(t *testing.T) {
 		RunWithNewEnvironment(t,
-			chain, func(
-				ctx fvm.Context,
-				vm fvm.VM,
-				snapshot snapshot.SnapshotTree,
-				testContract *TestContract,
-				testAccount *EOATestAccount,
-			) {
-				sc := systemcontracts.SystemContractsForChain(chain.ChainID())
-
-				data := testContract.MakeCallData(t, "store", big.NewInt(42))
-
-				// The dry-run tx uses nonce 0 (doesn't consume it).
-				dryTx := gethTypes.NewTransaction(
-					testAccount.Nonce(),
-					testContract.DeployedAt.ToCommon(),
-					big.NewInt(0),
-					uint64(50_000),
-					big.NewInt(0),
-					data,
-				)
-				dryTxBytes, err := dryTx.MarshalBinary()
-				require.NoError(t, err)
-
-				// The real tx is signed and uses the same nonce.
-				realTxBytes := testAccount.PrepareSignAndEncodeTx(t,
-					testContract.DeployedAt.ToCommon(),
-					data,
-					big.NewInt(0),
-					uint64(50_000),
-					big.NewInt(0),
-				)
-
-				code := []byte(fmt.Sprintf(`
-					import EVM from %s
-
-					transaction(dryTx: [UInt8], realTx: [UInt8], coinbaseBytes: [UInt8; 20]) {
-						prepare(account: &Account) {
-							let from = EVM.EVMAddress(bytes: coinbaseBytes)
-							let coinbase = EVM.EVMAddress(bytes: coinbaseBytes)
-
-							let dryResult = EVM.dryRun(tx: dryTx, from: from)
-							assert(dryResult.status == EVM.Status.successful, message: "dry run failed")
-
-							let runResult = EVM.run(tx: realTx, coinbase: coinbase)
-							assert(runResult.status == EVM.Status.successful, message: "run after dry run failed")
-						}
-					}
-				`, sc.EVMContract.Address.HexWithPrefix()))
-
-				dryTxArg := cadence.NewArray(
-					unittest.BytesToCdcUInt8(dryTxBytes),
-				).WithType(stdlib.EVMTransactionBytesCadenceType)
-
-				realTxArg := cadence.NewArray(
-					unittest.BytesToCdcUInt8(realTxBytes),
-				).WithType(stdlib.EVMTransactionBytesCadenceType)
-
-				coinbase := cadence.NewArray(
-					unittest.BytesToCdcUInt8(testAccount.Address().Bytes()),
-				).WithType(stdlib.EVMAddressBytesCadenceType)
-
-				txBody, err := flow.NewTransactionBodyBuilder().
-					SetScript(code).
-					SetPayer(sc.FlowServiceAccount.Address).
-					AddAuthorizer(sc.FlowServiceAccount.Address).
-					AddArgument(json.MustEncode(dryTxArg)).
-					AddArgument(json.MustEncode(realTxArg)).
-					AddArgument(json.MustEncode(coinbase)).
-					Build()
-				require.NoError(t, err)
-
-				tx := fvm.Transaction(txBody, 0)
-				_, output, err := vm.Run(ctx, tx, snapshot)
-				require.NoError(t, err)
-				require.NoError(t, output.Err)
-				// The metered computation depends on the block's UUID partition (see
-				// assertUpdatedRegisterCount): blocks selecting partition 0 (probability 1/256)
-				// reuse the legacy `uuid` register instead of a fresh `uuid_N` one, which
-				// changes the metered effort. Both values verified by forcing each partition.
-				expectedComputation := uint64(74)
-				blockID := ctx.BlockHeader.ID()
-				if sha256.Sum256(blockID[:])[0] == 0 {
-					expectedComputation = 79
-				}
-				assert.Equal(t, expectedComputation, output.ComputationUsed)
-			},
+			chain, dryRunFollowedByRunCase(t, chain),
 		)
 	})
+}
+
+// TestDryRunFollowedByRun_UUIDPartitionZero runs the dryRun-followed-by-run case with a block
+// that deterministically selects UUID partition 0. Partition 0 makes the EVM environment reuse
+// the legacy `uuid` register instead of a fresh partitioned one; this 1/256 branch is
+// practically never exercised by random block fixtures, and previously made exact
+// register-count and computation assertions flaky (see #8629).
+func TestDryRunFollowedByRun_UUIDPartitionZero(t *testing.T) {
+	t.Parallel()
+	chain := flow.Emulator.Chain()
+	runWithNewEnvironmentWithBlock(t,
+		chain, blockFixtureWithUUIDPartitionZero(), dryRunFollowedByRunCase(t, chain),
+	)
+}
+
+// dryRunFollowedByRunCase returns the test case body shared by the random-block and the
+// forced-partition-zero variants: dryRun reads the block proposal into the cache, and a
+// subsequent EVM.run in the same Cadence transaction must still see a clean proposal and
+// complete successfully, with partition-dependent metering.
+func dryRunFollowedByRunCase(t *testing.T, chain flow.Chain) func(fvm.Context, fvm.VM, snapshot.SnapshotTree, *TestContract, *EOATestAccount) {
+	return func(
+		ctx fvm.Context,
+		vm fvm.VM,
+		snapshot snapshot.SnapshotTree,
+		testContract *TestContract,
+		testAccount *EOATestAccount,
+	) {
+		sc := systemcontracts.SystemContractsForChain(chain.ChainID())
+
+		data := testContract.MakeCallData(t, "store", big.NewInt(42))
+
+		// The dry-run tx uses nonce 0 (doesn't consume it).
+		dryTx := gethTypes.NewTransaction(
+			testAccount.Nonce(),
+			testContract.DeployedAt.ToCommon(),
+			big.NewInt(0),
+			uint64(50_000),
+			big.NewInt(0),
+			data,
+		)
+		dryTxBytes, err := dryTx.MarshalBinary()
+		require.NoError(t, err)
+
+		// The real tx is signed and uses the same nonce.
+		realTxBytes := testAccount.PrepareSignAndEncodeTx(t,
+			testContract.DeployedAt.ToCommon(),
+			data,
+			big.NewInt(0),
+			uint64(50_000),
+			big.NewInt(0),
+		)
+
+		code := []byte(fmt.Sprintf(`
+			import EVM from %s
+
+			transaction(dryTx: [UInt8], realTx: [UInt8], coinbaseBytes: [UInt8; 20]) {
+				prepare(account: &Account) {
+					let from = EVM.EVMAddress(bytes: coinbaseBytes)
+					let coinbase = EVM.EVMAddress(bytes: coinbaseBytes)
+
+					let dryResult = EVM.dryRun(tx: dryTx, from: from)
+					assert(dryResult.status == EVM.Status.successful, message: "dry run failed")
+
+					let runResult = EVM.run(tx: realTx, coinbase: coinbase)
+					assert(runResult.status == EVM.Status.successful, message: "run after dry run failed")
+				}
+			}
+		`, sc.EVMContract.Address.HexWithPrefix()))
+
+		dryTxArg := cadence.NewArray(
+			unittest.BytesToCdcUInt8(dryTxBytes),
+		).WithType(stdlib.EVMTransactionBytesCadenceType)
+
+		realTxArg := cadence.NewArray(
+			unittest.BytesToCdcUInt8(realTxBytes),
+		).WithType(stdlib.EVMTransactionBytesCadenceType)
+
+		coinbase := cadence.NewArray(
+			unittest.BytesToCdcUInt8(testAccount.Address().Bytes()),
+		).WithType(stdlib.EVMAddressBytesCadenceType)
+
+		txBody, err := flow.NewTransactionBodyBuilder().
+			SetScript(code).
+			SetPayer(sc.FlowServiceAccount.Address).
+			AddAuthorizer(sc.FlowServiceAccount.Address).
+			AddArgument(json.MustEncode(dryTxArg)).
+			AddArgument(json.MustEncode(realTxArg)).
+			AddArgument(json.MustEncode(coinbase)).
+			Build()
+		require.NoError(t, err)
+
+		tx := fvm.Transaction(txBody, 0)
+		state, output, err := vm.Run(ctx, tx, snapshot)
+		require.NoError(t, err)
+		require.NoError(t, output.Err)
+
+		// the number of updated registers is the same for both UUID partitions (verified by
+		// forcing each partition)
+		assert.Len(t, state.UpdatedRegisterIDs(), 4)
+
+		// The metered computation depends on the block's UUID partition (see
+		// environment.uuidPartition with txnIndex 0): partition 0 (probability 1/256 for a
+		// random block) reuses the legacy `uuid` register, which exists and thus meters more
+		// interaction than the untouched partitioned register. The extra reads happen inside
+		// the dry-run's speculative (discarded) transaction, so they are metered without
+		// appearing in the returned snapshot. Both values verified by forcing each partition.
+		blockID := ctx.BlockHeader.ID()
+		partition := sha256.Sum256(blockID[:])[0]
+		expectedComputation := uint64(74)
+		if partition == 0 {
+			expectedComputation = 79
+		}
+		assert.Equal(t, expectedComputation, output.ComputationUsed)
+	}
 }
 
 func TestDryCall(t *testing.T) {
@@ -7218,12 +7247,38 @@ func RunWithNewEnvironment(
 	f func(fvm.Context, fvm.VM, snapshot.SnapshotTree, *TestContract, *EOATestAccount),
 	bootstrapOpts ...fvm.BootstrapProcedureOption,
 ) {
+	runWithNewEnvironmentWithBlock(t, chain, unittest.BlockFixture(), f, bootstrapOpts...)
+}
+
+// blockFixtureWithUUIDPartitionZero returns a block fixture whose ID selects UUID partition 0
+// for the transaction at index 0 (sha256(blockID)[0] == 0, see environment.uuidPartition).
+// Such blocks make the EVM environment reuse the legacy `uuid` register instead of a fresh
+// partitioned one, a 1/256 branch that random block fixtures practically never exercise.
+// On average this takes 256 attempts (a few milliseconds).
+func blockFixtureWithUUIDPartitionZero() *flow.Block {
+	for {
+		block := unittest.BlockFixture()
+		id := block.ID()
+		if sha256.Sum256(id[:])[0] == 0 {
+			return block
+		}
+	}
+}
+
+// runWithNewEnvironmentWithBlock is RunWithNewEnvironment with a caller-provided block, which
+// (among other things) determines the UUID partition used by the environment.
+func runWithNewEnvironmentWithBlock(
+	t *testing.T,
+	chain flow.Chain,
+	block1 *flow.Block,
+	f func(fvm.Context, fvm.VM, snapshot.SnapshotTree, *TestContract, *EOATestAccount),
+	bootstrapOpts ...fvm.BootstrapProcedureOption,
+) {
 	rootAddr := evm.StorageAccountAddress(chain.ChainID())
 	RunWithTestBackend(t, chain.ChainID(), func(backend *TestBackend) {
 		RunWithDeployedContract(t, GetStorageTestContract(t), backend, rootAddr, func(testContract *TestContract) {
 			RunWithEOATestAccount(t, backend, rootAddr, func(testAccount *EOATestAccount) {
 				blocks := new(envMock.Blocks)
-				block1 := unittest.BlockFixture()
 				blocks.On("ByHeightFrom",
 					block1.Height,
 					block1.ToHeader(),

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -4375,94 +4375,123 @@ func TestDryRun(t *testing.T) {
 	// one tainted by the dry-run read) and complete successfully.
 	t.Run("test EVM.dryRun followed by EVM.run in same transaction", func(t *testing.T) {
 		RunWithNewEnvironment(t,
-			chain, func(
-				ctx fvm.Context,
-				vm fvm.VM,
-				snapshot snapshot.SnapshotTree,
-				testContract *TestContract,
-				testAccount *EOATestAccount,
-			) {
-				sc := systemcontracts.SystemContractsForChain(chain.ChainID())
-
-				data := testContract.MakeCallData(t, "store", big.NewInt(42))
-
-				// The dry-run tx uses nonce 0 (doesn't consume it).
-				dryTx := gethTypes.NewTransaction(
-					testAccount.Nonce(),
-					testContract.DeployedAt.ToCommon(),
-					big.NewInt(0),
-					uint64(125_000),
-					big.NewInt(0),
-					data,
-				)
-				dryTxBytes, err := dryTx.MarshalBinary()
-				require.NoError(t, err)
-
-				// The real tx is signed and uses the same nonce.
-				realTxBytes := testAccount.PrepareSignAndEncodeTx(t,
-					testContract.DeployedAt.ToCommon(),
-					data,
-					big.NewInt(0),
-					uint64(125_000),
-					big.NewInt(0),
-				)
-
-				code := fmt.Appendf(nil, `
-					import EVM from %s
-
-					transaction(dryTx: [UInt8], realTx: [UInt8], coinbaseBytes: [UInt8; 20]) {
-						prepare(account: &Account) {
-							let from = EVM.EVMAddress(bytes: coinbaseBytes)
-							let coinbase = EVM.EVMAddress(bytes: coinbaseBytes)
-
-							let dryResult = EVM.dryRun(tx: dryTx, from: from)
-							assert(dryResult.status == EVM.Status.successful, message: "dry run failed")
-
-							let runResult = EVM.run(tx: realTx, coinbase: coinbase)
-							assert(runResult.status == EVM.Status.successful, message: "run after dry run failed")
-						}
-					}
-				`, sc.EVMContract.Address.HexWithPrefix())
-
-				dryTxArg := cadence.NewArray(
-					unittest.BytesToCdcUInt8(dryTxBytes),
-				).WithType(stdlib.EVMTransactionBytesCadenceType)
-
-				realTxArg := cadence.NewArray(
-					unittest.BytesToCdcUInt8(realTxBytes),
-				).WithType(stdlib.EVMTransactionBytesCadenceType)
-
-				coinbase := cadence.NewArray(
-					unittest.BytesToCdcUInt8(testAccount.Address().Bytes()),
-				).WithType(stdlib.EVMAddressBytesCadenceType)
-
-				txBody, err := flow.NewTransactionBodyBuilder().
-					SetScript(code).
-					SetPayer(sc.FlowServiceAccount.Address).
-					AddAuthorizer(sc.FlowServiceAccount.Address).
-					AddArgument(json.MustEncode(dryTxArg)).
-					AddArgument(json.MustEncode(realTxArg)).
-					AddArgument(json.MustEncode(coinbase)).
-					Build()
-				require.NoError(t, err)
-
-				tx := fvm.Transaction(txBody, 0)
-				_, output, err := vm.Run(ctx, tx, snapshot)
-				require.NoError(t, err)
-				require.NoError(t, output.Err)
-				// The metered computation depends on the block's UUID partition (see
-				// assertUpdatedRegisterCount): blocks selecting partition 0 (probability 1/256)
-				// reuse the legacy `uuid` register instead of a fresh `uuid_N` one, which
-				// changes the metered effort. Both values verified by forcing each partition.
-				expectedComputation := uint64(92)
-				blockID := ctx.BlockHeader.ID()
-				if sha256.Sum256(blockID[:])[0] == 0 {
-					expectedComputation = 96
-				}
-				assert.Equal(t, expectedComputation, output.ComputationUsed)
-			},
+			chain, dryRunFollowedByRunCase(t, chain),
 		)
 	})
+}
+
+// TestDryRunFollowedByRun_UUIDPartitionZero runs the dryRun-followed-by-run case with a block
+// that deterministically selects UUID partition 0. Partition 0 makes the EVM environment reuse
+// the legacy `uuid` register instead of a fresh partitioned one; this 1/256 branch is
+// practically never exercised by random block fixtures, and previously made exact
+// register-count and computation assertions flaky (see #8629).
+func TestDryRunFollowedByRun_UUIDPartitionZero(t *testing.T) {
+	t.Parallel()
+	chain := flow.Emulator.Chain()
+	runWithNewEnvironmentWithBlock(t,
+		chain, blockFixtureWithUUIDPartitionZero(), dryRunFollowedByRunCase(t, chain),
+	)
+}
+
+// dryRunFollowedByRunCase returns the test case body shared by the random-block and the
+// forced-partition-zero variants: dryRun reads the block proposal into the cache, and a
+// subsequent EVM.run in the same Cadence transaction must still see a clean proposal and
+// complete successfully, with partition-dependent metering.
+func dryRunFollowedByRunCase(t *testing.T, chain flow.Chain) func(fvm.Context, fvm.VM, snapshot.SnapshotTree, *TestContract, *EOATestAccount) {
+	return func(
+		ctx fvm.Context,
+		vm fvm.VM,
+		snapshot snapshot.SnapshotTree,
+		testContract *TestContract,
+		testAccount *EOATestAccount,
+	) {
+		sc := systemcontracts.SystemContractsForChain(chain.ChainID())
+
+		data := testContract.MakeCallData(t, "store", big.NewInt(42))
+
+		// The dry-run tx uses nonce 0 (doesn't consume it).
+		dryTx := gethTypes.NewTransaction(
+			testAccount.Nonce(),
+			testContract.DeployedAt.ToCommon(),
+			big.NewInt(0),
+			uint64(125_000),
+			big.NewInt(0),
+			data,
+		)
+		dryTxBytes, err := dryTx.MarshalBinary()
+		require.NoError(t, err)
+
+		// The real tx is signed and uses the same nonce.
+		realTxBytes := testAccount.PrepareSignAndEncodeTx(t,
+			testContract.DeployedAt.ToCommon(),
+			data,
+			big.NewInt(0),
+			uint64(125_000),
+			big.NewInt(0),
+		)
+
+		code := fmt.Appendf(nil, `
+			import EVM from %s
+
+			transaction(dryTx: [UInt8], realTx: [UInt8], coinbaseBytes: [UInt8; 20]) {
+				prepare(account: &Account) {
+					let from = EVM.EVMAddress(bytes: coinbaseBytes)
+					let coinbase = EVM.EVMAddress(bytes: coinbaseBytes)
+
+					let dryResult = EVM.dryRun(tx: dryTx, from: from)
+					assert(dryResult.status == EVM.Status.successful, message: "dry run failed")
+
+					let runResult = EVM.run(tx: realTx, coinbase: coinbase)
+					assert(runResult.status == EVM.Status.successful, message: "run after dry run failed")
+				}
+			}
+		`, sc.EVMContract.Address.HexWithPrefix())
+
+		dryTxArg := cadence.NewArray(
+			unittest.BytesToCdcUInt8(dryTxBytes),
+		).WithType(stdlib.EVMTransactionBytesCadenceType)
+
+		realTxArg := cadence.NewArray(
+			unittest.BytesToCdcUInt8(realTxBytes),
+		).WithType(stdlib.EVMTransactionBytesCadenceType)
+
+		coinbase := cadence.NewArray(
+			unittest.BytesToCdcUInt8(testAccount.Address().Bytes()),
+		).WithType(stdlib.EVMAddressBytesCadenceType)
+
+		txBody, err := flow.NewTransactionBodyBuilder().
+			SetScript(code).
+			SetPayer(sc.FlowServiceAccount.Address).
+			AddAuthorizer(sc.FlowServiceAccount.Address).
+			AddArgument(json.MustEncode(dryTxArg)).
+			AddArgument(json.MustEncode(realTxArg)).
+			AddArgument(json.MustEncode(coinbase)).
+			Build()
+		require.NoError(t, err)
+
+		tx := fvm.Transaction(txBody, 0)
+		state, output, err := vm.Run(ctx, tx, snapshot)
+		require.NoError(t, err)
+		require.NoError(t, output.Err)
+
+		// the number of updated registers is the same for both UUID partitions (verified by
+		// forcing each partition)
+		assert.Len(t, state.UpdatedRegisterIDs(), 4)
+
+		// The metered computation depends on the block's UUID partition (see
+		// environment.uuidPartition with txnIndex 0): partition 0 (probability 1/256 for a
+		// random block) reuses the legacy `uuid` register, which exists and thus meters more
+		// interaction than the untouched partitioned register. The extra reads happen inside
+		// the dry-run's speculative (discarded) transaction, so they are metered without
+		// appearing in the returned snapshot. Both values verified by forcing each partition.
+		blockID := ctx.BlockHeader.ID()
+		partition := sha256.Sum256(blockID[:])[0]
+		expectedComputation := uint64(92)
+		if partition == 0 {
+			expectedComputation = 96
+		}
+		assert.Equal(t, expectedComputation, output.ComputationUsed)
+	}
 }
 
 func TestDryCall(t *testing.T) {
@@ -7784,12 +7813,38 @@ func RunWithNewEnvironment(
 	f func(fvm.Context, fvm.VM, snapshot.SnapshotTree, *TestContract, *EOATestAccount),
 	bootstrapOpts ...fvm.BootstrapProcedureOption,
 ) {
+	runWithNewEnvironmentWithBlock(t, chain, unittest.BlockFixture(), f, bootstrapOpts...)
+}
+
+// blockFixtureWithUUIDPartitionZero returns a block fixture whose ID selects UUID partition 0
+// for the transaction at index 0 (sha256(blockID)[0] == 0, see environment.uuidPartition).
+// Such blocks make the EVM environment reuse the legacy `uuid` register instead of a fresh
+// partitioned one, a 1/256 branch that random block fixtures practically never exercise.
+// On average this takes 256 attempts (a few milliseconds).
+func blockFixtureWithUUIDPartitionZero() *flow.Block {
+	for {
+		block := unittest.BlockFixture()
+		id := block.ID()
+		if sha256.Sum256(id[:])[0] == 0 {
+			return block
+		}
+	}
+}
+
+// runWithNewEnvironmentWithBlock is RunWithNewEnvironment with a caller-provided block, which
+// (among other things) determines the UUID partition used by the environment.
+func runWithNewEnvironmentWithBlock(
+	t *testing.T,
+	chain flow.Chain,
+	block1 *flow.Block,
+	f func(fvm.Context, fvm.VM, snapshot.SnapshotTree, *TestContract, *EOATestAccount),
+	bootstrapOpts ...fvm.BootstrapProcedureOption,
+) {
 	rootAddr := evm.StorageAccountAddress(chain.ChainID())
 	RunWithTestBackend(t, chain.ChainID(), func(backend *TestBackend) {
 		RunWithDeployedContract(t, GetStorageTestContract(t), backend, rootAddr, func(testContract *TestContract) {
 			RunWithEOATestAccount(t, backend, rootAddr, func(testAccount *EOATestAccount) {
 				blocks := new(envMock.Blocks)
-				block1 := unittest.BlockFixture()
 				blocks.On("ByHeightFrom",
 					block1.Height,
 					block1.ToHeader(),


### PR DESCRIPTION
The EVM environment selects a UUID register partition from `sha256(blockID)[0]`. Partition 0 (probability 1/256 for a random block fixture) reuses the legacy `uuid` register, which changes metering and register counts. This branch made exact assertions flaky (#8629, and the `ComputationUsed` assertion fixed in #8634), and with random fixtures it is practically never exercised in CI.

## Changes

- Add `blockFixtureWithUUIDPartitionZero`, a block fixture that deterministically selects partition 0, and a block-parameterized variant of `RunWithNewEnvironment`.
- Extract the dryRun-followed-by-run test case and run it in a new test with partition 0 forced, asserting the partition-0 metering value (79) that was previously only reachable 1 run in 256.
- Strengthen the shared case: assert the exact updated-register count (4), verified to be partition-independent.

While investigating, confirmed the partition-dependent reads happen inside the dry-run's speculative (discarded) transaction: they are metered but do not appear in the returned execution snapshot, which is documented in the test.

Related: #8629, #8634

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788359970&installation_model_id=15376&pr_number=8637&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8637&signature=c16dfe79b1c6540527be7043e9df673624f65f8956f710622940325b336185aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for running a dry run followed by execution within the same transaction.
  * Added deterministic testing for a rare block-partition scenario.
  * Improved test setup flexibility for custom block fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->