### PR TITLE
[Testing] Fix flaky tests exposed by parallel test scheduling

### DIFF
--- a/engine/access/state_stream/backend/backend_executiondata_test.go
+++ b/engine/access/state_stream/backend/backend_executiondata_test.go
@@ -524,7 +524,7 @@ func (s *BackendExecutionDataSuite) subscribe(subscribeFunc func(ctx context.Con
 
 					assert.Equal(s.T(), b.Height, resp.Height)
 					assert.Equal(s.T(), execData.BlockExecutionData, resp.ExecutionData)
-				}, time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
+				}, 10*time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
 			}
 
 			// make sure there are no new messages waiting. the channel should be opened with nothing waiting

--- a/engine/access/state_stream/backend/handler_test.go
+++ b/engine/access/state_stream/backend/handler_test.go
@@ -111,7 +111,7 @@ func (s *HandlerTestSuite) TestHeartbeatResponse() {
 				require.NoError(s.T(), err)
 				require.Equal(s.T(), b.ID(), blockID)
 				require.Equal(s.T(), b.Height, resp.BlockHeight)
-			}, time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
+			}, 10*time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
 		}
 	})
 
@@ -146,7 +146,7 @@ func (s *HandlerTestSuite) TestHeartbeatResponse() {
 				require.NoError(s.T(), err)
 				require.Equal(s.T(), b.ID(), blockID)
 				require.Equal(s.T(), b.Height, resp.BlockHeight)
-			}, time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
+			}, 10*time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
 		}
 	})
 
@@ -192,7 +192,7 @@ func (s *HandlerTestSuite) TestHeartbeatResponse() {
 				require.Equal(s.T(), b.Height, resp.BlockHeight)
 				require.Equal(s.T(), b.ID(), blockID)
 				require.Empty(s.T(), resp.Events)
-			}, time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
+			}, 10*time.Second, fmt.Sprintf("timed out waiting for exec data for block %d %v", b.Height, b.ID()))
 		}
 	})
 }

--- a/engine/verification/fetcher/chunkconsumer/consumer_test.go
+++ b/engine/verification/fetcher/chunkconsumer/consumer_test.go
@@ -56,8 +56,9 @@ func TestProduceConsume(t *testing.T) {
 			<-consumer.Done()
 
 			// expect the mock engine receive only the first 3 calls (since it is blocked on those, hence no
-			// new job is fetched to process).
-			require.Equal(t, locators[:3], called)
+			// new job is fetched to process). The 3 concurrent workers append in nondeterministic
+			// order, so assert the multiset rather than the exact sequence.
+			require.ElementsMatch(t, locators[:3], called)
 		})
 	})
 

--- a/engine/verification/fetcher/chunkconsumer/consumer_test.go
+++ b/engine/verification/fetcher/chunkconsumer/consumer_test.go
@@ -91,8 +91,10 @@ func TestProduceConsume(t *testing.T) {
 
 			finishAll.Wait() // wait until all 10 jobs are processed and notified
 			<-consumer.Done()
-			// expect the mock engine receives all 10 calls
-			require.Equal(t, locators, called)
+			// expect the mock engine receives all 10 calls.
+			// the consumer processes jobs with 3 concurrent workers, so the receive order is
+			// not deterministic; assert the multiset rather than the exact sequence.
+			require.ElementsMatch(t, locators, called)
 		})
 	})
 

--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -96,11 +96,22 @@ func randPathPayload() (ledger.Path, ledger.Payload) {
 	return path, *payload
 }
 
-func randNPathPayloads(n int) ([]ledger.Path, []ledger.Payload) {
+// randNPathPayloadsUnique returns n random path/payload pairs whose payload keys are unique
+// with respect to each other and to the keys already present in `used` (which it updates).
+// Tests compare the payloads of the final trie by payload key, so a duplicate key with a
+// different value makes the comparison nondeterministic: with 1-byte random keys this
+// happens with probability ~1/256 per colliding pair (observed as a rare flake).
+func randNPathPayloadsUnique(n int, used map[string]struct{}) ([]ledger.Path, []ledger.Payload) {
 	paths := make([]ledger.Path, n)
 	payloads := make([]ledger.Payload, n)
 	for i := 0; i < n; i++ {
 		path, payload := randPathPayload()
+		key := hex.EncodeToString(payload.EncodedKey())
+		for _, dup := used[key]; dup; _, dup = used[key] {
+			path, payload = randPathPayload()
+			key = hex.EncodeToString(payload.EncodedKey())
+		}
+		used[key] = struct{}{}
 		paths[i] = path
 		payloads[i] = payload
 	}
@@ -110,23 +121,24 @@ func randNPathPayloads(n int) ([]ledger.Path, []ledger.Payload) {
 func createMultipleRandomTries(t *testing.T) []*trie.MTrie {
 	tries := make([]*trie.MTrie, 0)
 	activeTrie := trie.NewEmptyMTrie()
+	usedKeys := make(map[string]struct{})
 
 	var err error
 	// add tries with no shared paths
 	for i := 0; i < 100; i++ {
-		paths, payloads := randNPathPayloads(100)
+		paths, payloads := randNPathPayloadsUnique(100, usedKeys)
 		activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, paths, payloads, false)
 		require.NoError(t, err, "update registers")
 		tries = append(tries, activeTrie)
 	}
 
 	// add trie with some shared path
-	sharedPaths, payloads1 := randNPathPayloads(100)
+	sharedPaths, payloads1 := randNPathPayloadsUnique(100, usedKeys)
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads1, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)
 
-	_, payloads2 := randNPathPayloads(100)
+	_, payloads2 := randNPathPayloadsUnique(100, usedKeys)
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads2, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)
@@ -156,23 +168,24 @@ func isTrieDeepEnough(trie *trie.MTrie) bool {
 func createMultipleRandomTriesMini(t *testing.T) ([]*trie.MTrie, *trie.MTrie) {
 	tries := make([]*trie.MTrie, 0)
 	activeTrie := trie.NewEmptyMTrie()
+	usedKeys := make(map[string]struct{})
 
 	var err error
 	// add tries with no shared paths
 	for i := 0; i < 5; i++ {
-		paths, payloads := randNPathPayloads(20)
+		paths, payloads := randNPathPayloadsUnique(20, usedKeys)
 		activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, paths, payloads, false)
 		require.NoError(t, err, "update registers")
 		tries = append(tries, activeTrie)
 	}
 
 	// add trie with some shared path
-	sharedPaths, payloads1 := randNPathPayloads(10)
+	sharedPaths, payloads1 := randNPathPayloadsUnique(10, usedKeys)
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads1, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)
 
-	_, payloads2 := randNPathPayloads(10)
+	_, payloads2 := randNPathPayloadsUnique(10, usedKeys)
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads2, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)

--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -96,11 +96,22 @@ func randPathPayload() (ledger.Path, ledger.Payload) {
 	return path, *payload
 }
 
-func randNPathPayloads(n int) ([]ledger.Path, []ledger.Payload) {
+// randNPathPayloadsUnique returns n random path/payload pairs whose payload keys are unique
+// with respect to each other and to the keys already present in `used` (which it updates).
+// Tests compare the payloads of the final trie by payload key, so a duplicate key with a
+// different value makes the comparison nondeterministic: with 1-byte random keys this
+// happens with probability ~1/256 per colliding pair (observed as a rare flake).
+func randNPathPayloadsUnique(n int, used map[string]struct{}) ([]ledger.Path, []ledger.Payload) {
 	paths := make([]ledger.Path, n)
 	payloads := make([]ledger.Payload, n)
 	for i := range n {
 		path, payload := randPathPayload()
+		key := hex.EncodeToString(payload.EncodedKey())
+		for _, dup := used[key]; dup; _, dup = used[key] {
+			path, payload = randPathPayload()
+			key = hex.EncodeToString(payload.EncodedKey())
+		}
+		used[key] = struct{}{}
 		paths[i] = path
 		payloads[i] = payload
 	}
@@ -110,23 +121,24 @@ func randNPathPayloads(n int) ([]ledger.Path, []ledger.Payload) {
 func createMultipleRandomTries(t *testing.T) []*trie.MTrie {
 	tries := make([]*trie.MTrie, 0)
 	activeTrie := trie.NewEmptyMTrie()
+	usedKeys := make(map[string]struct{})
 
 	var err error
 	// add tries with no shared paths
 	for range 100 {
-		paths, payloads := randNPathPayloads(100)
+		paths, payloads := randNPathPayloadsUnique(100, usedKeys)
 		activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, paths, payloads, false)
 		require.NoError(t, err, "update registers")
 		tries = append(tries, activeTrie)
 	}
 
 	// add trie with some shared path
-	sharedPaths, payloads1 := randNPathPayloads(100)
+	sharedPaths, payloads1 := randNPathPayloadsUnique(100, usedKeys)
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads1, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)
 
-	_, payloads2 := randNPathPayloads(100)
+	_, payloads2 := randNPathPayloadsUnique(100, usedKeys)
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads2, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)
@@ -156,23 +168,24 @@ func isTrieDeepEnough(trie *trie.MTrie) bool {
 func createMultipleRandomTriesMini(t *testing.T) ([]*trie.MTrie, *trie.MTrie) {
 	tries := make([]*trie.MTrie, 0)
 	activeTrie := trie.NewEmptyMTrie()
+	usedKeys := make(map[string]struct{})
 
 	var err error
 	// add tries with no shared paths
 	for range 5 {
-		paths, payloads := randNPathPayloads(20)
+		paths, payloads := randNPathPayloadsUnique(20, usedKeys)
 		activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, paths, payloads, false)
 		require.NoError(t, err, "update registers")
 		tries = append(tries, activeTrie)
 	}
 
 	// add trie with some shared path
-	sharedPaths, payloads1 := randNPathPayloads(10)
+	sharedPaths, payloads1 := randNPathPayloadsUnique(10, usedKeys)
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads1, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)
 
-	_, payloads2 := randNPathPayloads(10)
+	_, payloads2 := randNPathPayloadsUnique(10, usedKeys)
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads2, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)

--- a/network/alsp/manager/manager_test.go
+++ b/network/alsp/manager/manager_test.go
@@ -416,12 +416,16 @@ func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integratio
 
 		penalty1 := record.Penalty
 
-		// wait for one heartbeat to be processed.
-		time.Sleep(1 * time.Second)
-
-		record, ok = victimSpamRecordCache.Get(ids[spammerIndex].NodeID)
-		require.True(t, ok)
-		require.NotNil(t, record)
+		// wait for one heartbeat to be processed: poll for the first penalty change instead of
+		// sleeping exactly one heartbeat interval. A fixed 1s sleep races the 1s heartbeat ticker
+		// (which can be delayed under load) and may span 0 or 2 decays; polling at 10ms granularity
+		// reliably catches the state after exactly one decay.
+		require.Eventually(t, func() bool {
+			record, ok = victimSpamRecordCache.Get(ids[spammerIndex].NodeID)
+			require.True(t, ok)
+			require.NotNil(t, record)
+			return record.Penalty != penalty1
+		}, 10*time.Second, 10*time.Millisecond, "penalty did not decay after one heartbeat")
 
 		// check the penalty of the spammer node, which should be below the disallow-listing threshold.
 		// i.e. spammer penalty should be more negative than the disallow-listing threshold, hence disallow-listed.


### PR DESCRIPTION
Flaky test fixes for failures that surfaced once slow test packages were scheduled first (heavier contention at the start of a full-suite run), plus one pre-existing tail flake.

- `engine/access/state_stream/backend`: widen per-block exec-data liveness waits (1s -> 10s); they timed out under full-suite load.
- `network/alsp/manager` RepeatOffender: poll for the first penalty change instead of sleeping exactly one heartbeat interval, which could observe 0 or 2 decays when the heartbeat ticker was delayed.
- `ledger/complete/wal` checkpoint test: redraw random payloads on duplicate encoded keys. Keys can be as short as 1 byte (~1/256 collision per pair, ~130 payloads per trie), which made the payload comparison nondeterministic.
- `engine/verification/fetcher/chunkconsumer`: assert the multiset instead of the exact receive order in both "receive N" subtests; the consumer's 3 concurrent workers append in nondeterministic order.

All fixes preserve the original assertions' strength. Validation: per-test stress runs (3x-50x, `-race` where relevant) and clean 10x full-suite campaigns.

Related: #8639

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788460662&installation_model_id=15376&pr_number=8640&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8640&signature=95841f62aea9a479586c5b0bb5f3a1a0d762c36db1481b39f1e5b31d3a4b73ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by allowing more time for asynchronous execution data and heartbeat responses.
  * Updated concurrent processing checks to accept results in any valid order.
  * Ensured generated test payloads remain unique for deterministic comparisons.
  * Replaced fixed delays with condition-based waiting for penalty decay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->