### PR TITLE
[Testing] Fix network test flakes exposed by slow-first scheduling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,19 @@ VERSION := $(shell git describe --tags --abbrev=2 --match "v*" --match "secure-c
 # dynamically split up CI jobs into smaller jobs that can be run in parallel
 GO_TEST_PACKAGES := ./...
 
+# The slowest test packages. `go test` schedules package test binaries in argument order
+# (alphabetical for ./...), so these long, internally-sequential packages would otherwise
+# start last and form a straggler tail that dominates the wall time of a full-suite run.
+# Listing them first lets them run while the remaining packages fill the other slots.
+# Only prepended when running the full suite (not for CI's per-job package subsets).
+# Overlapping package patterns are deduplicated by the go tool, so nothing runs twice.
+# First line: the slowest packages (the wall-time critical path).
+# Second line: second-tier packages (~20-35s each) that would otherwise start only
+# after the first wave of short packages drains and form a tail at the end of the run.
+SLOW_TEST_PACKAGES := ./network/p2p/scoring/... ./ledger/complete/... ./network/p2p/connection/... ./network/p2p/inspector/validation/... \
+	./consensus/integration/... ./cmd/util/ledger/util/... ./engine/verification/test/... ./network/alsp/... ./network/test/... \
+	./network/p2p/test/... ./network/p2p/node/... ./engine/verification/assigner/blockconsumer/... ./module/dkg/... ./engine/access/state_stream/backend/...
+
 # Image tag: if image tag is not set, set it with version (or short commit if empty)
 ifeq (${IMAGE_TAG},)
 IMAGE_TAG := ${VERSION}
@@ -70,7 +83,7 @@ update-cadence-version:
 .PHONY: unittest-main
 unittest-main:
 	# test all packages
-	CGO_CFLAGS=$(CRYPTO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(RACE_DETECTOR),-race,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(GO_TEST_PACKAGES)
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(RACE_DETECTOR),-race,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(if $(filter ./...,$(GO_TEST_PACKAGES)),$(SLOW_TEST_PACKAGES)) $(GO_TEST_PACKAGES)
 
 .PHONY: install-mock-generators
 install-mock-generators:

--- a/engine/access/rpc/connection/connection_test.go
+++ b/engine/access/rpc/connection/connection_test.go
@@ -839,24 +839,42 @@ func TestConcurrentConnections(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(requestCount)
 
+		// failures are collected and asserted on the main test goroutine: calling require inside
+		// these goroutines invokes FailNow, which panics in rapid and kills the whole package binary.
+		getClientErrs := make(chan error, requestCount)
+		pingErrCodes := make(chan codes.Code, requestCount)
+
 		for i := 0; i < requestCount; i++ {
 			go func() {
 				defer wg.Done()
 
 				client, _, err := connectionFactory.GetExecutionAPIClient(clientAddress)
-				require.NoError(tt, err)
+				if err != nil {
+					getClientErrs <- err
+					return
+				}
 
 				_, err = client.Ping(ctx, req)
-
 				if err != nil {
-					// Note: for some reason, when Unavailable is returned, the error message is
-					// changed to "the connection to 127.0.0.1:57753 was closed". Other error codes
-					// preserve the message.
-					require.Equalf(tt, codes.Unavailable, status.Code(err), "unexpected error: %v", err)
+					pingErrCodes <- status.Code(err)
 				}
 			}()
 		}
 		wg.Wait()
+		close(getClientErrs)
+		close(pingErrCodes)
+
+		for err := range getClientErrs {
+			require.NoError(tt, err)
+		}
+		for code := range pingErrCodes {
+			// Note: for some reason, when Unavailable is returned, the error message is
+			// changed to "the connection to 127.0.0.1:57753 was closed". Other error codes
+			// preserve the message.
+			// DeadlineExceeded is also allowed: under heavy load the 1s client timeout can
+			// fire before the request reaches the server.
+			require.Contains(tt, []codes.Code{codes.Unavailable, codes.DeadlineExceeded}, code, "unexpected error code")
+		}
 
 		// the grpc client seems to throttle requests to servers that return Unavailable, so not
 		// all of the requests make it through to the backend every test. Requiring that at least 1

--- a/engine/access/rpc/connection/connection_test.go
+++ b/engine/access/rpc/connection/connection_test.go
@@ -835,24 +835,42 @@ func TestConcurrentConnections(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(requestCount)
 
+		// failures are collected and asserted on the main test goroutine: calling require inside
+		// these goroutines invokes FailNow, which panics in rapid and kills the whole package binary.
+		getClientErrs := make(chan error, requestCount)
+		pingErrCodes := make(chan codes.Code, requestCount)
+
 		for range requestCount {
 			go func() {
 				defer wg.Done()
 
 				client, _, err := connectionFactory.GetExecutionAPIClient(clientAddress)
-				require.NoError(tt, err)
+				if err != nil {
+					getClientErrs <- err
+					return
+				}
 
 				_, err = client.Ping(ctx, req)
-
 				if err != nil {
-					// Note: for some reason, when Unavailable is returned, the error message is
-					// changed to "the connection to 127.0.0.1:57753 was closed". Other error codes
-					// preserve the message.
-					require.Equalf(tt, codes.Unavailable, status.Code(err), "unexpected error: %v", err)
+					pingErrCodes <- status.Code(err)
 				}
 			}()
 		}
 		wg.Wait()
+		close(getClientErrs)
+		close(pingErrCodes)
+
+		for err := range getClientErrs {
+			require.NoError(tt, err)
+		}
+		for code := range pingErrCodes {
+			// Note: for some reason, when Unavailable is returned, the error message is
+			// changed to "the connection to 127.0.0.1:57753 was closed". Other error codes
+			// preserve the message.
+			// DeadlineExceeded is also allowed: under heavy load the 1s client timeout can
+			// fire before the request reaches the server.
+			require.Contains(tt, []codes.Code{codes.Unavailable, codes.DeadlineExceeded}, code, "unexpected error code")
+		}
 
 		// the grpc client seems to throttle requests to servers that return Unavailable, so not
 		// all of the requests make it through to the backend every test. Requiring that at least 1

--- a/engine/verification/test/happypath_test.go
+++ b/engine/verification/test/happypath_test.go
@@ -121,6 +121,10 @@ func TestVerificationHappyPath(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.msg, func(t *testing.T) {
+			// each subtest builds its own full node fixture (own hub, networks, mocks,
+			// and FVM instance), so they are independent and can run in parallel.
+			t.Parallel()
+
 			collector := &metrics.NoopCollector{}
 
 			vertestutils.NewVerificationHappyPathTest(t,

--- a/ledger/complete/compactor_test.go
+++ b/ledger/complete/compactor_test.go
@@ -58,6 +58,8 @@ func (co *CompactorObserver) OnComplete() {
 // TestCompactorCreation tests creation of WAL segments and checkpoints, and
 // checks if the rebuilt ledger state matches previous ledger state.
 func TestCompactorCreation(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numInsPerStep      = 2
 		pathByteSize       = 32
@@ -287,6 +289,8 @@ func TestCompactorCreation(t *testing.T) {
 // TestCompactorSkipCheckpointing tests that only one
 // checkpointing is running at a time.
 func TestCompactorSkipCheckpointing(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numInsPerStep      = 2
 		pathByteSize       = 32
@@ -410,6 +414,8 @@ func TestCompactorSkipCheckpointing(t *testing.T) {
 // (from segment 0, ignoring prior checkpoints) to the checkpoint number.
 // This verifies that checkpointed tries are snapshopt of segments and at segment boundary.
 func TestCompactorAccuracy(t *testing.T) {
+	t.Parallel()
+
 
 	const (
 		numInsPerStep      = 2
@@ -526,6 +532,8 @@ func TestCompactorAccuracy(t *testing.T) {
 // TestCompactorTriggeredByAdminTool tests that the compactor will listen to the signal from admin tool
 // to trigger checkpoint when current segment file is finished.
 func TestCompactorTriggeredByAdminTool(t *testing.T) {
+	t.Parallel()
+
 
 	const (
 		numInsPerStep      = 2 // the number of payloads in each trie update
@@ -628,6 +636,8 @@ func TestCompactorTriggeredByAdminTool(t *testing.T) {
 // When initial state is from ledger's forest (LRU cache), its
 // sequence is altered by reads when replaying segment records.
 func TestCompactorConcurrency(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numInsPerStep      = 2
 		pathByteSize       = 32

--- a/ledger/complete/compactor_test.go
+++ b/ledger/complete/compactor_test.go
@@ -416,7 +416,6 @@ func TestCompactorSkipCheckpointing(t *testing.T) {
 func TestCompactorAccuracy(t *testing.T) {
 	t.Parallel()
 
-
 	const (
 		numInsPerStep      = 2
 		pathByteSize       = 32
@@ -533,7 +532,6 @@ func TestCompactorAccuracy(t *testing.T) {
 // to trigger checkpoint when current segment file is finished.
 func TestCompactorTriggeredByAdminTool(t *testing.T) {
 	t.Parallel()
-
 
 	const (
 		numInsPerStep      = 2 // the number of payloads in each trie update

--- a/ledger/complete/ledger_test.go
+++ b/ledger/complete/ledger_test.go
@@ -585,6 +585,8 @@ func Test_WAL(t *testing.T) {
 }
 
 func TestLedgerFunctionality(t *testing.T) {
+	t.Parallel()
+
 	const (
 		checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
 		checkpointsToKeep  = 1

--- a/network/alsp/manager/manager_test.go
+++ b/network/alsp/manager/manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/flow-go/network/internal/testutils"
 	mocknetwork "github.com/onflow/flow-go/network/mock"
 	"github.com/onflow/flow-go/network/p2p"
+	p2pbuilderconfig "github.com/onflow/flow-go/network/p2p/builder/config"
 	p2ptest "github.com/onflow/flow-go/network/p2p/test"
 	"github.com/onflow/flow-go/network/slashing"
 	"github.com/onflow/flow-go/network/underlay"
@@ -299,6 +300,10 @@ func TestHandleReportedMisbehavior_And_DisallowListing_Integration(t *testing.T)
 // handling of repeated reported misbehavior and disallow listing.
 func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integration(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// compress the heartbeat interval: all assertions in this test are per-heartbeat
+	// (decay deltas, disallow-listing rounds), so a faster heartbeat preserves semantics
+	// while cutting the wall time roughly proportionally.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	sporkId := unittest.IdentifierFixture()
 	fastDecay := false
 	fastDecayFunc := func(record *model.ProtocolSpamRecord) float64 {
@@ -327,7 +332,11 @@ func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integratio
 	}
 
 	ids, nodes := testutils.LibP2PNodeForNetworkFixture(t, sporkId, 3,
-		p2ptest.WithPeerManagerEnabled(p2ptest.PeerManagerConfigFixture(p2ptest.WithZeroJitterAndZeroBackoff(t)), nil))
+		p2ptest.WithPeerManagerEnabled(p2ptest.PeerManagerConfigFixture(p2ptest.WithZeroJitterAndZeroBackoff(t), func(cfg *p2pbuilderconfig.PeerManagerConfig) {
+			// compress the peer manager tick as well: pruning and reconnection waits are
+			// tick-quantized, and the test only cares about the sequence of events.
+			cfg.UpdateInterval = 100 * time.Millisecond
+		}), nil))
 	idProvider := unittest.NewUpdatableIDProvider(ids)
 	networkCfg := testutils.NetworkConfigFixture(t, *ids[0], idProvider, sporkId, nodes[0], underlay.WithAlspConfig(cfg))
 
@@ -417,7 +426,7 @@ func TestHandleReportedMisbehavior_And_DisallowListing_RepeatOffender_Integratio
 		penalty1 := record.Penalty
 
 		// wait for one heartbeat to be processed: poll for the first penalty change instead of
-		// sleeping exactly one heartbeat interval. A fixed 1s sleep races the 1s heartbeat ticker
+		// sleeping exactly one heartbeat interval. A fixed sleep races the heartbeat ticker
 		// (which can be delayed under load) and may span 0 or 2 decays; polling at 10ms granularity
 		// reliably catches the state after exactly one decay.
 		require.Eventually(t, func() bool {
@@ -1420,6 +1429,8 @@ func TestHandleMisbehaviorReport_DuplicateReportsForSinglePeer_Concurrently(t *t
 // is decayed after a single heartbeat. The test guarantees waiting for at least one heartbeat by waiting for the first decay to happen.
 func TestDecayMisbehaviorPenalty_SingleHeartbeat(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// decay assertions are per-heartbeat; a faster heartbeat preserves semantics.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	consumer := mocknetwork.NewDisallowListNotificationConsumer(t)
 
 	var cache alsp.SpamRecordCache
@@ -1523,6 +1534,8 @@ func TestDecayMisbehaviorPenalty_SingleHeartbeat(t *testing.T) {
 // The test ensures that the misbehavior penalty is decayed with a linear progression within multiple heartbeats.
 func TestDecayMisbehaviorPenalty_MultipleHeartbeats(t *testing.T) {
 	cfg := managerCfgFixture(t)
+	// decay assertions are per-heartbeat; a faster heartbeat preserves semantics.
+	cfg.HeartBeatInterval = 100 * time.Millisecond
 	consumer := mocknetwork.NewDisallowListNotificationConsumer(t)
 
 	var cache alsp.SpamRecordCache

--- a/network/p2p/connection/connection_gater_test.go
+++ b/network/p2p/connection/connection_gater_test.go
@@ -3,6 +3,7 @@ package connection_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -421,19 +422,26 @@ func ensureCommunicationSilenceAmongGroups(
 	// ensures no connection, unicast, or pubsub going to the disallow-listed nodes
 	p2ptest.EnsureNotConnectedBetweenGroups(t, ctx, groupANodes, groupBNodes)
 
+	// check both pubsub directions (A->B and B->A) concurrently on two distinct topics.
+	// Each direction is self-paced (1s subscription propagation + 5s never-receive window);
+	// checking them sequentially doubles that cost, while distinct topics keep the checks
+	// fully isolated from each other. Identical per-direction windows and assertions.
 	blockTopic := channels.TopicFromChannel(channels.PushBlocks, sporkId)
-	p2ptest.EnsureNoPubsubExchangeBetweenGroups(
-		t,
-		ctx,
-		groupANodes,
-		groupAIdentifiers,
-		groupBNodes,
-		groupBIdentifiers,
-		blockTopic,
-		1,
-		func() any {
-			return (*messages.Proposal)(unittest.ProposalFixture())
-		})
+	receiptTopic := channels.TopicFromChannel(channels.PushReceipts, sporkId)
+	messageFactory := func() any {
+		return (*messages.Proposal)(unittest.ProposalFixture())
+	}
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsureNoPubsubMessageExchange(t, ctx, groupANodes, groupBNodes, groupBIdentifiers, blockTopic, 1, messageFactory)
+	}()
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsureNoPubsubMessageExchange(t, ctx, groupBNodes, groupANodes, groupAIdentifiers, receiptTopic, 1, messageFactory)
+	}()
+	unittest.RequireReturnsBefore(t, wg.Wait, 12*time.Second, "timed out waiting for pubsub silence checks")
 	p2pfixtures.EnsureNoStreamCreationBetweenGroups(t, ctx, groupANodes, groupBNodes)
 }
 
@@ -441,8 +449,19 @@ func ensureCommunicationSilenceAmongGroups(
 func ensureCommunicationOverAllProtocols(t *testing.T, ctx context.Context, sporkId flow.Identifier, nodes []p2p.LibP2PNode, inbounds []chan string) {
 	blockTopic := channels.TopicFromChannel(channels.PushBlocks, sporkId)
 	p2ptest.TryConnectionAndEnsureConnected(t, ctx, nodes)
-	p2ptest.EnsurePubsubMessageExchange(t, ctx, nodes, blockTopic, 1, func() any {
-		return (*messages.Proposal)(unittest.ProposalFixture())
-	})
-	p2pfixtures.EnsureMessageExchangeOverUnicast(t, ctx, nodes, inbounds, p2pfixtures.LongStringMessageFactoryFixture(t))
+	// the pubsub and unicast exchanges are independent of each other (different protocols);
+	// run them concurrently. Both return early on success.
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		p2ptest.EnsurePubsubMessageExchange(t, ctx, nodes, blockTopic, 1, func() any {
+			return (*messages.Proposal)(unittest.ProposalFixture())
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		p2pfixtures.EnsureMessageExchangeOverUnicast(t, ctx, nodes, inbounds, p2pfixtures.LongStringMessageFactoryFixture(t))
+	}()
+	unittest.RequireReturnsBefore(t, wg.Wait, 30*time.Second, "timed out waiting for protocol exchanges")
 }

--- a/network/p2p/connection/peerManager_test.go
+++ b/network/p2p/connection/peerManager_test.go
@@ -156,7 +156,9 @@ func (suite *PeerManagerTestSuite) TestPeriodicPeerUpdate() {
 	pm.Start(signalerCtx)
 	unittest.RequireCloseBefore(suite.T(), pm.Ready(), 2*time.Second, "could not start peer manager")
 
-	unittest.RequireReturnsBefore(suite.T(), wg.Wait, 2*peerUpdateInterval,
+	// liveness bound: 2 ticker cycles normally take ~20ms, but under full-suite load the
+	// ticker and the mock callback can be starved well beyond 2*peerUpdateInterval.
+	unittest.RequireReturnsBefore(suite.T(), wg.Wait, 2*time.Second,
 		"UpdatePeers is not running on UpdateIntervals")
 }
 
@@ -228,8 +230,18 @@ func (suite *PeerManagerTestSuite) TestConcurrentOnDemandPeerUpdate() {
 	// choose the periodic interval as a high value so that periodic runs don't interfere with this test
 	peerUpdateInterval := time.Hour
 
-	peerUpdater.On("UpdatePeers", mock.Anything, mock.Anything).Return(nil).
-		WaitUntil(connectPeerGate) // blocks call for connectPeerGate channel
+	// count UpdatePeers invocations under a mutex: reading testify's Mock.Calls field directly
+	// races with the manager's update loop calling the mock concurrently.
+	// The count is incremented before blocking on the gate (testify's WaitUntil would block
+	// before the Run callback executes, hiding the call start from the test).
+	mu := &sync.Mutex{}
+	updateCalls := 0
+	peerUpdater.On("UpdatePeers", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		mu.Lock()
+		updateCalls++
+		mu.Unlock()
+		<-connectPeerGate // block this call until the test releases it (WaitUntil semantics)
+	}).Return(nil)
 	pm := connection.NewPeerManager(suite.log, peerUpdateInterval, peerUpdater)
 	pm.SetPeersProvider(func() peer.IDSlice {
 		return pids
@@ -243,7 +255,9 @@ func (suite *PeerManagerTestSuite) TestConcurrentOnDemandPeerUpdate() {
 
 	// assert that the first update started
 	assert.Eventually(suite.T(), func() bool {
-		return len(peerUpdater.Calls) > 0 && peerUpdater.AssertNumberOfCalls(suite.T(), "UpdatePeers", 1)
+		mu.Lock()
+		defer mu.Unlock()
+		return updateCalls == 1
 	}, 3*time.Second, 100*time.Millisecond)
 
 	// makes 10 concurrent request for peer update
@@ -255,6 +269,8 @@ func (suite *PeerManagerTestSuite) TestConcurrentOnDemandPeerUpdate() {
 
 	// assert that only two calls to UpdatePeers were made (one by the periodic update and one by the on-demand update)
 	assert.Eventually(suite.T(), func() bool {
-		return len(peerUpdater.Calls) > 1 && peerUpdater.AssertNumberOfCalls(suite.T(), "UpdatePeers", 2)
+		mu.Lock()
+		defer mu.Unlock()
+		return updateCalls == 2
 	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/network/p2p/inspector/validation/control_message_validation_inspector_test.go
+++ b/network/p2p/inspector/validation/control_message_validation_inspector_test.go
@@ -1595,6 +1595,8 @@ func TestControlMessageValidationInspector_ActiveClustersChanged(t *testing.T) {
 // TestControlMessageValidationInspector_TruncationConfigToggle ensures that rpc's are not truncated when truncation is disabled through configs.
 func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) {
 	t.Run("should not perform truncation when disabled is set to true", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		logCounter := atomic.NewInt64(0)
 		logger := hookedLogger(logCounter, zerolog.TraceLevel, validation.RPCTruncationDisabledWarning, worker.QueuedItemProcessedLog)
@@ -1639,6 +1641,8 @@ func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not perform truncation when disabled for each individual control message type directly", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		expectedLogStrs := []string{
 			validation.GraftTruncationDisabledWarning,
@@ -1700,6 +1704,8 @@ func TestControlMessageValidationInspector_TruncationConfigToggle(t *testing.T) 
 // TestControlMessageValidationInspector_InspectionConfigToggle ensures that rpc's are not inspected when inspection is disabled through configs.
 func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) {
 	t.Run("should not perform inspection when disabled is set to true", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		logCounter := atomic.NewInt64(0)
 		logger := hookedLogger(logCounter, zerolog.TraceLevel, validation.RPCInspectionDisabledWarning)
@@ -1734,6 +1740,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not check identity when reject-unstaked-peers is false", func(t *testing.T) {
+		t.Parallel()
+
 		inspector, signalerCtx, cancel, consumer, rpcTracker, _, idProvider, _ := inspectorFixture(t, func(params *validation.InspectorParams) {
 			// disable inspector for all control message types
 			params.Config.InspectionProcess.Inspect.RejectUnstakedPeers = false
@@ -1757,6 +1765,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should check identity when reject-unstaked-peers is true", func(t *testing.T) {
+		t.Parallel()
+
 		inspector, signalerCtx, cancel, consumer, rpcTracker, _, idProvider, _ := inspectorFixture(t, func(params *validation.InspectorParams) {
 			// disable inspector for all control message types
 			params.Config.InspectionProcess.Inspect.RejectUnstakedPeers = true
@@ -1784,6 +1794,8 @@ func TestControlMessageValidationInspector_InspectionConfigToggle(t *testing.T) 
 	})
 
 	t.Run("should not perform inspection when disabled for each individual control message type directly", func(t *testing.T) {
+		t.Parallel()
+
 		numOfMsgs := 5000
 		expectedLogStrs := []string{
 			validation.GraftInspectionDisabledWarning,

--- a/network/p2p/scoring/app_score_test.go
+++ b/network/p2p/scoring/app_score_test.go
@@ -29,6 +29,8 @@ import (
 // pushing access nodes to the edges of the network (i.e., the access nodes are not in the mesh of any honest nodes)
 // will not cause the network to partition, i.e., all honest nodes can still communicate with each other through GossipSub.
 func TestFullGossipSubConnectivity(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)
 	sporkId := unittest.IdentifierFixture()
@@ -121,6 +123,8 @@ func TestFullGossipSubConnectivity(t *testing.T) {
 // when the network topology is a complete graph (i.e., full topology) and a malicious majority of access nodes are present.
 // The honest nodes (i.e., non-Access nodes) are enabled with peer scoring, then the honest nodes are enabled with peer scoring.
 func TestFullGossipSubConnectivityAmongHonestNodesWithMaliciousMajority(t *testing.T) {
+	t.Parallel()
+
 	// Note: if this test is ever flaky, this means a bug in our scoring system. Please escalate to the team instead of skipping.
 	ctx, cancel := context.WithCancel(context.Background())
 	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)

--- a/network/p2p/scoring/registry_test.go
+++ b/network/p2p/scoring/registry_test.go
@@ -38,6 +38,8 @@ import (
 // for its GossipSub app specific score. The "eventually" comes from the fact that the app specific score is updated asynchronously in the cache, and the cache is
 // updated when the app specific score function is called by GossipSub.
 func TestScoreRegistry_FreshStart(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -97,6 +99,8 @@ func TestScoreRegistry_FreshStart(t *testing.T) {
 // a staked peer would otherwise receive, leaving only the penalty as the app-specific score. This testing reflects the
 // asynchronous nature of app-specific score updates in GossipSub's cache.
 func TestScoreRegistry_PeerWithSpamRecord(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistryPeerWithSpamRecord(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -206,6 +210,8 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 // message types, including graft, prune, ihave, iwant, and RpcPublishMessage. Each sub-test validates the app-specific
 // penalty computation and updates to the score registry when a peer with an unknown identity sends these control messages.
 func TestScoreRegistry_SpamRecordWithUnknownIdentity(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithUnknownIdentity(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -315,6 +321,8 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 // validate the appropriate application of penalties in the ScoreRegistry when a peer with an invalid subscription is involved
 // in spam activities, as indicated by these control messages.
 func TestScoreRegistry_SpamRecordWithSubscriptionPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithSubscriptionPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -421,6 +429,8 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 // a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithDuplicateMessagesPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
@@ -532,19 +542,31 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 // It encompasses a series of sub-tests, each focusing on a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithoutDuplicateMessagesPenalty(t *testing.T) {
+	t.Parallel()
+
 	t.Run("graft", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
 	})
 	t.Run("prune", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgPrune, penaltyValueFixtures().PruneMisbehaviour)
 	})
 	t.Run("ihave", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgIHave, penaltyValueFixtures().IHaveMisbehaviour)
 	})
 	t.Run("iwant", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgIWant, penaltyValueFixtures().IWantMisbehaviour)
 	})
 	t.Run("RpcPublishMessage", func(t *testing.T) {
+		t.Parallel()
+
 		testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t, p2pmsg.RpcPublishMessage, penaltyValueFixtures().PublishMisbehaviour)
 	})
 }
@@ -651,6 +673,8 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 
 // TestSpamPenaltyDecaysInCache tests that the spam penalty records decay over time in the cache.
 func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
@@ -734,6 +758,8 @@ func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
 // TestSpamPenaltyDecayToZero tests that the spam penalty decays to zero over time, and when the spam penalty of
 // a peer is set back to zero, its app specific penalty is also reset to the initial state.
 func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
@@ -801,6 +827,8 @@ func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
 // TestPersistingUnknownIdentityPenalty tests that even though the spam penalty is decayed to zero, the unknown identity penalty
 // is persisted. This is because the unknown identity penalty is not decayed.
 func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -878,6 +906,8 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 // TestPersistingInvalidSubscriptionPenalty tests that even though the spam penalty is decayed to zero, the invalid subscription penalty
 // is persisted. This is because the invalid subscription penalty is not decayed.
 func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
+	t.Parallel()
+
 	peerID := peer.ID("peer-1")
 
 	cfg, err := config.DefaultConfig()
@@ -950,6 +980,8 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 // TestScoreRegistry_TestSpamRecordDecayAdjustment ensures that spam record decay is increased each time a peers score reaches the scoring.IncreaseDecayThreshold eventually
 // sustained misbehavior will result in the spam record decay reaching the minimum decay speed .99, and the decay speed is reset to the max decay speed .8.
 func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
+	t.Parallel()
+
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
 	// refresh cached app-specific score every 100 milliseconds to speed up the test.
@@ -1068,6 +1100,8 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 // the application-specific penalty should be reduced by the default reduction factor. This test verifies the accurate computation
 // of the application-specific score under these conditions.
 func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
+	t.Parallel()
+
 	ctlMsgTypes := p2pmsg.ControlMessageTypes()
 	peerIds := unittest.PeerIdFixtures(t, len(ctlMsgTypes))
 
@@ -1166,6 +1200,8 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 // TestScoringRegistrySilencePeriod ensures that the scoring registry does not penalize nodes during the silence period, and
 // starts to penalize nodes only after the silence period is over.
 func TestScoringRegistrySilencePeriod(t *testing.T) {
+	t.Parallel()
+
 	unittest.SkipUnless(t, unittest.TEST_FLAKY, "flakey tests")
 	peerID := unittest.PeerIdFixture(t)
 	silenceDuration := 5 * time.Second

--- a/network/p2p/scoring/registry_test.go
+++ b/network/p2p/scoring/registry_test.go
@@ -76,7 +76,7 @@ func TestScoreRegistry_FreshStart(t *testing.T) {
 		// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 		// is the default reward for a staked peer that has valid subscriptions.
 		return score == maxAppSpecificReward
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// still the spamRecords should not have the peer id (as there is no spam record for the peer id).
 	require.False(t, spamRecords.Has(peerID))
@@ -166,7 +166,7 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 		// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 		// is the default reward for a staked peer that has valid subscriptions.
 		return scoreOptParameters.MaxAppSpecificReward == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -192,7 +192,7 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 		// and the peer should be deprived of the default reward for its valid staked role.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -210,7 +210,9 @@ func testScoreRegistryPeerWithSpamRecord(t *testing.T, messageType p2pmsg.Contro
 // message types, including graft, prune, ihave, iwant, and RpcPublishMessage. Each sub-test validates the app-specific
 // penalty computation and updates to the score registry when a peer with an unknown identity sends these control messages.
 func TestScoreRegistry_SpamRecordWithUnknownIdentity(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithUnknownIdentity(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -273,7 +275,7 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// peer does not have spam record, but has an unknown identity. Hence, the app specific score should be the staking penalty.
 		return scoreOptParameters.UnknownIdentityPenalty == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// queryTime := time.Now()
 	// report a misbehavior for the peer id.
@@ -300,7 +302,7 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 		// and the staking penalty.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+scoreOptParameters.UnknownIdentityPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -321,7 +323,9 @@ func testScoreRegistrySpamRecordWithUnknownIdentity(t *testing.T, messageType p2
 // validate the appropriate application of penalties in the ScoreRegistry when a peer with an invalid subscription is involved
 // in spam activities, as indicated by these control messages.
 func TestScoreRegistry_SpamRecordWithSubscriptionPenalty(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithSubscriptionPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -385,7 +389,7 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// peer does not have spam record, but has an invalid subscription penalty.
 		return scoreOptParameters.InvalidSubscriptionPenalty == score
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -411,7 +415,7 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 		// and the staking penalty.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+scoreOptParameters.InvalidSubscriptionPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -429,7 +433,9 @@ func testScoreRegistrySpamRecordWithSubscriptionPenalty(t *testing.T, messageTyp
 // a different control message type: graft, prune, ihave, iwant, and RpcPublishMessage. These sub-tests are designed to
 // validate the appropriate application of penalties in the ScoreRegistry when a peer has sent duplicate messages.
 func TestScoreRegistry_SpamRecordWithDuplicateMessagesPenalty(t *testing.T) {
-	t.Parallel()
+	// not parallel: the score assertions tolerate only ~5-10% deviation, which the
+	// continuous spam-penalty decay exceeds once contention delays the async score
+	// refresh past the first decay evaluation period.
 
 	t.Run("graft", func(t *testing.T) {
 		testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t, p2pmsg.CtrlMsgGraft, penaltyValueFixtures().GraftMisbehaviour)
@@ -500,7 +506,7 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// since the peer id does no other penalties the score is eventually expected to be the expected penalty for 10000 duplicate messages
 		return score == expectedDuplicateMessagesPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -524,7 +530,7 @@ func testScoreRegistrySpamRecordWithDuplicateMessagesPenalty(t *testing.T, messa
 		// eventually, the app specific score should be updated in the cache.
 		// As the app specific score in the cache and spam penalty in the spamRecords are updated at different times, we account for 5% error.
 		return unittest.AreNumericallyClose(expectedPenalty+expectedDuplicateMessagesPenalty, reg.AppSpecificScoreFunc()(peerID), 0.05)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -653,12 +659,12 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 		require.Equal(t, scoring.InitAppScoreRecordStateFunc(maximumSpamPenaltyDecayFactor)().Decay, record.Decay) // decay should be initialized to the initial state.
 
 		return true
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 	// eventually, the app specific score should be updated in the cache.
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return unittest.AreNumericallyClose(expectedPenalty, score, 0.2)
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// the app specific score should now be updated in the cache.
 	score, updated, exists = appScoreCache.Get(peerID) // get the score from the cache.
@@ -673,7 +679,8 @@ func testScoreRegistrySpamRecordWithoutDuplicateMessagesPenalty(t *testing.T, me
 
 // TestSpamPenaltyDecaysInCache tests that the spam penalty records decay over time in the cache.
 func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
-	t.Parallel()
+	// not parallel: the decay assertion uses a two-sided time window that overshoots
+	// if the test is delayed by contention (score decays past the lower bound).
 
 	peerID := peer.ID("peer-1")
 	cfg, err := config.DefaultConfig()
@@ -748,7 +755,7 @@ func TestScoreRegistry_SpamPenaltyDecaysInCache(t *testing.T) {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// with decay, the penalty should be between the upper and lower bounds.
 		return score > scoreUpperBound && score < scoreLowerBound
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// stop the registry.
 	cancel()
@@ -800,18 +807,18 @@ func TestScoreRegistry_SpamPenaltyDecayToZero(t *testing.T) {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		// the penalty should be less than zero and greater than the penalty value (due to decay).
 		return score < 0 && score > penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should reset back to default staking reward.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.StakedIdentityReward
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the penalty should now be zero.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -861,7 +868,7 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return score == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -879,18 +886,18 @@ func TestScoreRegistry_PersistingUnknownIdentityPenalty(t *testing.T) {
 		// due to exponential decay of the spam penalty and asynchronous update the app specific score; score should be in the range of [scoring.
 		// (scoring.DefaultUnknownIdentityPenalty+penaltyValueFixtures().GraftMisbehaviour, scoring.DefaultUnknownIdentityPenalty).
 		return score < scoreOptParameters.UnknownIdentityPenalty && score > scoreOptParameters.UnknownIdentityPenalty+penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the unknown identity penalty.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the spam penalty should now be zero in spamRecords.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -938,7 +945,7 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 	require.Eventually(t, func() bool {
 		score := reg.AppSpecificScoreFunc()(peerID)
 		return score == scoreOptParameters.InvalidSubscriptionPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// report a misbehavior for the peer id.
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -953,18 +960,18 @@ func TestScoreRegistry_PersistingInvalidSubscriptionPenalty(t *testing.T) {
 		// due to exponential decay of the spam penalty and asynchronous update the app specific score; score should be in the range of [scoring.
 		// (DefaultInvalidSubscriptionPenalty+penaltyValueFixtures().GraftMisbehaviour, scoring.DefaultInvalidSubscriptionPenalty).
 		return score < scoreOptParameters.InvalidSubscriptionPenalty && score > scoreOptParameters.InvalidSubscriptionPenalty+penaltyValueFixtures().GraftMisbehaviour
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// the spam penalty should eventually decay to zero.
 		r, err, ok := spamRecords.Get(peerID)
 		return ok && err == nil && r.Penalty == 0.0
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the default invalid subscription penalty.
 		return reg.AppSpecificScoreFunc()(peerID) == scoreOptParameters.UnknownIdentityPenalty
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// the spam penalty should now be zero in spamRecords.
 	record, err, ok := spamRecords.Get(peerID) // get the record from the spamRecords.
@@ -1014,7 +1021,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 	require.Eventually(t, func() bool {
 		// when the spam penalty is decayed to zero, the app specific penalty of the node should only contain the unknown identity penalty.
 		return scoreOptParameters.MaxAppSpecificReward == reg.AppSpecificScoreFunc()(peer1) && scoreOptParameters.MaxAppSpecificReward == reg.AppSpecificScoreFunc()(peer2)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// simulate sustained malicious activity from peer1, eventually the decay speed
 	// for a spam record should be reduced to the MinimumSpamPenaltyDecayFactor
@@ -1038,7 +1045,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 		}
 		prevDecay = record.Decay
 		return record.Decay == scoringRegistryParameters.SpamRecordCache.Decay.MinimumSpamPenaltyDecayFactor
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 15*time.Second, 500*time.Millisecond)
 
 	// initialize a spam record for peer2
 	reg.OnInvalidControlMessageNotification(&p2p.InvCtrlMsgNotif{
@@ -1051,7 +1058,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 		_, err, ok := spamRecords.Get(peer2)
 		require.NoError(t, err)
 		return ok
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// reduce penalty and increase Decay to scoring.MinimumSpamPenaltyDecayFactor
 	record, err := spamRecords.Adjust(peer2, func(record p2p.GossipSubSpamRecord) p2p.GossipSubSpamRecord {
@@ -1088,7 +1095,7 @@ func TestScoreRegistry_TestSpamRecordDecayAdjustment(t *testing.T) {
 			return false
 		}
 		return record.Decay == scoringRegistryParameters.SpamRecordCache.Decay.MinimumSpamPenaltyDecayFactor
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 15*time.Second, 500*time.Millisecond)
 
 	// stop the registry.
 	cancel()
@@ -1135,7 +1142,7 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 			// since the peer id does not have a spam record, the app specific score should be the max app specific reward, which
 			// is the default reward for a staked peer that has valid subscriptions.
 			return score == scoreOptParameters.MaxAppSpecificReward
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 15*time.Second, 100*time.Millisecond)
 
 	}
 
@@ -1179,7 +1186,7 @@ func TestPeerSpamPenaltyClusterPrefixed(t *testing.T) {
 			}
 			require.Equal(t, scoring.InitAppScoreRecordStateFunc(maximumSpamPenaltyDecayFactor)().Decay, record.Decay) // decay should be initialized to the initial state.
 			return true
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 15*time.Second, 100*time.Millisecond)
 
 		// this peer has a spam record, with no subscription penalty. Hence, the app specific score should only be the spam penalty,
 		// and the peer should be deprived of the default reward for its valid staked role.

--- a/network/p2p/scoring/scoring_test.go
+++ b/network/p2p/scoring/scoring_test.go
@@ -36,6 +36,8 @@ import (
 // eventually disconnects from the spamming peer on the gossipsub layer, i.e., messages sent by the spamming peer are no longer
 // received by the node.
 func TestInvalidCtrlMsgScoringIntegration(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)
 	sporkId := unittest.IdentifierFixture()

--- a/network/p2p/test/sporking_test.go
+++ b/network/p2p/test/sporking_test.go
@@ -2,6 +2,7 @@ package p2ptest_test
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -40,6 +41,21 @@ import (
 
 // TestCrosstalkPreventionOnNetworkKeyChange tests that a node from the old chain cannot talk to a node in the new chain
 // if it's network key is updated while the libp2p protocol ID remains the same
+// requireAddressReleased waits until the given address can be bound again. The libp2p
+// component's Done signal does not guarantee the OS has released the listener socket yet,
+// so re-binding the same address immediately after stopping a node can race the socket
+// release and fail with "address already in use".
+func requireAddressReleased(t *testing.T, address string) {
+	require.Eventually(t, func() bool {
+		l, err := net.Listen("tcp4", address)
+		if err != nil {
+			return false
+		}
+		_ = l.Close()
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "address %s was not released in time", address)
+}
+
 func TestCrosstalkPreventionOnNetworkKeyChange(t *testing.T) {
 	idProvider := unittest.NewUpdatableIDProvider(flow.IdentityList{})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -98,6 +114,7 @@ func TestCrosstalkPreventionOnNetworkKeyChange(t *testing.T) {
 	// Simulate a hard-spoon: node1 is on the old chain, but node2 is moved from the old chain to the new chain
 	// stop node 2 and start it again with a different networking key but on the same IP and port
 	p2ptest.StopNode(t, node2, cancel2)
+	requireAddressReleased(t, id2.Address)
 
 	// start node2 with the same name, ip and port but with the new key
 	node2keyNew := p2pfixtures.NetworkingKeyFixtures(t)
@@ -167,6 +184,7 @@ func TestOneToOneCrosstalkPrevention(t *testing.T) {
 	// Simulate a hard-spoon: node1 is on the old chain, but node2 is moved from the old chain to the new chain
 	// stop node 2 and start it again with a different libp2p protocol id to listen for
 	p2ptest.StopNode(t, node2, cancel2)
+	requireAddressReleased(t, id2.Address)
 
 	// start node2 with the same address and root key but different root block id
 	node2, id2New := p2ptest.NodeFixture(t,

--- a/network/p2p/test/sporking_test.go
+++ b/network/p2p/test/sporking_test.go
@@ -2,6 +2,7 @@ package p2ptest_test
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -40,6 +41,21 @@ import (
 
 // TestCrosstalkPreventionOnNetworkKeyChange tests that a node from the old chain cannot talk to a node in the new chain
 // if it's network key is updated while the libp2p protocol ID remains the same
+// requireAddressReleased waits until the given address can be bound again. The libp2p
+// component's Done signal does not guarantee the OS has released the listener socket yet,
+// so re-binding the same address immediately after stopping a node can race the socket
+// release and fail with "address already in use".
+func requireAddressReleased(t *testing.T, address string) {
+	require.Eventually(t, func() bool {
+		l, err := net.Listen("tcp4", address)
+		if err != nil {
+			return false
+		}
+		_ = l.Close()
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "address %s was not released in time", address)
+}
+
 func TestCrosstalkPreventionOnNetworkKeyChange(t *testing.T) {
 	idProvider := unittest.NewUpdatableIDProvider(flow.IdentityList{})
 	ctx := t.Context()
@@ -97,6 +113,7 @@ func TestCrosstalkPreventionOnNetworkKeyChange(t *testing.T) {
 	// Simulate a hard-spoon: node1 is on the old chain, but node2 is moved from the old chain to the new chain
 	// stop node 2 and start it again with a different networking key but on the same IP and port
 	p2ptest.StopNode(t, node2, cancel2)
+	requireAddressReleased(t, id2.Address)
 
 	// start node2 with the same name, ip and port but with the new key
 	node2keyNew := p2pfixtures.NetworkingKeyFixtures(t)
@@ -165,6 +182,7 @@ func TestOneToOneCrosstalkPrevention(t *testing.T) {
 	// Simulate a hard-spoon: node1 is on the old chain, but node2 is moved from the old chain to the new chain
 	// stop node 2 and start it again with a different libp2p protocol id to listen for
 	p2ptest.StopNode(t, node2, cancel2)
+	requireAddressReleased(t, id2.Address)
 
 	// start node2 with the same address and root key but different root block id
 	node2, id2New := p2ptest.NodeFixture(t,

--- a/network/test/cohort1/network_test.go
+++ b/network/test/cohort1/network_test.go
@@ -534,7 +534,9 @@ func (suite *NetworkTestSuite) TestUnicastRateLimit_Bandwidth() {
 		Text: generate('C'),
 	}, newId.NodeID)
 	if err != nil {
-		require.Contains(suite.T(), err.Error(), "stream reset")
+		// depending on the send timing, the sender either observes a "stream reset" write error,
+		// or an EOF when closing the already-reset stream.
+		require.Regexp(suite.T(), "stream reset|EOF", err.Error())
 	}
 
 	// wait for all rate limits before shutting down network

--- a/network/test/cohort2/unicast_authorization_test.go
+++ b/network/test/cohort2/unicast_authorization_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -57,6 +58,17 @@ type UnicastAuthorizationTestSuite struct {
 	// waitCh is the channel used to wait for the networks to perform authorization and invoke the slashing
 	// violation's consumer before making mock assertions and cleaning up resources
 	waitCh chan struct{}
+	// waitChOnce makes signaling waitCh idempotent: violation reports and message deliveries are
+	// async and can legitimately arrive more than once (e.g. retried streams), and closing an
+	// already-closed channel would panic.
+	waitChOnce sync.Once
+}
+
+// signalExpectedViolation closes waitCh exactly once, no matter how many times it is called.
+func (u *UnicastAuthorizationTestSuite) signalExpectedViolation() {
+	u.waitChOnce.Do(func() {
+		close(u.waitCh)
+	})
 }
 
 // TestUnicastAuthorizationTestSuite runs all the test methods in this test suit
@@ -69,6 +81,7 @@ func (u *UnicastAuthorizationTestSuite) SetupTest() {
 	u.channelCloseDuration = 100 * time.Millisecond
 	// this ch will allow us to wait until the expected method call happens before shutting down networks.
 	u.waitCh = make(chan struct{})
+	u.waitChOnce = sync.Once{}
 }
 
 func (u *UnicastAuthorizationTestSuite) TearDownTest() {
@@ -147,8 +160,8 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnstakedPeer() 
 		Protocol: message.ProtocolTypeUnicast,
 		Err:      validator.ErrIdentityUnverified,
 	}
-	slashingViolationsConsumer.On("OnUnauthorizedSenderError", expectedViolation).Return(nil).Once().Run(func(args mockery.Arguments) {
-		close(u.waitCh)
+	slashingViolationsConsumer.On("OnUnauthorizedSenderError", expectedViolation).Return(nil).Run(func(args mockery.Arguments) {
+		u.signalExpectedViolation()
 	})
 
 	u.startNetworksAndLibp2pNodes()
@@ -199,8 +212,8 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_EjectedPeer() {
 		Err:      validator.ErrSenderEjected,
 	}
 	slashingViolationsConsumer.On("OnSenderEjectedError", expectedViolation).
-		Return(nil).Once().Run(func(args mockery.Arguments) {
-		close(u.waitCh)
+		Return(nil).Run(func(args mockery.Arguments) {
+		u.signalExpectedViolation()
 	})
 
 	u.startNetworksAndLibp2pNodes()
@@ -240,8 +253,8 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnauthorizedPee
 	}
 
 	slashingViolationsConsumer.On("OnUnauthorizedSenderError", expectedViolation).
-		Return(nil).Once().Run(func(args mockery.Arguments) {
-		close(u.waitCh)
+		Return(nil).Run(func(args mockery.Arguments) {
+		u.signalExpectedViolation()
 	})
 
 	u.startNetworksAndLibp2pNodes()
@@ -295,8 +308,8 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnknownMsgCode(
 	}
 
 	slashingViolationsConsumer.On("OnUnknownMsgTypeError", expectedViolation).
-		Return(nil).Once().Run(func(args mockery.Arguments) {
-		close(u.waitCh)
+		Return(nil).Run(func(args mockery.Arguments) {
+		u.signalExpectedViolation()
 	})
 
 	u.startNetworksAndLibp2pNodes()
@@ -343,8 +356,8 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_WrongMsgCode() 
 	}
 
 	slashingViolationsConsumer.On("OnUnauthorizedSenderError", expectedViolation).
-		Return(nil).Once().Run(func(args mockery.Arguments) {
-		close(u.waitCh)
+		Return(nil).Run(func(args mockery.Arguments) {
+		u.signalExpectedViolation()
 	})
 
 	u.startNetworksAndLibp2pNodes()
@@ -379,7 +392,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_PublicChannel()
 	receiverEngine := &mocknetwork.MessageProcessor{}
 	receiverEngine.On("Process", channels.PublicPushBlocks, u.senderID.NodeID, msg).Run(
 		func(args mockery.Arguments) {
-			close(u.waitCh)
+			u.signalExpectedViolation()
 		}).Return(nil).Once()
 	_, err := u.receiverNetwork.Register(channels.PublicPushBlocks, receiverEngine)
 	require.NoError(u.T(), err)
@@ -419,8 +432,8 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnauthorizedUni
 	}
 
 	slashingViolationsConsumer.On("OnUnauthorizedUnicastOnChannel", expectedViolation).
-		Return(nil).Once().Run(func(args mockery.Arguments) {
-		close(u.waitCh)
+		Return(nil).Run(func(args mockery.Arguments) {
+		u.signalExpectedViolation()
 	})
 
 	u.startNetworksAndLibp2pNodes()
@@ -460,8 +473,8 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_ReceiverHasNoSu
 	}
 
 	slashingViolationsConsumer.On("OnUnauthorizedUnicastOnChannel", expectedViolation).
-		Return(nil).Once().Run(func(args mockery.Arguments) {
-		close(u.waitCh)
+		Return(nil).Run(func(args mockery.Arguments) {
+		u.signalExpectedViolation()
 	})
 
 	u.startNetworksAndLibp2pNodes()
@@ -500,7 +513,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_ReceiverHasSubs
 	receiverEngine := &mocknetwork.MessageProcessor{}
 	receiverEngine.On("Process", channels.RequestReceiptsByBlockID, u.senderID.NodeID, internal).Run(
 		func(args mockery.Arguments) {
-			close(u.waitCh)
+			u.signalExpectedViolation()
 		}).Return(nil).Once()
 	_, err = u.receiverNetwork.Register(channels.RequestReceiptsByBlockID, receiverEngine)
 	require.NoError(u.T(), err)
@@ -576,8 +589,8 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnauthorizedSen
 	}
 
 	slashingViolationsConsumer.On("OnUnauthorizedUnicastOnChannel", expectedViolation).
-		Return(nil).Once().Run(func(args mockery.Arguments) {
-		close(u.waitCh)
+		Return(nil).Run(func(args mockery.Arguments) {
+		u.signalExpectedViolation()
 	})
 
 	u.startNetworksAndLibp2pNodes()


### PR DESCRIPTION
Fixes 6 flaky network tests (plus one pre-existing data race) found by a 200x full-suite campaign on the speedup stack (6/200 failures, all distinct, all network-stack). All are latent timing assumptions exposed by the heavier contention at the start of a slow-first-scheduled run; none are production bugs.

- `engine/access/rpc/connection` `TestConcurrentConnections` (rapid): assertions moved out of the request goroutines (a `require` failure there panics the whole package binary); error codes are collected and asserted on the main goroutine. `DeadlineExceeded` is now accepted alongside `Unavailable`: under load the 1s client timeout can fire before the request reaches the server.
- `network/test/cohort2` unicast authorization suite: violation-report expectations made unbounded (async violation reports can legitimately repeat on retried streams), and the suite's wait-channel close is now idempotent. Receiver `Process` expectations keep `.Once()`: duplicate delivery should still fail loudly.
- `network/test/cohort1` `TestUnicastRateLimit_Bandwidth`: the error assertion now matches `stream reset|EOF`; teardown timing selects which libp2p error form surfaces for a remotely reset stream.
- `network/p2p/test` crosstalk tests: wait for the stopped node's address to be released (probe-bind with Eventually) before re-creating a node on the same address; the component `Done` signal does not guarantee the OS released the listener socket.
- `network/p2p/connection` `TestPeriodicPeerUpdate`: the bound for two ticker-driven `UpdatePeers` calls was 2*10ms; now a 2s liveness bound that returns early on success.
- `network/p2p/connection` `TestConcurrentOnDemandPeerUpdate` (pre-existing `-race` failure): direct reads of testify's `Mock.Calls` raced the manager's update loop; calls are now counted under a mutex in the mock's `Run` callback (with the gate moved inside `Run`, since testify's `WaitUntil` blocks before `Run` executes).

Coverage: statement coverage verified identical before/after in all 5 packages. Assertion-strength review in the PR discussion: the only relaxations are the two documented cases above (DeadlineExceeded, duplicate identical violation reports), both reflecting legitimate behavior.

Validation: targeted stress runs (5x-50x, `-race` where relevant), all affected packages green, 20x full-suite campaign clean.

Depends on: #8641

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788526205&installation_model_id=15376&pr_number=8642&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8642&signature=1e4a8ebd9333201322b2dddd95a3a1912d1b36e98bca2e89be1db56e7057f0c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of connection and peer-management tests under concurrent and timing-sensitive conditions.
  - Added safeguards to ensure network listeners are fully released before reuse.
  - Updated bandwidth and connectivity tests to accommodate valid timing-dependent outcomes.
  - Hardened authorization and violation-handling tests against duplicate signals and race conditions.
  - Preserved existing request, response, invocation, and behavior validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->