### PR TITLE
[Testing] Speed up unit test suite: slow-first scheduling and long-pole parallelization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,19 @@ VERSION := $(shell git describe --tags --abbrev=2 --match "v*" --match "secure-c
 # dynamically split up CI jobs into smaller jobs that can be run in parallel
 GO_TEST_PACKAGES := ./...
 
+# The slowest test packages. `go test` schedules package test binaries in argument order
+# (alphabetical for ./...), so these long, internally-sequential packages would otherwise
+# start last and form a straggler tail that dominates the wall time of a full-suite run.
+# Listing them first lets them run while the remaining packages fill the other slots.
+# Only prepended when running the full suite (not for CI's per-job package subsets).
+# Overlapping package patterns are deduplicated by the go tool, so nothing runs twice.
+# First line: the slowest packages (the wall-time critical path).
+# Second line: second-tier packages (~20-35s each) that would otherwise start only
+# after the first wave of short packages drains and form a tail at the end of the run.
+SLOW_TEST_PACKAGES := ./network/p2p/scoring/... ./ledger/complete/... ./network/p2p/connection/... ./network/p2p/inspector/validation/... \
+	./consensus/integration/... ./cmd/util/ledger/util/... ./engine/verification/test/... ./network/alsp/... ./network/test/... \
+	./network/p2p/test/... ./network/p2p/node/... ./engine/verification/assigner/blockconsumer/... ./module/dkg/... ./engine/access/state_stream/backend/...
+
 # Image tag: if image tag is not set, set it with version (or short commit if empty)
 ifeq (${IMAGE_TAG},)
 IMAGE_TAG := ${VERSION}
@@ -70,7 +83,7 @@ update-cadence-version:
 .PHONY: unittest-main
 unittest-main:
 	# test all packages
-	CGO_CFLAGS=$(CRYPTO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(RACE_DETECTOR),-race,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(GO_TEST_PACKAGES)
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(RACE_DETECTOR),-race,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(if $(filter ./...,$(GO_TEST_PACKAGES)),$(SLOW_TEST_PACKAGES)) $(GO_TEST_PACKAGES)
 
 .PHONY: install-mock-generators
 install-mock-generators:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,19 @@ VERSION := $(shell git describe --tags --abbrev=2 --match "v*" --match "secure-c
 # dynamically split up CI jobs into smaller jobs that can be run in parallel
 GO_TEST_PACKAGES := ./...
 
+# The slowest test packages. `go test` schedules package test binaries in argument order
+# (alphabetical for ./...), so these long, internally-sequential packages would otherwise
+# start last and form a straggler tail that dominates the wall time of a full-suite run.
+# Listing them first lets them run while the remaining packages fill the other slots.
+# Only prepended when running the full suite (not for CI's per-job package subsets).
+# Overlapping package patterns are deduplicated by the go tool, so nothing runs twice.
+# First line: the slowest packages (the wall-time critical path).
+# Second line: second-tier packages (~20-35s each) that would otherwise start only
+# after the first wave of short packages drains and form a tail at the end of the run.
+SLOW_TEST_PACKAGES := ./network/p2p/scoring/... ./ledger/complete/... ./network/p2p/connection/... ./network/p2p/inspector/validation/... \
+	./consensus/integration/... ./cmd/util/ledger/util/... ./engine/verification/test/... ./network/alsp/... ./network/test/... \
+	./network/p2p/test/... ./network/p2p/node/... ./engine/verification/assigner/blockconsumer/... ./module/dkg/... ./engine/access/state_stream/backend/...
+
 # Image tag: if image tag is not set, set it with version (or short commit if empty)
 ifeq (${IMAGE_TAG},)
 IMAGE_TAG := ${VERSION}
@@ -68,7 +81,7 @@ update-cadence-version:
 .PHONY: unittest-main
 unittest-main:
 	# test all packages
-	CGO_CFLAGS=$(CRYPTO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(RACE_DETECTOR),-race,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(GO_TEST_PACKAGES)
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(RACE_DETECTOR),-race,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(if $(filter ./...,$(GO_TEST_PACKAGES)),$(SLOW_TEST_PACKAGES)) $(GO_TEST_PACKAGES)
 
 .PHONY: install-mock-generators
 install-mock-generators:

--- a/engine/verification/test/happypath_test.go
+++ b/engine/verification/test/happypath_test.go
@@ -121,6 +121,10 @@ func TestVerificationHappyPath(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.msg, func(t *testing.T) {
+			// each subtest builds its own full node fixture (own hub, networks, mocks,
+			// and FVM instance), so they are independent and can run in parallel.
+			t.Parallel()
+
 			collector := &metrics.NoopCollector{}
 
 			vertestutils.NewVerificationHappyPathTest(t,

--- a/ledger/complete/compactor_test.go
+++ b/ledger/complete/compactor_test.go
@@ -58,6 +58,8 @@ func (co *CompactorObserver) OnComplete() {
 // TestCompactorCreation tests creation of WAL segments and checkpoints, and
 // checks if the rebuilt ledger state matches previous ledger state.
 func TestCompactorCreation(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numInsPerStep      = 2
 		pathByteSize       = 32
@@ -287,6 +289,8 @@ func TestCompactorCreation(t *testing.T) {
 // TestCompactorSkipCheckpointing tests that only one
 // checkpointing is running at a time.
 func TestCompactorSkipCheckpointing(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numInsPerStep      = 2
 		pathByteSize       = 32
@@ -410,6 +414,8 @@ func TestCompactorSkipCheckpointing(t *testing.T) {
 // (from segment 0, ignoring prior checkpoints) to the checkpoint number.
 // This verifies that checkpointed tries are snapshopt of segments and at segment boundary.
 func TestCompactorAccuracy(t *testing.T) {
+	t.Parallel()
+
 
 	const (
 		numInsPerStep      = 2
@@ -526,6 +532,8 @@ func TestCompactorAccuracy(t *testing.T) {
 // TestCompactorTriggeredByAdminTool tests that the compactor will listen to the signal from admin tool
 // to trigger checkpoint when current segment file is finished.
 func TestCompactorTriggeredByAdminTool(t *testing.T) {
+	t.Parallel()
+
 
 	const (
 		numInsPerStep      = 2 // the number of payloads in each trie update
@@ -628,6 +636,8 @@ func TestCompactorTriggeredByAdminTool(t *testing.T) {
 // When initial state is from ledger's forest (LRU cache), its
 // sequence is altered by reads when replaying segment records.
 func TestCompactorConcurrency(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numInsPerStep      = 2
 		pathByteSize       = 32

--- a/ledger/complete/compactor_test.go
+++ b/ledger/complete/compactor_test.go
@@ -416,7 +416,6 @@ func TestCompactorSkipCheckpointing(t *testing.T) {
 func TestCompactorAccuracy(t *testing.T) {
 	t.Parallel()
 
-
 	const (
 		numInsPerStep      = 2
 		pathByteSize       = 32
@@ -533,7 +532,6 @@ func TestCompactorAccuracy(t *testing.T) {
 // to trigger checkpoint when current segment file is finished.
 func TestCompactorTriggeredByAdminTool(t *testing.T) {
 	t.Parallel()
-
 
 	const (
 		numInsPerStep      = 2 // the number of payloads in each trie update

--- a/ledger/complete/ledger_test.go
+++ b/ledger/complete/ledger_test.go
@@ -585,6 +585,8 @@ func Test_WAL(t *testing.T) {
 }
 
 func TestLedgerFunctionality(t *testing.T) {
+	t.Parallel()
+
 	const (
 		checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
 		checkpointsToKeep  = 1

--- a/network/alsp/manager/manager_test.go
+++ b/network/alsp/manager/manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/flow-go/network/internal/testutils"
 	mocknetwork "github.com/onflow/flow-go/network/mock"
 	"github.com/onflow/flow-go/network/p2p"
+	p2pbuilderconfig "github.com/onflow/flow-go/network/p2p/builder/config"
 	p2ptest "github.com/onflow/flow-go/network/p2p/test"
 	"github.com/onflow/flow-go/network/slashing"
 	"github.com/onflow/flow-go/network/underlay"
@@ -299,6 +300,10 @@ func TestHandleReportedMisbehavior_And_DisallowListing_Integration(t *testing.T)
 // handling of repeated reported misbehavior and disallow listing.
 func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integration(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// compress the heartbeat interval: all assertions in this test are per-heartbeat
+	// (decay deltas, disallow-listing rounds), so a faster heartbeat preserves semantics
+	// while cutting the wall time roughly proportionally.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	sporkId := unittest.IdentifierFixture()
 	fastDecay := false
 	fastDecayFunc := func(record *model.ProtocolSpamRecord) float64 {
@@ -327,7 +332,11 @@ func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integratio
 	}
 
 	ids, nodes := testutils.LibP2PNodeForNetworkFixture(t, sporkId, 3,
-		p2ptest.WithPeerManagerEnabled(p2ptest.PeerManagerConfigFixture(p2ptest.WithZeroJitterAndZeroBackoff(t)), nil))
+		p2ptest.WithPeerManagerEnabled(p2ptest.PeerManagerConfigFixture(p2ptest.WithZeroJitterAndZeroBackoff(t), func(cfg *p2pbuilderconfig.PeerManagerConfig) {
+			// compress the peer manager tick as well: pruning and reconnection waits are
+			// tick-quantized, and the test only cares about the sequence of events.
+			cfg.UpdateInterval = 100 * time.Millisecond
+		}), nil))
 	idProvider := unittest.NewUpdatableIDProvider(ids)
 	networkCfg := testutils.NetworkConfigFixture(t, *ids[0], idProvider, sporkId, nodes[0], underlay.WithAlspConfig(cfg))
 
@@ -417,7 +426,7 @@ func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integratio
 		penalty1 := record.Penalty
 
 		// wait for one heartbeat to be processed: poll for the first penalty change instead of
-		// sleeping exactly one heartbeat interval. A fixed 1s sleep races the 1s heartbeat ticker
+		// sleeping exactly one heartbeat interval. A fixed sleep races the heartbeat ticker
 		// (which can be delayed under load) and may span 0 or 2 decays; polling at 10ms granularity
 		// reliably catches the state after exactly one decay.
 		require.Eventually(t, func() bool {
@@ -1420,6 +1429,8 @@ func TestHandleMisbehaviorReport_DuplicateReportsForSinglePeer_Concurrently(t *t
 // is decayed after a single heartbeat. The test guarantees waiting for at least one heartbeat by waiting for the first decay to happen.
 func TestDecayMisbehaviorPenalty_SingleHeartbeat(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// decay assertions are per-heartbeat; a faster heartbeat preserves semantics.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	consumer := mocknetwork.NewDisallowListNotificationConsumer(t)
 
 	var cache alsp.SpamRecordCache
@@ -1523,6 +1534,8 @@ func TestDecayMisbehaviorPenalty_SingleHeartbeat(t *testing.T) {
 // The test ensures that the misbehavior penalty is decayed with a linear progression within multiple heartbeats.
 func TestDecayMisbehaviorPenalty_MultipleHeartbeats(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// decay assertions are per-heartbeat; a faster heartbeat preserves semantics.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	consumer := mocknetwork.NewDisallowListNotificationConsumer(t)
 
 	var cache alsp.SpamRecordCache

--- a/network/alsp/manager/manager_test.go
+++ b/network/alsp/manager/manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/flow-go/network/internal/testutils"
 	mocknetwork "github.com/onflow/flow-go/network/mock"
 	"github.com/onflow/flow-go/network/p2p"
+	p2pbuilderconfig "github.com/onflow/flow-go/network/p2p/builder/config"
 	p2ptest "github.com/onflow/flow-go/network/p2p/test"
 	"github.com/onflow/flow-go/network/slashing"
 	"github.com/onflow/flow-go/network/underlay"
@@ -299,6 +300,10 @@ func TestHandleReportedMisbehavior_And_DisallowListing_Integration(t *testing.T)
 // handling of repeated reported misbehavior and disallow listing.
 func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integration(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// compress the heartbeat interval: all assertions in this test are per-heartbeat
+	// (decay deltas, disallow-listing rounds), so a faster heartbeat preserves semantics
+	// while cutting the wall time roughly proportionally.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	sporkId := unittest.IdentifierFixture()
 	fastDecay := false
 	fastDecayFunc := func(record *model.ProtocolSpamRecord) float64 {
@@ -327,7 +332,11 @@ func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integratio
 	}
 
 	ids, nodes := testutils.LibP2PNodeForNetworkFixture(t, sporkId, 3,
-		p2ptest.WithPeerManagerEnabled(p2ptest.PeerManagerConfigFixture(p2ptest.WithZeroJitterAndZeroBackoff(t)), nil))
+		p2ptest.WithPeerManagerEnabled(p2ptest.PeerManagerConfigFixture(p2ptest.WithZeroJitterAndZeroBackoff(t), func(cfg *p2pbuilderconfig.PeerManagerConfig) {
+			// compress the peer manager tick as well: pruning and reconnection waits are
+			// tick-quantized, and the test only cares about the sequence of events.
+			cfg.UpdateInterval = 100 * time.Millisecond
+		}), nil))
 	idProvider := unittest.NewUpdatableIDProvider(ids)
 	networkCfg := testutils.NetworkConfigFixture(t, *ids[0], idProvider, sporkId, nodes[0], underlay.WithAlspConfig(cfg))
 
@@ -417,7 +426,7 @@ func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integratio
 		penalty1 := record.Penalty
 
 		// wait for one heartbeat to be processed: poll for the first penalty change instead of
-		// sleeping exactly one heartbeat interval. A fixed 1s sleep races the 1s heartbeat ticker
+		// sleeping exactly one heartbeat interval. A fixed sleep races the heartbeat ticker
 		// (which can be delayed under load) and may span 0 or 2 decays; polling at 10ms granularity
 		// reliably catches the state after exactly one decay.
 		require.Eventually(t, func() bool {
@@ -1422,6 +1431,8 @@ func TestHandleMisbehaviorReport_DuplicateReportsForSinglePeer_Concurrently(t *t
 // is decayed after a single heartbeat. The test guarantees waiting for at least one heartbeat by waiting for the first decay to happen.
 func TestDecayMisbehaviorPenalty_SingleHeartbeat(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// decay assertions are per-heartbeat; a faster heartbeat preserves semantics.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	consumer := mocknetwork.NewDisallowListNotificationConsumer(t)
 
 	var cache alsp.SpamRecordCache
@@ -1525,6 +1536,8 @@ func TestDecayMisbehaviorPenalty_SingleHeartbeat(t *testing.T) {
 // The test ensures that the misbehavior penalty is decayed with a linear progression within multiple heartbeats.
 func TestDecayMisbehaviorPenalty_MultipleHeartbeats(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// decay assertions are per-heartbeat; a faster heartbeat preserves semantics.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	consumer := mocknetwork.NewDisallowListNotificationConsumer(t)
 
 	var cache alsp.SpamRecordCache

--- a/network/p2p/connection/connection_gater_test.go
+++ b/network/p2p/connection/connection_gater_test.go
@@ -3,6 +3,7 @@ package connection_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -421,19 +422,26 @@ func ensureCommunicationSilenceAmongGroups(
 	// ensures no connection, unicast, or pubsub going to the disallow-listed nodes
 	p2ptest.EnsureNotConnectedBetweenGroups(t, ctx, groupANodes, groupBNodes)
 
+	// check both pubsub directions (A->B and B->A) concurrently on two distinct topics.
+	// Each direction is self-paced (1s subscription propagation + 5s never-receive window);
+	// checking them sequentially doubles that cost, while distinct topics keep the checks
+	// fully isolated from each other. Identical per-direction windows and assertions.
 	blockTopic := channels.TopicFromChannel(channels.PushBlocks, sporkId)
-	p2ptest.EnsureNoPubsubExchangeBetweenGroups(
-		t,
-		ctx,
-		groupANodes,
-		groupAIdentifiers,
-		groupBNodes,
-		groupBIdentifiers,
-		blockTopic,
-		1,
-		func() interface{} {
-			return (*messages.Proposal)(unittest.ProposalFixture())
-		})
+	receiptTopic := channels.TopicFromChannel(channels.PushReceipts, sporkId)
+	messageFactory := func() interface{} {
+		return (*messages.Proposal)(unittest.ProposalFixture())
+	}
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsureNoPubsubMessageExchange(t, ctx, groupANodes, groupBNodes, groupBIdentifiers, blockTopic, 1, messageFactory)
+	}()
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsureNoPubsubMessageExchange(t, ctx, groupBNodes, groupANodes, groupAIdentifiers, receiptTopic, 1, messageFactory)
+	}()
+	unittest.RequireReturnsBefore(t, wg.Wait, 12*time.Second, "timed out waiting for pubsub silence checks")
 	p2pfixtures.EnsureNoStreamCreationBetweenGroups(t, ctx, groupANodes, groupBNodes)
 }
 
@@ -441,8 +449,19 @@ func ensureCommunicationSilenceAmongGroups(
 func ensureCommunicationOverAllProtocols(t *testing.T, ctx context.Context, sporkId flow.Identifier, nodes []p2p.LibP2PNode, inbounds []chan string) {
 	blockTopic := channels.TopicFromChannel(channels.PushBlocks, sporkId)
 	p2ptest.TryConnectionAndEnsureConnected(t, ctx, nodes)
-	p2ptest.EnsurePubsubMessageExchange(t, ctx, nodes, blockTopic, 1, func() interface{} {
-		return (*messages.Proposal)(unittest.ProposalFixture())
-	})
-	p2pfixtures.EnsureMessageExchangeOverUnicast(t, ctx, nodes, inbounds, p2pfixtures.LongStringMessageFactoryFixture(t))
+	// the pubsub and unicast exchanges are independent of each other (different protocols);
+	// run them concurrently. Both return early on success.
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsurePubsubMessageExchange(t, ctx, nodes, blockTopic, 1, func() interface{} {
+			return (*messages.Proposal)(unittest.ProposalFixture())
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		p2pfixtures.EnsureMessageExchangeOverUnicast(t, ctx, nodes, inbounds, p2pfixtures.LongStringMessageFactoryFixture(t))
+	}()
+	unittest.RequireReturnsBefore(t, wg.Wait, 30*time.Second, "timed out waiting for protocol exchanges")
 }

--- a/network/p2p/connection/connection_gater_test.go
+++ b/network/p2p/connection/connection_gater_test.go
@@ -3,6 +3,7 @@ package connection_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -421,19 +422,26 @@ func ensureCommunicationSilenceAmongGroups(
 	// ensures no connection, unicast, or pubsub going to the disallow-listed nodes
 	p2ptest.EnsureNotConnectedBetweenGroups(t, ctx, groupANodes, groupBNodes)
 
+	// check both pubsub directions (A->B and B->A) concurrently on two distinct topics.
+	// Each direction is self-paced (1s subscription propagation + 5s never-receive window);
+	// checking them sequentially doubles that cost, while distinct topics keep the checks
+	// fully isolated from each other. Identical per-direction windows and assertions.
 	blockTopic := channels.TopicFromChannel(channels.PushBlocks, sporkId)
-	p2ptest.EnsureNoPubsubExchangeBetweenGroups(
-		t,
-		ctx,
-		groupANodes,
-		groupAIdentifiers,
-		groupBNodes,
-		groupBIdentifiers,
-		blockTopic,
-		1,
-		func() any {
-			return (*messages.Proposal)(unittest.ProposalFixture())
-		})
+	receiptTopic := channels.TopicFromChannel(channels.PushReceipts, sporkId)
+	messageFactory := func() any {
+		return (*messages.Proposal)(unittest.ProposalFixture())
+	}
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsureNoPubsubMessageExchange(t, ctx, groupANodes, groupBNodes, groupBIdentifiers, blockTopic, 1, messageFactory)
+	}()
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsureNoPubsubMessageExchange(t, ctx, groupBNodes, groupANodes, groupAIdentifiers, receiptTopic, 1, messageFactory)
+	}()
+	unittest.RequireReturnsBefore(t, wg.Wait, 12*time.Second, "timed out waiting for pubsub silence checks")
 	p2pfixtures.EnsureNoStreamCreationBetweenGroups(t, ctx, groupANodes, groupBNodes)
 }
 
@@ -441,8 +449,19 @@ func ensureCommunicationSilenceAmongGroups(
 func ensureCommunicationOverAllProtocols(t *testing.T, ctx context.Context, sporkId flow.Identifier, nodes []p2p.LibP2PNode, inbounds []chan string) {
 	blockTopic := channels.TopicFromChannel(channels.PushBlocks, sporkId)
 	p2ptest.TryConnectionAndEnsureConnected(t, ctx, nodes)
-	p2ptest.EnsurePubsubMessageExchange(t, ctx, nodes, blockTopic, 1, func() any {
-		return (*messages.Proposal)(unittest.ProposalFixture())
-	})
-	p2pfixtures.EnsureMessageExchangeOverUnicast(t, ctx, nodes, inbounds, p2pfixtures.LongStringMessageFactoryFixture(t))
+	// the pubsub and unicast exchanges are independent of each other (different protocols);
+	// run them concurrently. Both return early on success.
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsurePubsubMessageExchange(t, ctx, nodes, blockTopic, 1, func() any {
+			return (*messages.Proposal)(unittest.ProposalFixture())
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		p2pfixtures.EnsureMessageExchangeOverUnicast(t, ctx, nodes, inbounds, p2pfixtures.LongStringMessageFactoryFixture(t))
+	}()
+	unittest.RequireReturnsBefore(t, wg.Wait, 30*time.Second, "timed out waiting for protocol exchanges")
 }

--- a/network/p2p/inspector/validation/control_message_validation_inspector_test.go
+++ b/network/p2p/inspector/validation/control_message_validation_inspector_test.go
@@ -1596,6 +1596,8 @@ func TestControlMessageValidationInspector_ActiveClustersChanged(t *testing.T) {
 // TestControlMessageValidationInspector_TruncationConfigToggle ensures that rpc's are not truncated when truncation is disabled through configs.
 func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) {
 	t.Run("should not perform truncation when disabled is set to true", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		logCounter := atomic.NewInt64(0)
 		logger := hookedLogger(logCounter, zerolog.TraceLevel, validation.RPCTruncationDisabledWarning, worker.QueuedItemProcessedLog)
@@ -1640,6 +1642,8 @@ func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not perform truncation when disabled for each individual control message type directly", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		expectedLogStrs := []string{
 			validation.GraftTruncationDisabledWarning,
@@ -1701,6 +1705,8 @@ func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) 
 // TestControlMessageValidationInspector_InspectionConfigToggle ensures that rpc's are not inspected when inspection is disabled through configs.
 func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) {
 	t.Run("should not perform inspection when disabled is set to true", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		logCounter := atomic.NewInt64(0)
 		logger := hookedLogger(logCounter, zerolog.TraceLevel, validation.RPCInspectionDisabledWarning)
@@ -1735,6 +1741,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not check identity when reject-unstaked-peers is false", func(t *testing.T) {
+		t.Parallel()
+
 		inspector, signalerCtx, cancel, consumer, rpcTracker, _, idProvider, _ := inspectorFixture(t, func(params *validation.InspectorParams) {
 			// disable inspector for all control message types
 			params.Config.InspectionProcess.Inspect.RejectUnstakedPeers = false
@@ -1758,6 +1766,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should check identity when reject-unstaked-peers is true", func(t *testing.T) {
+		t.Parallel()
+
 		inspector, signalerCtx, cancel, consumer, rpcTracker, _, idProvider, _ := inspectorFixture(t, func(params *validation.InspectorParams) {
 			// disable inspector for all control message types
 			params.Config.InspectionProcess.Inspect.RejectUnstakedPeers = true
@@ -1785,6 +1795,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not perform inspection when disabled for each individual control message type directly", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		expectedLogStrs := []string{
 			validation.GraftInspectionDisabledWarning,

--- a/network/p2p/inspector/validation/control_message_validation_inspector_test.go
+++ b/network/p2p/inspector/validation/control_message_validation_inspector_test.go
@@ -1595,6 +1595,8 @@ func TestControlMessageValidationInspector_ActiveClustersChanged(t *testing.T) {
 // TestControlMessageValidationInspector_TruncationConfigToggle ensures that rpc's are not truncated when truncation is disabled through configs.
 func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) {
 	t.Run("should not perform truncation when disabled is set to true", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		logCounter := atomic.NewInt64(0)
 		logger := hookedLogger(logCounter, zerolog.TraceLevel, validation.RPCTruncationDisabledWarning, worker.QueuedItemProcessedLog)
@@ -1639,6 +1641,8 @@ func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not perform truncation when disabled for each individual control message type directly", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		expectedLogStrs := []string{
 			validation.GraftTruncationDisabledWarning,
@@ -1700,6 +1704,8 @@ func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) 
 // TestControlMessageValidationInspector_InspectionConfigToggle ensures that rpc's are not inspected when inspection is disabled through configs.
 func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) {
 	t.Run("should not perform inspection when disabled is set to true", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		logCounter := atomic.NewInt64(0)
 		logger := hookedLogger(logCounter, zerolog.TraceLevel, validation.RPCInspectionDisabledWarning)
@@ -1734,6 +1740,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not check identity when reject-unstaked-peers is false", func(t *testing.T) {
+		t.Parallel()
+
 		inspector, signalerCtx, cancel, consumer, rpcTracker, _, idProvider, _ := inspectorFixture(t, func(params *validation.InspectorParams) {
 			// disable inspector for all control message types
 			params.Config.InspectionProcess.Inspect.RejectUnstakedPeers = false
@@ -1757,6 +1765,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should check identity when reject-unstaked-peers is true", func(t *testing.T) {
+		t.Parallel()
+
 		inspector, signalerCtx, cancel, consumer, rpcTracker, _, idProvider, _ := inspectorFixture(t, func(params *validation.InspectorParams) {
 			// disable inspector for all control message types
 			params.Config.InspectionProcess.Inspect.RejectUnstakedPeers = true
@@ -1784,6 +1794,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not perform inspection when disabled for each individual control message type directly", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		expectedLogStrs := []string{
 			validation.GraftInspectionDisabledWarning,

--- a/network/p2p/scoring/app_score_test.go
+++ b/network/p2p/scoring/app_score_test.go
@@ -29,6 +29,8 @@ import (
 // pushing access nodes to the edges of the network (i.e., the access nodes are not in the mesh of any honest nodes)
 // will not cause the network to partition, i.e., all honest nodes can still communicate with each other through GossipSub.
 func TestFullGossipSubConnectivity(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)
 	sporkId := unittest.IdentifierFixture()
@@ -121,6 +123,8 @@ func TestFullGossipSubConnectivity(t *testing.T) {
 // when the network topology is a complete graph (i.e., full topology) and a malicious majority of access nodes are present.
 // The honest nodes (i.e., non-Access nodes) are enabled with peer scoring, then the honest nodes are enabled with peer scoring.
 func TestFullGossipSubConnectivityAmongHonestNodesWithMaliciousMajority(t *testing.T) {
+	t.Parallel()
+
 	// Note: if this test is ever flaky, this means a bug in our scoring system. Please escalate to the team instead of skipping.
 	ctx, cancel := context.WithCancel(context.Background())
 	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)

--- a/network/p2p/scoring/registry_test.go
+++ b/network/p2p/scoring/registry_test.go
@@ -38,6 +38,8 @@ import (
 // for its GossipSub app specific score. The "eventually" comes from the fact that the app specific score is updated asynchronously in the cache, and the cache is
 // updated when the app specific score function is called by GossipSub.
 func TestScoreRegistry_FreshStart(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -97,6 +99,8 @@ func TestScoreRegistry_FreshStart(t *testing.T) {
 // a staked peer would otherwise receive, leaving only the penalty as the app-specific score. This testing reflects the
 // asynchronous nature of app-specific score updates in GossipSub's cache.
 func TestScoreRegistry_PeerWithSpamRecord(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistryPeerWithSpamRecord(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -206,6 +210,8 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 // message types, including graft, prune, ihave, iwant, and RpcPublishMessage. Each sub-test validates the app-specific
 // penalty computation and updates to the score registry when a peer with an unknown identity sends these control messages.
 func TestScoreRegistry_SpamRecordWithUnknownIdentity(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithUnknownIdentity(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -315,6 +321,8 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 // validate the appropriate application of penalties in the ScoreRegistry when a peer with an invalid subscription is involved
 // in spam activities, as indicated by these control messages.
 func TestScoreRegistry_SpamRecordWithSubscriptionPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithSubscriptionPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -421,6 +429,8 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 // a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithDuplicateMessagesPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -532,19 +542,31 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 // It encompasses a series of sub-tests, each focusing on a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithoutDuplicateMessagesPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
 	t.Run("prune", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgPrune, penaltyValueFixtures().PruneMisbehaviour)
 	})
 	t.Run("ihave", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgIHave, penaltyValueFixtures().IHaveMisbehaviour)
 	})
 	t.Run("iwant", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgIWant, penaltyValueFixtures().IWantMisbehaviour)
 	})
 	t.Run("RpcPublishMessage", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.RpcPublishMessage, penaltyValueFixtures().PublishMisbehaviour)
 	})
 }
@@ -651,6 +673,8 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 
 // TestSpamPenaltyDecaysInCache tests that the spam penalty records decay over time in the cache.
 func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
@@ -734,6 +758,8 @@ func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
 // TestSpamPenaltyDecayToZero tests that the spam penalty decays to zero over time, and when the spam penalty of
 // a peer is set back to zero, its app specific penalty is also reset to the initial state.
 func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
@@ -801,6 +827,8 @@ func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
 // TestPersistingUnknownIdentityPenalty tests that even though the spam penalty is decayed to zero, the unknown identity penalty
 // is persisted. This is because the unknown identity penalty is not decayed.
 func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -878,6 +906,8 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 // TestPersistingInvalidSubscriptionPenalty tests that even though the spam penalty is decayed to zero, the invalid subscription penalty
 // is persisted. This is because the invalid subscription penalty is not decayed.
 func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -950,6 +980,8 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 // TestScoreRegistry_TestSpamRecordDecayAdjustment ensures that spam record decay is increased each time a peers score reaches the scoring.IncreaseDecayThreshold eventually
 // sustained misbehavior will result in the spam record decay reaching the minimum decay speed .99, and the decay speed is reset to the max decay speed .8.
 func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
+	t.Parallel()
+
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
 	// refresh cached app-specific score every 100 milliseconds to speed up the test.
@@ -1068,6 +1100,8 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 // the application-specific penalty should be reduced by the default reduction factor. This test verifies the accurate computation
 // of the application-specific score under these conditions.
 func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
+	t.Parallel()
+
 	ctlMsgTypes := p2pmsg.ControlMessageTypes()
 	peerIds := unittest.PeerIdFixtures(t, len(ctlMsgTypes))
 
@@ -1166,6 +1200,8 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 // TestScoringRegistrySilencePeriod ensures that the scoring registry does not penalize nodes during the silence period, and
 // starts to penalize nodes only after the silence period is over.
 func TestScoringRegistrySilencePeriod(t *testing.T) {
+	t.Parallel()
+
 	unittest.SkipUnless(t, unittest.TEST_FLAKY, "flakey tests")
 	peerID := unittest.PeerIdFixture(t)
 	silenceDuration := 5 * time.Second

--- a/network/p2p/scoring/registry_test.go
+++ b/network/p2p/scoring/registry_test.go
@@ -76,7 +76,7 @@ func TestScoreRegistry_FreshStart(t *testing.T) {
 		// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 		// is the default reward for a staked peer that has valid subscriptions.
 		return score == maxAppSpecificReward
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// still the spamRecords should not have the peer id (as there is no spam record for the peer id).
 	require.False(t, spamRecords.Has(peerID))
@@ -166,7 +166,7 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 		// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 		// is the default reward for a staked peer that has valid subscriptions.
 		return scoreOptParameters.MaxAppSpecificReward == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -192,7 +192,7 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 		// and the peer should be deprived of the default reward for its valid staked role.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -210,7 +210,9 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 // message types, including graft, prune, ihave, iwant, and RpcPublishMessage. Each sub-test validates the app-specific
 // penalty computation and updates to the score registry when a peer with an unknown identity sends these control messages.
 func TestScoreRegistry_SpamRecordWithUnknownIdentity(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithUnknownIdentity(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -273,7 +275,7 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// peer does not have spam record, but has an unknown identity. Hence, the app specific score should be the staking penalty.
 		return scoreOptParameters.UnknownIdentityPenalty == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// queryTime := time.Now()
 	// report a misbehavior for the peer id.
@@ -300,7 +302,7 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 		// and the staking penalty.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+scoreOptParameters.UnknownIdentityPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -321,7 +323,9 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 // validate the appropriate application of penalties in the ScoreRegistry when a peer with an invalid subscription is involved
 // in spam activities, as indicated by these control messages.
 func TestScoreRegistry_SpamRecordWithSubscriptionPenalty(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithSubscriptionPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -385,7 +389,7 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// peer does not have spam record, but has an invalid subscription penalty.
 		return scoreOptParameters.InvalidSubscriptionPenalty == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -411,7 +415,7 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 		// and the staking penalty.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+scoreOptParameters.InvalidSubscriptionPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -429,7 +433,9 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 // a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithDuplicateMessagesPenalty(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -500,7 +506,7 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// since the peer id does no other penalties the score is eventually expected to be the expected penalty for 10000 duplicate messages
 		return score == expectedDuplicateMessagesPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -524,7 +530,7 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 		// eventually, the app specific score should be updated in the cache.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+expectedDuplicateMessagesPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -653,12 +659,12 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 		require.Equal(t, scoring.InitAppScoreRecordStateFunc(maximumSpamPenaltyDecayFactor)().Decay, record.Decay) // decay should be initialized to the initial state.
 
 		return true
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 	// eventually, the app specific score should be updated in the cache.
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return unittest.AreNumericallyClose(expectedPenalty, score, 0.2)
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -673,7 +679,8 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 
 // TestSpamPenaltyDecaysInCache tests that the spam penalty records decay over time in the cache.
 func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
-	t.Parallel()
+	// not parallel: the decay assertion uses a two-sided time window that overshoots
+	// if the test is delayed by contention (score decays past the lower bound).
 
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
@@ -748,7 +755,7 @@ func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// with decay, the penalty should be between the upper and lower bounds.
 		return score > scoreUpperBound && score < scoreLowerBound
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// stop the registry.
 	cancel()
@@ -800,18 +807,18 @@ func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// the penalty should be less than zero and greater than the penalty value (due to decay).
 		return score < 0 && score > penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should reset back to default staking reward.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.StakedIdentityReward
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the penalty should now be zero.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -861,7 +868,7 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return score == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -879,18 +886,18 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 		// due to exponential decay of the spam penalty and asynchronous update the app specific score; score should be in the range of [scoring.
 		// (scoring.DefaultUnknownIdentityPenalty+penaltyValueFixtures().GraftMisbehaviour, scoring.DefaultUnknownIdentityPenalty).
 		return score < scoreOptParameters.UnknownIdentityPenalty && score > scoreOptParameters.UnknownIdentityPenalty+penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the unknown identity penalty.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the spam penalty should now be zero in spamRecords.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -938,7 +945,7 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return score == scoreOptParameters.InvalidSubscriptionPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -953,18 +960,18 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 		// due to exponential decay of the spam penalty and asynchronous update the app specific score; score should be in the range of [scoring.
 		// (DefaultInvalidSubscriptionPenalty+penaltyValueFixtures().GraftMisbehaviour, scoring.DefaultInvalidSubscriptionPenalty).
 		return score < scoreOptParameters.InvalidSubscriptionPenalty && score > scoreOptParameters.InvalidSubscriptionPenalty+penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the default invalid subscription penalty.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the spam penalty should now be zero in spamRecords.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -1014,7 +1021,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the unknown identity penalty.
 		return scoreOptParameters.MaxAppSpecificReward == reg.AppSpecificScoreFunc()(peer1) && scoreOptParameters.MaxAppSpecificReward == reg.AppSpecificScoreFunc()(peer2)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// simulate sustained malicious activity from peer1, eventually the decay speed
 	// for a spam record should be reduced to the MinimumSpamPenaltyDecayFactor
@@ -1038,7 +1045,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 		}
 		prevDecay = record.Decay
 		return record.Decay == scoringRegistryParameters.SpamRecordCache.Decay.MinimumSpamPenaltyDecayFactor
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 15*time.Second, 500*time.Millisecond)
 
 	// initialize a spam record for peer2
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -1051,7 +1058,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 		_, err, ok := spamRecords.Get(peer2)
 		require.NoError(t, err)
 		return ok
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// reduce penalty and increase Decay to scoring.MinimumSpamPenaltyDecayFactor
 	record, err := spamRecords.Adjust(peer2, func(record p2p.GossipSubSpamRecord) p2p.GossipSubSpamRecord {
@@ -1088,7 +1095,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 			return false
 		}
 		return record.Decay == scoringRegistryParameters.SpamRecordCache.Decay.MinimumSpamPenaltyDecayFactor
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 15*time.Second, 500*time.Millisecond)
 
 	// stop the registry.
 	cancel()
@@ -1135,7 +1142,7 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 			// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 			// is the default reward for a staked peer that has valid subscriptions.
 			return score == scoreOptParameters.MaxAppSpecificReward
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 15*time.Second, 100*time.Millisecond)
 
 	}
 
@@ -1179,7 +1186,7 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 			}
 			require.Equal(t, scoring.InitAppScoreRecordStateFunc(maximumSpamPenaltyDecayFactor)().Decay, record.Decay) // decay should be initialized to the initial state.
 			return true
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 15*time.Second, 100*time.Millisecond)
 
 		// this peer has a spam record, with no subscription penalty. Hence, the app specific score should only be the spam penalty,
 		// and the peer should be deprived of the default reward for its valid staked role.

--- a/network/p2p/scoring/registry_test.go
+++ b/network/p2p/scoring/registry_test.go
@@ -75,7 +75,7 @@ func TestScoreRegistry_FreshStart(t *testing.T) {
 		// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 		// is the default reward for a staked peer that has valid subscriptions.
 		return score == maxAppSpecificReward
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// still the spamRecords should not have the peer id (as there is no spam record for the peer id).
 	require.False(t, spamRecords.Has(peerID))
@@ -165,7 +165,7 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 		// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 		// is the default reward for a staked peer that has valid subscriptions.
 		return scoreOptParameters.MaxAppSpecificReward == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -191,7 +191,7 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 		// and the peer should be deprived of the default reward for its valid staked role.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -209,7 +209,9 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 // message types, including graft, prune, ihave, iwant, and RpcPublishMessage. Each sub-test validates the app-specific
 // penalty computation and updates to the score registry when a peer with an unknown identity sends these control messages.
 func TestScoreRegistry_SpamRecordWithUnknownIdentity(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithUnknownIdentity(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -272,7 +274,7 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// peer does not have spam record, but has an unknown identity. Hence, the app specific score should be the staking penalty.
 		return scoreOptParameters.UnknownIdentityPenalty == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// queryTime := time.Now()
 	// report a misbehavior for the peer id.
@@ -299,7 +301,7 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 		// and the staking penalty.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+scoreOptParameters.UnknownIdentityPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -320,7 +322,9 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 // validate the appropriate application of penalties in the ScoreRegistry when a peer with an invalid subscription is involved
 // in spam activities, as indicated by these control messages.
 func TestScoreRegistry_SpamRecordWithSubscriptionPenalty(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithSubscriptionPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -384,7 +388,7 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// peer does not have spam record, but has an invalid subscription penalty.
 		return scoreOptParameters.InvalidSubscriptionPenalty == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -410,7 +414,7 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 		// and the staking penalty.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+scoreOptParameters.InvalidSubscriptionPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -428,7 +432,9 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 // a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithDuplicateMessagesPenalty(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -499,7 +505,7 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// since the peer id does no other penalties the score is eventually expected to be the expected penalty for 10000 duplicate messages
 		return score == expectedDuplicateMessagesPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -523,7 +529,7 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 		// eventually, the app specific score should be updated in the cache.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+expectedDuplicateMessagesPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -652,12 +658,12 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 		require.Equal(t, scoring.InitAppScoreRecordStateFunc(maximumSpamPenaltyDecayFactor)().Decay, record.Decay) // decay should be initialized to the initial state.
 
 		return true
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 	// eventually, the app specific score should be updated in the cache.
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return unittest.AreNumericallyClose(expectedPenalty, score, 0.2)
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -672,7 +678,8 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 
 // TestSpamPenaltyDecaysInCache tests that the spam penalty records decay over time in the cache.
 func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
-	t.Parallel()
+	// not parallel: the decay assertion uses a two-sided time window that overshoots
+	// if the test is delayed by contention (score decays past the lower bound).
 
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
@@ -747,7 +754,7 @@ func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// with decay, the penalty should be between the upper and lower bounds.
 		return score > scoreUpperBound && score < scoreLowerBound
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// stop the registry.
 	cancel()
@@ -799,18 +806,18 @@ func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// the penalty should be less than zero and greater than the penalty value (due to decay).
 		return score < 0 && score > penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should reset back to default staking reward.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.StakedIdentityReward
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the penalty should now be zero.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -860,7 +867,7 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return score == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -878,18 +885,18 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 		// due to exponential decay of the spam penalty and asynchronous update the app specific score; score should be in the range of [scoring.
 		// (scoring.DefaultUnknownIdentityPenalty+penaltyValueFixtures().GraftMisbehaviour, scoring.DefaultUnknownIdentityPenalty).
 		return score < scoreOptParameters.UnknownIdentityPenalty && score > scoreOptParameters.UnknownIdentityPenalty+penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the unknown identity penalty.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the spam penalty should now be zero in spamRecords.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -937,7 +944,7 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return score == scoreOptParameters.InvalidSubscriptionPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -952,18 +959,18 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 		// due to exponential decay of the spam penalty and asynchronous update the app specific score; score should be in the range of [scoring.
 		// (DefaultInvalidSubscriptionPenalty+penaltyValueFixtures().GraftMisbehaviour, scoring.DefaultInvalidSubscriptionPenalty).
 		return score < scoreOptParameters.InvalidSubscriptionPenalty && score > scoreOptParameters.InvalidSubscriptionPenalty+penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the default invalid subscription penalty.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the spam penalty should now be zero in spamRecords.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -1013,7 +1020,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the unknown identity penalty.
 		return scoreOptParameters.MaxAppSpecificReward == reg.AppSpecificScoreFunc()(peer1) && scoreOptParameters.MaxAppSpecificReward == reg.AppSpecificScoreFunc()(peer2)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// simulate sustained malicious activity from peer1, eventually the decay speed
 	// for a spam record should be reduced to the MinimumSpamPenaltyDecayFactor
@@ -1037,7 +1044,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 		}
 		prevDecay = record.Decay
 		return record.Decay == scoringRegistryParameters.SpamRecordCache.Decay.MinimumSpamPenaltyDecayFactor
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 15*time.Second, 500*time.Millisecond)
 
 	// initialize a spam record for peer2
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -1050,7 +1057,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 		_, err, ok := spamRecords.Get(peer2)
 		require.NoError(t, err)
 		return ok
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// reduce penalty and increase Decay to scoring.MinimumSpamPenaltyDecayFactor
 	record, err := spamRecords.Adjust(peer2, func(record p2p.GossipSubSpamRecord) p2p.GossipSubSpamRecord {
@@ -1087,7 +1094,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 			return false
 		}
 		return record.Decay == scoringRegistryParameters.SpamRecordCache.Decay.MinimumSpamPenaltyDecayFactor
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 15*time.Second, 500*time.Millisecond)
 
 	// stop the registry.
 	cancel()
@@ -1134,7 +1141,7 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 			// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 			// is the default reward for a staked peer that has valid subscriptions.
 			return score == scoreOptParameters.MaxAppSpecificReward
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 15*time.Second, 100*time.Millisecond)
 
 	}
 
@@ -1178,7 +1185,7 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 			}
 			require.Equal(t, scoring.InitAppScoreRecordStateFunc(maximumSpamPenaltyDecayFactor)().Decay, record.Decay) // decay should be initialized to the initial state.
 			return true
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 15*time.Second, 100*time.Millisecond)
 
 		// this peer has a spam record, with no subscription penalty. Hence, the app specific score should only be the spam penalty,
 		// and the peer should be deprived of the default reward for its valid staked role.

--- a/network/p2p/scoring/registry_test.go
+++ b/network/p2p/scoring/registry_test.go
@@ -37,6 +37,8 @@ import (
 // for its GossipSub app specific score. The "eventually" comes from the fact that the app specific score is updated asynchronously in the cache, and the cache is
 // updated when the app specific score function is called by GossipSub.
 func TestScoreRegistry_FreshStart(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -96,6 +98,8 @@ func TestScoreRegistry_FreshStart(t *testing.T) {
 // a staked peer would otherwise receive, leaving only the penalty as the app-specific score. This testing reflects the
 // asynchronous nature of app-specific score updates in GossipSub's cache.
 func TestScoreRegistry_PeerWithSpamRecord(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistryPeerWithSpamRecord(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -205,6 +209,8 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 // message types, including graft, prune, ihave, iwant, and RpcPublishMessage. Each sub-test validates the app-specific
 // penalty computation and updates to the score registry when a peer with an unknown identity sends these control messages.
 func TestScoreRegistry_SpamRecordWithUnknownIdentity(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithUnknownIdentity(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -314,6 +320,8 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 // validate the appropriate application of penalties in the ScoreRegistry when a peer with an invalid subscription is involved
 // in spam activities, as indicated by these control messages.
 func TestScoreRegistry_SpamRecordWithSubscriptionPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithSubscriptionPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -420,6 +428,8 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 // a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithDuplicateMessagesPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -531,19 +541,31 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 // It encompasses a series of sub-tests, each focusing on a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithoutDuplicateMessagesPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
 	t.Run("prune", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgPrune, penaltyValueFixtures().PruneMisbehaviour)
 	})
 	t.Run("ihave", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgIHave, penaltyValueFixtures().IHaveMisbehaviour)
 	})
 	t.Run("iwant", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgIWant, penaltyValueFixtures().IWantMisbehaviour)
 	})
 	t.Run("RpcPublishMessage", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.RpcPublishMessage, penaltyValueFixtures().PublishMisbehaviour)
 	})
 }
@@ -650,6 +672,8 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 
 // TestSpamPenaltyDecaysInCache tests that the spam penalty records decay over time in the cache.
 func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
@@ -733,6 +757,8 @@ func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
 // TestSpamPenaltyDecayToZero tests that the spam penalty decays to zero over time, and when the spam penalty of
 // a peer is set back to zero, its app specific penalty is also reset to the initial state.
 func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
@@ -800,6 +826,8 @@ func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
 // TestPersistingUnknownIdentityPenalty tests that even though the spam penalty is decayed to zero, the unknown identity penalty
 // is persisted. This is because the unknown identity penalty is not decayed.
 func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -877,6 +905,8 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 // TestPersistingInvalidSubscriptionPenalty tests that even though the spam penalty is decayed to zero, the invalid subscription penalty
 // is persisted. This is because the invalid subscription penalty is not decayed.
 func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -949,6 +979,8 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 // TestScoreRegistry_TestSpamRecordDecayAdjustment ensures that spam record decay is increased each time a peers score reaches the scoring.IncreaseDecayThreshold eventually
 // sustained misbehavior will result in the spam record decay reaching the minimum decay speed .99, and the decay speed is reset to the max decay speed .8.
 func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
+	t.Parallel()
+
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
 	// refresh cached app-specific score every 100 milliseconds to speed up the test.
@@ -1067,6 +1099,8 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 // the application-specific penalty should be reduced by the default reduction factor. This test verifies the accurate computation
 // of the application-specific score under these conditions.
 func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
+	t.Parallel()
+
 	ctlMsgTypes := p2pmsg.ControlMessageTypes()
 	peerIds := unittest.PeerIdFixtures(t, len(ctlMsgTypes))
 
@@ -1165,6 +1199,8 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 // TestScoringRegistrySilencePeriod ensures that the scoring registry does not penalize nodes during the silence period, and
 // starts to penalize nodes only after the silence period is over.
 func TestScoringRegistrySilencePeriod(t *testing.T) {
+	t.Parallel()
+
 	unittest.SkipUnless(t, unittest.TEST_FLAKY, "flakey tests")
 	peerID := unittest.PeerIdFixture(t)
 	silenceDuration := 5 * time.Second

--- a/network/p2p/scoring/scoring_test.go
+++ b/network/p2p/scoring/scoring_test.go
@@ -36,6 +36,8 @@ import (
 // eventually disconnects from the spamming peer on the gossipsub layer, i.e., messages sent by the spamming peer are no longer
 // received by the node.
 func TestInvalidCtrlMsgScoringIntegration(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)
 	sporkId := unittest.IdentifierFixture()


### PR DESCRIPTION
Speeds up the full unit test suite (`make unittest-main`) from ~147s to ~84s median wall time on a 32-core machine, without weakening any assertion (statement coverage verified identical per package before/after).

- Makefile: schedule the slowest packages first when running the full suite (`SLOW_TEST_PACKAGES`, only applied for the default `./...` package set; CI per-job package subsets are unaffected). `go test` schedules packages alphabetically, so the long, internally-sequential packages previously started at ~t+60s and formed a straggler tail that dominated the wall time (147s -> 97s).
- Parallelize long-pole packages whose tests ran fully serially (zero `t.Parallel` anywhere): scoring registry unit tests and the 5 subtests of `TestScoreRegistry_SpamRecordWithoutDuplicateMessagesPenalty` (5 sequential 5s `require.Never` windows now overlap), inspector validation ConfigToggle subtests, ledger compactor tests. All verified to have per-test fixtures and no shared state.
- connection gater integration test: run the two pubsub silence directions concurrently on two distinct topics (identical 5s never-receive windows, fully isolated), and overlap the pubsub and unicast protocol exchanges (package 65s -> 53s).
- Compress pacing intervals where assertions are per-heartbeat/per-tick, preserving semantics: ALSP heartbeat and peer manager update interval 1s -> 100ms (RepeatOffender test 21s -> 2s), parallelize the 6 verification happy path subtests (30s -> 8s).
- scoring libp2p integration tests run in parallel (they use random ports and noop metrics).

Deliberately kept serial: 4 scoring registry/decay tests whose score assertions tolerate only ~5-10% deviation, which the continuous spam-penalty decay exceeds under parallel contention (found via `-race` stress; parallelism there made them permanently fail, not just slower).

Validation: `-race` stress runs on all affected packages and repeated 10x full-suite campaigns (10/10 clean).

Depends on: #8640

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788460683&installation_model_id=15376&pr_number=8641&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8641&signature=f8d70f94a2f5c9cde8398446c67a261ea97fdef7cffd4644663dd2867e581d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test-suite efficiency by enabling parallel execution across verification, ledger, networking, and scoring tests.
  - Strengthened peer communication checks to validate bidirectional silence and concurrent protocol behavior.
  - Reduced timing delays in selected networking tests while maintaining reliable asynchronous assertions.
  - Preserved longer timeouts where needed to support stable parallel test execution.
- **Chores**
  - Prioritized slow test packages when running the complete Go test suite, while preserving targeted package selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->