### PR TITLE
Fold code-sanity-check into make tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,6 @@ jobs:
           cache: true
       - name: Run tidy
         run: make tidy
-      - name: code sanity check
-        run: make code-sanity-check
 
   create-dynamic-test-matrix:
     name: Create Dynamic Test Matrix

--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,6 @@ go-fix:
 	go fix ./...
 	git diff --exit-code
 
-
-.PHONY: code-sanity-check
-code-sanity-check: go-fix check-geth-crypto-versions go-math-rand-check
-
 .PHONY: fuzz-fvm
 fuzz-fvm:
 	# run fuzz tests in the fvm package
@@ -189,8 +185,9 @@ generate-mocks: install-mock-generators
 	mockery --config .mockery.yaml --log-level warn
 
 # this ensures there is no unused dependency being added by accident
+# also runs sanity checks: go-fix, geth/crypto version consistency, math/rand usage
 .PHONY: tidy
-tidy:
+tidy: go-fix check-geth-crypto-versions go-math-rand-check
 	go mod tidy -v
 	cd integration; go mod tidy -v
 	cd crypto; go mod tidy -v


### PR DESCRIPTION
IMO: we don't need another individual check to run locally before commiting.

Fold the code-sanity-check target into make tidy and remove the standalone target.

make tidy now runs the three sanity checks (go-fix, geth/crypto version consistency, math/rand usage) before tidying the modules. The CI Tidy job already ran both back-to-back, so the separate step is dropped. The lint job invokes golangci-lint-action directly rather than make lint, which is why tidy is the right home and CI coverage is unchanged.

The individual checks (go-fix, check-geth-crypto-versions, go-math-rand-check) remain available as standalone targets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789132263&installation_model_id=15376&pr_number=8653&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8653&signature=49a74651edb1a9ffbe6480138bb393da943fafe6d0699aefe0073d751f5002e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the code-cleanup workflow by running focused validation checks before module tidying.
  * Removed the standalone code sanity-check step from continuous integration.
  * Retired the obsolete `code-sanity-check` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->