### PR TITLE
[Testing] Fix flaky TestFailedTxWillNotChangeStateCommitment

### DIFF
--- a/engine/execution/execution_test.go
+++ b/engine/execution/execution_test.go
@@ -479,9 +479,12 @@ func TestFailedTxWillNotChangeStateCommitment(t *testing.T) {
 	assert.NoError(t, err)
 
 	// ensure block 1 has been executed
-	hub.DeliverAllEventually(t, func() bool {
+	// the receipt travels a multi-hop async pipeline (follower -> ingestion -> execution ->
+	// pusher -> stub network -> consensus mock), so use a generous liveness bound with a fast
+	// poll: it returns as soon as the receipt arrives and only slow, loaded runs pay the wait.
+	hub.DeliverAllEventuallyUntil(t, func() bool {
 		return receiptsReceived.Load() == 1
-	})
+	}, 60*time.Second, 100*time.Millisecond)
 
 	if exe1Node.StorehouseEnabled {
 		exe1Node.AssertHighestExecutedBlock(t, genesis.ToHeader())
@@ -507,9 +510,11 @@ func TestFailedTxWillNotChangeStateCommitment(t *testing.T) {
 	assert.NoError(t, err)
 
 	// ensure block 1, 2 and 3 have been executed
-	hub.DeliverAllEventually(t, func() bool {
+	// waiting for 2 more receipts doubles the pipeline hops compared to the wait above;
+	// under full-suite load this exceeded the 10s/500ms default bound of DeliverAllEventually.
+	hub.DeliverAllEventuallyUntil(t, func() bool {
 		return receiptsReceived.Load() == 3
-	})
+	}, 60*time.Second, 100*time.Millisecond)
 
 	// ensure state has been synced across both nodes
 	exe1Node.AssertBlockIsExecuted(t, block2.ToHeader())


### PR DESCRIPTION
`TestFailedTxWillNotChangeStateCommitment` flaked once in a 10x full-suite campaign: its
second receipt wait (`hub.DeliverAllEventually`, waiting for 3 execution receipts) hit the
10s timeout. Typical runtime is ~5.5s with a tight distribution, so the pipeline was
genuinely delayed, not deadlocked.

Each receipt crosses an ~8-hop async pipeline (follower -> ingestion -> collection fetch ->
execution -> receipt pusher -> stub network -> consensus mock), where every hop is an
independently scheduled goroutine handoff. Under full-suite parallel load, the accumulated
scheduling delay for 2 more receipts exceeded the 10s/500ms default bound of
`DeliverAllEventually`.

Change: both receipt waits in this test now use `DeliverAllEventuallyUntil` with a 60s
bound and a 100ms poll. Liveness bounds return early on success, so the common case is
unaffected; the faster poll actually speeds the test up to ~2.3s typical (was ~5.5s) by
removing tick-quantization latency.

Validation: 10x full-suite campaign with the fix, 10/10 green. In one run the test took
10.8s, which would have failed under the old 10s bound. All assertions unchanged, no
coverage reduction. Test-only change.

Related: #8634

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788436023&installation_model_id=15376&pr_number=8639&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8639&signature=2ae98ad0de312360d37df4d3e50c6631581a9766a745e67a1ca99566769f47fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous test reliability by adding bounded waiting and polling for transaction receipt delivery.
  * Tests now allow up to 60 seconds for expected receipts while checking at regular intervals.
  * This helps reduce intermittent failures when receipt processing takes longer than usual, providing more consistent validation of failed-transaction state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->