### PR TITLE
Fix BLS host functions panicking on non-BLS public keys

### DIFF
--- a/fvm/crypto/crypto.go
+++ b/fvm/crypto/crypto.go
@@ -253,12 +253,26 @@ func VerifySignatureFromTransaction(
 }
 
 // VerifyPOP verifies a proof of possession (PoP) for the receiver public key; currently only works for BLS
+//
+// The function errors:
+//   - NewValueErrorf for any user error
+//   - panic for any other unexpected error
 func VerifyPOP(pk *runtime.PublicKey, s crypto.Signature) (bool, error) {
+
+	// a non-BLS runtime key is valid user input, so reject it with an error
+	if pk.SignAlgo != runtime.SignatureAlgorithmBLS_BLS12_381 {
+		return false, errors.NewValueErrorf(
+			fmt.Sprintf("%d", pk.SignAlgo),
+			"public key is not a BLS key")
+	}
 
 	key, err := crypto.DecodePublicKey(crypto.BLSBLS12381, pk.PublicKey)
 	if err != nil {
-		// at this stage, the runtime public key is valid and there are no possible user value errors
-		panic(fmt.Errorf("verify PoP failed: runtime BLS public key should be valid %x", pk.PublicKey))
+		// invalid BLS bytes are a user error
+		if crypto.IsInvalidInputsError(err) {
+			return false, errors.NewValueErrorf(hex.EncodeToString(pk.PublicKey), "cannot decode public key: %w", err)
+		}
+		panic(fmt.Errorf("decode public key failed with unexpected error %w", err))
 	}
 
 	valid, err := crypto.BLSVerifyPOP(key, s)
@@ -288,22 +302,36 @@ func AggregateSignatures(sigs [][]byte) (crypto.Signature, error) {
 }
 
 // AggregatePublicKeys aggregate multiple public keys into one; currently only works for BLS
+//
+// The function errors:
+//   - NewValueErrorf or a propagated crypto module error for any user error
+//   - panic for any other unexpected error
 func AggregatePublicKeys(keys []*runtime.PublicKey) (*runtime.PublicKey, error) {
 	pks := make([]crypto.PublicKey, 0, len(keys))
-	for _, key := range keys {
+	for i, key := range keys {
+		// a non-BLS runtime key is valid user input, so reject it with an error
+		if key.SignAlgo != runtime.SignatureAlgorithmBLS_BLS12_381 {
+			return nil, errors.NewValueErrorf(
+				fmt.Sprintf("%d", key.SignAlgo),
+				"public key at index %d is not a BLS key", i)
+		}
 		// TODO: avoid validating the public keys again since Cadence makes sure runtime keys have been validated.
 		// This requires exporting an unsafe function in the crypto package.
 		pk, err := crypto.DecodePublicKey(crypto.BLSBLS12381, key.PublicKey)
 		if err != nil {
-			// at this stage, the runtime public key is valid and there are no possible user value errors
-			panic(fmt.Errorf("aggregate BLS public keys failed: runtime public key should be valid %x", key.PublicKey))
+			// invalid BLS bytes are a user error
+			if crypto.IsInvalidInputsError(err) {
+				return nil, errors.NewValueErrorf(hex.EncodeToString(key.PublicKey), "cannot decode public key: %w", err)
+			}
+			panic(fmt.Errorf("decode public key failed with unexpected error %w", err))
 		}
 		pks = append(pks, pk)
 	}
 
 	pk, err := crypto.AggregateBLSPublicKeys(pks)
 	if err != nil {
-		// check for a user error
+		// check for user errors (errNotBLSKey is unreachable since all keys were
+		// decoded as BLS, but the function documents it, so check for it)
 		if crypto.IsBLSAggregateEmptyListError(err) || crypto.IsNotBLSKeyError(err) {
 			return nil, err
 		}

--- a/fvm/crypto/crypto.go
+++ b/fvm/crypto/crypto.go
@@ -268,7 +268,9 @@ func VerifyPOP(pk *runtime.PublicKey, s crypto.Signature) (bool, error) {
 
 	key, err := crypto.DecodePublicKey(crypto.BLSBLS12381, pk.PublicKey)
 	if err != nil {
-		// invalid BLS bytes are a user error
+		// invalid BLS bytes are a user error; any other decode error is
+		// unexpected and escalated, unlike VerifySignatureFromRuntime which
+		// treats all decode errors as user errors
 		if crypto.IsInvalidInputsError(err) {
 			return false, errors.NewValueErrorf(hex.EncodeToString(pk.PublicKey), "cannot decode public key: %w", err)
 		}
@@ -319,7 +321,9 @@ func AggregatePublicKeys(keys []*runtime.PublicKey) (*runtime.PublicKey, error) 
 		// This requires exporting an unsafe function in the crypto package.
 		pk, err := crypto.DecodePublicKey(crypto.BLSBLS12381, key.PublicKey)
 		if err != nil {
-			// invalid BLS bytes are a user error
+			// invalid BLS bytes are a user error; any other decode error is
+			// unexpected and escalated, unlike VerifySignatureFromRuntime which
+			// treats all decode errors as user errors
 			if crypto.IsInvalidInputsError(err) {
 				return nil, errors.NewValueErrorf(hex.EncodeToString(key.PublicKey), "cannot decode public key: %w", err)
 			}

--- a/fvm/crypto/crypto_test.go
+++ b/fvm/crypto/crypto_test.go
@@ -459,6 +459,131 @@ func TestAuthenticationSchemeConversion(t *testing.T) {
 	}
 }
 
+// TestBLSHostFunctionsOnNonBLSKey verifies that the BLS host functions return
+// user errors instead of panicking on valid non-BLS public keys: a Cadence
+// PublicKey built from e.g. a valid ECDSA key passes construction-time
+// validation and reaches these host functions ungated by the stdlib.
+func TestBLSHostFunctionsOnNonBLSKey(t *testing.T) {
+
+	seed := make([]byte, onflowCrypto.KeyGenSeedMinLen)
+	_, err := rand.Read(seed)
+	require.NoError(t, err)
+
+	nonBLSAlgorithms := []struct {
+		name     string
+		signAlgo onflowCrypto.SigningAlgorithm
+		rtAlgo   runtime.SignatureAlgorithm
+	}{
+		{"ECDSA_P256", onflowCrypto.ECDSAP256, runtime.SignatureAlgorithmECDSA_P256},
+		{"ECDSA_secp256k1", onflowCrypto.ECDSASecp256k1, runtime.SignatureAlgorithmECDSA_secp256k1},
+	}
+
+	newRuntimePublicKey := func(
+		t *testing.T,
+		signAlgo onflowCrypto.SigningAlgorithm,
+		rtAlgo runtime.SignatureAlgorithm,
+	) *runtime.PublicKey {
+		sk, err := onflowCrypto.GeneratePrivateKey(signAlgo, seed)
+		require.NoError(t, err)
+		return &runtime.PublicKey{
+			PublicKey: sk.PublicKey().Encode(),
+			SignAlgo:  rtAlgo,
+		}
+	}
+
+	t.Run("VerifyPOP", func(t *testing.T) {
+
+		t.Run("control: valid BLS key", func(t *testing.T) {
+			sk, err := onflowCrypto.GeneratePrivateKey(onflowCrypto.BLSBLS12381, seed)
+			require.NoError(t, err)
+			pop, err := onflowCrypto.BLSGeneratePOP(sk)
+			require.NoError(t, err)
+
+			valid, err := crypto.VerifyPOP(
+				&runtime.PublicKey{
+					PublicKey: sk.PublicKey().Encode(),
+					SignAlgo:  runtime.SignatureAlgorithmBLS_BLS12_381,
+				},
+				pop,
+			)
+			require.NoError(t, err)
+			require.True(t, valid)
+		})
+
+		for _, algo := range nonBLSAlgorithms {
+			t.Run("valid non-BLS key returns user error/"+algo.name, func(t *testing.T) {
+				pk := newRuntimePublicKey(t, algo.signAlgo, algo.rtAlgo)
+				sig := make([]byte, onflowCrypto.SignatureLenBLSBLS12381)
+
+				valid, err := crypto.VerifyPOP(pk, sig)
+				require.Error(t, err)
+				require.True(t, errors.IsValueError(err))
+				require.Contains(t, err.Error(), "public key is not a BLS key")
+				require.False(t, valid)
+			})
+		}
+	})
+
+	t.Run("AggregatePublicKeys", func(t *testing.T) {
+
+		t.Run("control: valid BLS keys", func(t *testing.T) {
+			keys := make([]*runtime.PublicKey, 0, 2)
+			for i := 0; i < 2; i++ {
+				sk, err := onflowCrypto.GeneratePrivateKey(onflowCrypto.BLSBLS12381, seed)
+				require.NoError(t, err)
+				keys = append(keys, &runtime.PublicKey{
+					PublicKey: sk.PublicKey().Encode(),
+					SignAlgo:  runtime.SignatureAlgorithmBLS_BLS12_381,
+				})
+			}
+
+			agg, err := crypto.AggregatePublicKeys(keys)
+			require.NoError(t, err)
+			require.NotNil(t, agg)
+		})
+
+		for _, algo := range nonBLSAlgorithms {
+			t.Run("valid non-BLS key returns user error/"+algo.name, func(t *testing.T) {
+				pk := newRuntimePublicKey(t, algo.signAlgo, algo.rtAlgo)
+
+				agg, err := crypto.AggregatePublicKeys([]*runtime.PublicKey{pk})
+				require.Error(t, err)
+				require.True(t, errors.IsValueError(err))
+				require.Contains(t, err.Error(), "not a BLS key")
+				require.Nil(t, agg)
+			})
+		}
+	})
+}
+
+// Errors returned by the BLS host functions propagate through Cadence and
+// must be valid UTF-8 and CBOR-encodable.
+func TestBLSHostFunctions_error_handling_produces_valid_utf8(t *testing.T) {
+
+	pk := &runtime.PublicKey{
+		PublicKey: []byte{0xc3, 0x28}, // some invalid UTF-8
+		SignAlgo:  runtime.SignatureAlgorithmECDSA_P256,
+	}
+
+	_, popErr := crypto.VerifyPOP(pk, nil)
+	_, aggErr := crypto.AggregatePublicKeys([]*runtime.PublicKey{pk})
+
+	for _, err := range []error{popErr, aggErr} {
+		require.True(t, errors.IsValueError(err))
+
+		errorString := err.Error()
+		assert.True(t, utf8.ValidString(errorString))
+
+		// check the error string can be encoded and decoded using CBOR
+		marshalledBytes, err := cbor.Marshal(errorString)
+		require.NoError(t, err)
+
+		var unmarshalledString string
+		require.NoError(t, cbor.Unmarshal(marshalledBytes, &unmarshalledString))
+		require.Equal(t, errorString, unmarshalledString)
+	}
+}
+
 func TestVerifySignatureFromRuntime_error_handling_produces_valid_utf8_for_invalid_sign_algo(t *testing.T) {
 
 	invalidSignatureAlgo := runtime.SignatureAlgorithm(164)

--- a/fvm/crypto/crypto_test.go
+++ b/fvm/crypto/crypto_test.go
@@ -528,7 +528,7 @@ func TestBLSHostFunctionsOnNonBLSKey(t *testing.T) {
 
 		t.Run("control: valid BLS keys", func(t *testing.T) {
 			keys := make([]*runtime.PublicKey, 0, 2)
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// use a distinct seed per key so the control case aggregates
 				// two different keys
 				keySeed := make([]byte, onflowCrypto.KeyGenSeedMinLen)

--- a/fvm/crypto/crypto_test.go
+++ b/fvm/crypto/crypto_test.go
@@ -562,7 +562,7 @@ func TestBLSHostFunctions_error_handling_produces_valid_utf8(t *testing.T) {
 
 	pk := &runtime.PublicKey{
 		PublicKey: []byte{0xc3, 0x28}, // some invalid UTF-8
-		SignAlgo:  runtime.SignatureAlgorithmECDSA_P256,
+		SignAlgo:  runtime.SignatureAlgorithmBLS_BLS12_381,
 	}
 
 	_, popErr := crypto.VerifyPOP(pk, nil)
@@ -572,6 +572,8 @@ func TestBLSHostFunctions_error_handling_produces_valid_utf8(t *testing.T) {
 		require.True(t, errors.IsValueError(err))
 
 		errorString := err.Error()
+		// the invalid bytes must appear hex-encoded, not raw
+		assert.Contains(t, errorString, "c328")
 		assert.True(t, utf8.ValidString(errorString))
 
 		// check the error string can be encoded and decoded using CBOR

--- a/fvm/crypto/crypto_test.go
+++ b/fvm/crypto/crypto_test.go
@@ -529,7 +529,12 @@ func TestBLSHostFunctionsOnNonBLSKey(t *testing.T) {
 		t.Run("control: valid BLS keys", func(t *testing.T) {
 			keys := make([]*runtime.PublicKey, 0, 2)
 			for i := 0; i < 2; i++ {
-				sk, err := onflowCrypto.GeneratePrivateKey(onflowCrypto.BLSBLS12381, seed)
+				// use a distinct seed per key so the control case aggregates
+				// two different keys
+				keySeed := make([]byte, onflowCrypto.KeyGenSeedMinLen)
+				_, err := rand.Read(keySeed)
+				require.NoError(t, err)
+				sk, err := onflowCrypto.GeneratePrivateKey(onflowCrypto.BLSBLS12381, keySeed)
 				require.NoError(t, err)
 				keys = append(keys, &runtime.PublicKey{
 					PublicKey: sk.PublicKey().Encode(),

--- a/fvm/fvm_signature_test.go
+++ b/fvm/fvm_signature_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
 	fvmCrypto "github.com/onflow/flow-go/fvm/crypto"
+	fvmErrors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/storage/snapshot"
 	"github.com/onflow/flow-go/model/flow"
 	msig "github.com/onflow/flow-go/module/signature"
@@ -503,6 +504,9 @@ func TestBLSMultiSignature(t *testing.T) {
 						// verifyPoP is documented to abort on non-BLS keys; the abort
 						// surfaces as a controlled user error, not a panic
 						assert.ErrorContains(t, output.Err, "public key is not a BLS key")
+						// the user error is reported as a value error, not a generic
+						// Cadence runtime error
+						assert.True(t, fvmErrors.HasErrorCode(output.Err, fvmErrors.ErrCodeValueError))
 					})
 				}
 			},
@@ -712,6 +716,9 @@ func TestBLSMultiSignature(t *testing.T) {
 						// the stdlib maps the host function's user error to the
 						// documented nil return; the script aborts force-unwrapping it
 						assert.ErrorContains(t, output.Err, "unexpectedly found nil while forcing an Optional value")
+						// the surfaced error is the nil-force abort, a Cadence runtime
+						// error, since the host function's error was mapped to nil
+						assert.True(t, fvmErrors.HasErrorCode(output.Err, fvmErrors.ErrCodeCadenceRunTimeError))
 					})
 				}
 

--- a/fvm/fvm_signature_test.go
+++ b/fvm/fvm_signature_test.go
@@ -499,6 +499,10 @@ func TestBLSMultiSignature(t *testing.T) {
 						_, output, err := vm.Run(ctx, script, snapshotTree)
 						assert.NoError(t, err)
 						assert.Error(t, output.Err)
+
+						// verifyPoP is documented to abort on non-BLS keys; the abort
+						// surfaces as a controlled user error, not a panic
+						assert.ErrorContains(t, output.Err, "public key is not a BLS key")
 					})
 				}
 			},
@@ -704,6 +708,10 @@ func TestBLSMultiSignature(t *testing.T) {
 						_, output, err := vm.Run(ctx, script, snapshotTree)
 						assert.NoError(t, err)
 						assert.Error(t, output.Err)
+
+						// the stdlib maps the host function's user error to the
+						// documented nil return; the script aborts force-unwrapping it
+						assert.ErrorContains(t, output.Err, "unexpectedly found nil while forcing an Optional value")
 					})
 				}
 

--- a/fvm/fvm_signature_test.go
+++ b/fvm/fvm_signature_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
 	fvmCrypto "github.com/onflow/flow-go/fvm/crypto"
+	fvmErrors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/storage/snapshot"
 	"github.com/onflow/flow-go/model/flow"
 	msig "github.com/onflow/flow-go/module/signature"
@@ -506,6 +507,9 @@ func TestBLSMultiSignature(t *testing.T) {
 						// verifyPoP is documented to abort on non-BLS keys; the abort
 						// surfaces as a controlled user error, not a panic
 						assert.ErrorContains(t, output.Err, "public key is not a BLS key")
+						// the user error is reported as a value error, not a generic
+						// Cadence runtime error
+						assert.True(t, fvmErrors.HasErrorCode(output.Err, fvmErrors.ErrCodeValueError))
 					})
 				}
 			},
@@ -717,6 +721,9 @@ func TestBLSMultiSignature(t *testing.T) {
 						// the stdlib maps the host function's user error to the
 						// documented nil return; the script aborts force-unwrapping it
 						assert.ErrorContains(t, output.Err, "unexpectedly found nil while forcing an Optional value")
+						// the surfaced error is the nil-force abort, a Cadence runtime
+						// error, since the host function's error was mapped to nil
+						assert.True(t, fvmErrors.HasErrorCode(output.Err, fvmErrors.ErrCodeCadenceRunTimeError))
 					})
 				}
 

--- a/fvm/fvm_signature_test.go
+++ b/fvm/fvm_signature_test.go
@@ -502,6 +502,10 @@ func TestBLSMultiSignature(t *testing.T) {
 						_, output, err := vm.Run(ctx, script, snapshotTree)
 						assert.NoError(t, err)
 						assert.Error(t, output.Err)
+
+						// verifyPoP is documented to abort on non-BLS keys; the abort
+						// surfaces as a controlled user error, not a panic
+						assert.ErrorContains(t, output.Err, "public key is not a BLS key")
 					})
 				}
 			},
@@ -709,6 +713,10 @@ func TestBLSMultiSignature(t *testing.T) {
 						_, output, err := vm.Run(ctx, script, snapshotTree)
 						assert.NoError(t, err)
 						assert.Error(t, output.Err)
+
+						// the stdlib maps the host function's user error to the
+						// documented nil return; the script aborts force-unwrapping it
+						assert.ErrorContains(t, output.Err, "unexpectedly found nil while forcing an Optional value")
 					})
 				}
 


### PR DESCRIPTION
Closes: #8649

`VerifyPOP` and `AggregatePublicKeys` panicked on valid non-BLS public keys (e.g. ECDSA), reachable from Cadence because neither stdlib entry point gates on the signature algorithm. For `BLS.aggregatePublicKeys` this violated the documented nil return; for `PublicKey.verifyPoP` the abort is documented, but it surfaced as a panic asserting a false invariant.

## Changes
- Both functions gate on `SignAlgo` and return a `NewValueErrorf` for non-BLS keys, following the `VerifySignatureFromRuntime` pattern
- Decode failures propagate invalid-input errors as `NewValueErrorf`, panic only on unexpected crypto-module errors
- Tests: unit coverage for both host functions, plus e2e assertions that scripts now surface the controlled error / documented nil

For `aggregatePublicKeys` the Cadence stdlib maps any host error to nil, so this restores the documented behavior with no Cadence change. Gating in the Cadence stdlib remains as optional defense in depth.

## ⚠️ Requires HCU

This changes execution results and must ship via a Height Coordinated Upgrade:
- `BLS.aggregatePublicKeys` with non-BLS keys previously aborted the entire transaction (host panic recovered by Cadence); it now returns the documented `nil` and **execution continues**. Transactions handling the optional (e.g. `?? fallback`) can now commit where they previously failed.
- `PublicKey.verifyPoP` with a non-BLS key still aborts, but the reported `ErrorCode` changes from 1101 (`CadenceRunTimeError`) to 1051 (`ValueError`), which downstream systems index. E2e tests pin both behaviors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788707067&installation_model_id=15376&pr_number=8652&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8652&signature=a781aceb9b9835b57dfff0a8b83587afb234aba83a0f029fc09f4ec4e322fa85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - BLS cryptographic operations now reject non-BLS and malformed keys with clear validation errors instead of unexpectedly crashing.
  - Public-key aggregation reports which inputs are invalid and preserves expected runtime error details.
  - Error responses use valid, consistently formatted encodings compatible with downstream processing.

- **Tests**
  - Added coverage for valid BLS keys, non-BLS key rejection, malformed key handling, proof-of-possession verification, aggregation, and error-message consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
