### PR TITLE
[AN] Cancel streaming RPCs on shutdown via interceptor

### DIFF
--- a/module/grpcserver/interceptor_shutdown.go
+++ b/module/grpcserver/interceptor_shutdown.go
@@ -1,0 +1,59 @@
+package grpcserver
+
+import (
+	"context"
+
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+
+	"github.com/onflow/flow-go/module/irrecoverable"
+)
+
+// ShutdownStreamInterceptor cancels the per-stream context as soon as the node's
+// [irrecoverable.SignalerContext] is cancelled. This lets long-lived streaming RPCs
+// (e.g. block subscriptions) observe shutdown and return promptly, which in turn allows
+// [grpc.Server.GracefulStop] to finish without waiting for the client to disconnect.
+//
+// Without this interceptor, `stream.Context()` is only cancelled when the underlying
+// transport dies; [grpc.Server.GracefulStop] does not cancel it. That is why active
+// subscriptions block shutdown until either the client disconnects or the server is
+// force-stopped via [grpc.Server.Stop].
+//
+// If `signalerCtx` has not been populated yet (the server is still initializing), the
+// stream is passed through unchanged.
+func ShutdownStreamInterceptor(signalerCtx *atomic.Pointer[irrecoverable.SignalerContext]) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		sigCtx := signalerCtx.Load()
+		if sigCtx == nil {
+			return handler(srv, ss)
+		}
+
+		ctx, cancel := context.WithCancel(ss.Context())
+		defer cancel()
+
+		// Fan the SignalerContext's Done into the stream's context. The watcher exits either
+		// when shutdown begins (SignalerContext cancelled) or when the handler returns
+		// (defer cancel() above), so no goroutine is leaked.
+		go func() {
+			select {
+			case <-(*sigCtx).Done():
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
+		return handler(srv, &shutdownAwareStream{ServerStream: ss, ctx: ctx})
+	}
+}
+
+// shutdownAwareStream wraps a [grpc.ServerStream] so that its Context reflects both the
+// original transport-level cancellation and node shutdown.
+type shutdownAwareStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+// Context returns the shutdown-aware context for the stream.
+func (s *shutdownAwareStream) Context() context.Context {
+	return s.ctx
+}

--- a/module/grpcserver/server.go
+++ b/module/grpcserver/server.go
@@ -19,9 +19,9 @@ import (
 	"github.com/onflow/flow-go/module/irrecoverable"
 )
 
-// DefaultGracefulStopTimeout is the time GracefulStop is allowed to wait for active streaming
-// RPCs to finish before the server is force-stopped via Stop. Long-lived streaming subscriptions
-// would otherwise block shutdown indefinitely.
+// DefaultGracefulStopTimeout is the time [grpc.Server.GracefulStop] is allowed to wait for
+// active RPCs to finish before the server is force-stopped via [grpc.Server.Stop]. Long-lived
+// streaming subscriptions would otherwise block shutdown indefinitely.
 const DefaultGracefulStopTimeout = 5 * time.Second
 
 // GrpcServer wraps `grpc.Server` and allows to manage it using `component.Component` interface. It can be injected
@@ -46,12 +46,18 @@ type GrpcServer struct {
 var _ component.Component = (*GrpcServer)(nil)
 
 // NewGrpcServer returns a new grpc server.
+//
+// If `gracefulStopTimeout` is zero, [DefaultGracefulStopTimeout] is used. A positive value
+// bounds how long shutdown waits for active RPCs to finish before force-stopping.
 func NewGrpcServer(log zerolog.Logger,
 	grpcListenAddr string,
 	grpcServer *grpc.Server,
 	grpcSignalerCtx *atomic.Pointer[irrecoverable.SignalerContext],
 	gracefulStopTimeout time.Duration,
 ) *GrpcServer {
+	if gracefulStopTimeout <= 0 {
+		gracefulStopTimeout = DefaultGracefulStopTimeout
+	}
 	server := &GrpcServer{
 		log:                 log,
 		server:              grpcServer,
@@ -113,19 +119,26 @@ func (g *GrpcServer) GRPCAddress() net.Addr {
 }
 
 // shutdownWorker is a worker routine which shuts down server when the context is cancelled.
-// It attempts a graceful stop first. If active streaming RPCs do not finish within
-// gracefulStopTimeout, the server is force-stopped to avoid blocking shutdown indefinitely.
+//
+// It attempts a graceful stop first. If active RPCs do not finish within
+// `gracefulStopTimeout`, the server is force-stopped via [grpc.Server.Stop] to avoid
+// blocking shutdown indefinitely.
 func (g *GrpcServer) shutdownWorker(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
 	ready()
 	<-ctx.Done()
+
 	gracefulDone := make(chan struct{})
 	go func() {
 		defer close(gracefulDone)
 		g.server.GracefulStop()
 	}()
+
+	timer := time.NewTimer(g.gracefulStopTimeout)
+	defer timer.Stop()
+
 	select {
 	case <-gracefulDone:
-	case <-time.After(g.gracefulStopTimeout):
+	case <-timer.C:
 		g.log.Warn().
 			Dur("timeout", g.gracefulStopTimeout).
 			Msg("graceful stop timed out; force-stopping gRPC server")

--- a/module/grpcserver/server.go
+++ b/module/grpcserver/server.go
@@ -19,9 +19,9 @@ import (
 	"github.com/onflow/flow-go/module/irrecoverable"
 )
 
-// DefaultGracefulStopTimeout is the time [grpc.Server.GracefulStop] is allowed to wait for
-// active RPCs to finish before the server is force-stopped via [grpc.Server.Stop]. Long-lived
-// streaming subscriptions would otherwise block shutdown indefinitely.
+// DefaultGracefulStopTimeout is the time GracefulStop is allowed to wait for active streaming
+// RPCs to finish before the server is force-stopped via Stop. Long-lived streaming subscriptions
+// would otherwise block shutdown indefinitely.
 const DefaultGracefulStopTimeout = 5 * time.Second
 
 // GrpcServer wraps `grpc.Server` and allows to manage it using `component.Component` interface. It can be injected
@@ -45,10 +45,8 @@ type GrpcServer struct {
 
 var _ component.Component = (*GrpcServer)(nil)
 
-// NewGrpcServer returns a new grpc server.
-//
-// If `gracefulStopTimeout` is zero, [DefaultGracefulStopTimeout] is used. A positive value
-// bounds how long shutdown waits for active RPCs to finish before force-stopping.
+// NewGrpcServer returns a new grpc server. If gracefulStopTimeout is zero,
+// DefaultGracefulStopTimeout is used.
 func NewGrpcServer(log zerolog.Logger,
 	grpcListenAddr string,
 	grpcServer *grpc.Server,
@@ -119,23 +117,18 @@ func (g *GrpcServer) GRPCAddress() net.Addr {
 }
 
 // shutdownWorker is a worker routine which shuts down server when the context is cancelled.
-//
-// It attempts a graceful stop first. If active RPCs do not finish within
-// `gracefulStopTimeout`, the server is force-stopped via [grpc.Server.Stop] to avoid
-// blocking shutdown indefinitely.
+// It attempts a graceful stop first. If active streaming RPCs do not finish within
+// gracefulStopTimeout, the server is force-stopped to avoid blocking shutdown indefinitely.
 func (g *GrpcServer) shutdownWorker(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
 	ready()
 	<-ctx.Done()
-
 	gracefulDone := make(chan struct{})
 	go func() {
 		defer close(gracefulDone)
 		g.server.GracefulStop()
 	}()
-
 	timer := time.NewTimer(g.gracefulStopTimeout)
 	defer timer.Stop()
-
 	select {
 	case <-gracefulDone:
 	case <-timer.C:

--- a/module/grpcserver/server_builder.go
+++ b/module/grpcserver/server_builder.go
@@ -29,7 +29,7 @@ func WithStreamInterceptor() Option {
 }
 
 // WithGracefulStopTimeout sets how long the server waits for active streaming RPCs to finish
-// before force-stopping during shutdown. Defaults to DefaultGracefulStopTimeout.
+// before force-stopping during shutdown. Defaults to [DefaultGracefulStopTimeout].
 func WithGracefulStopTimeout(d time.Duration) Option {
 	return func(c *GrpcServerBuilder) {
 		c.gracefulStopTimeout = d
@@ -99,6 +99,12 @@ func NewGrpcServerBuilder(
 	var streamInterceptors []grpc.StreamServerInterceptor
 
 	unaryInterceptors = append(unaryInterceptors, IrrecoverableCtxInjector(signalerCtx))
+
+	// ShutdownStreamInterceptor must be registered before any interceptor or handler that
+	// reads stream.Context(), so subsequent interceptors and the handler see the
+	// shutdown-aware context.
+	streamInterceptors = append(streamInterceptors, ShutdownStreamInterceptor(signalerCtx))
+
 	if rpcMetricsEnabled {
 		unaryInterceptors = append(unaryInterceptors, grpc_prometheus.UnaryServerInterceptor)
 

--- a/module/grpcserver/server_builder.go
+++ b/module/grpcserver/server_builder.go
@@ -29,7 +29,7 @@ func WithStreamInterceptor() Option {
 }
 
 // WithGracefulStopTimeout sets how long the server waits for active streaming RPCs to finish
-// before force-stopping during shutdown. Defaults to [DefaultGracefulStopTimeout].
+// before force-stopping during shutdown. Defaults to DefaultGracefulStopTimeout.
 func WithGracefulStopTimeout(d time.Duration) Option {
 	return func(c *GrpcServerBuilder) {
 		c.gracefulStopTimeout = d

--- a/module/grpcserver/server_test.go
+++ b/module/grpcserver/server_test.go
@@ -100,6 +100,59 @@ func TestGrpcServerShutdown_WithActiveStream(t *testing.T) {
 	unittest.RequireComponentsDoneBefore(t, gracefulStopTimeout+500*time.Millisecond, server)
 }
 
+// TestGrpcServerShutdown_ShutdownStreamInterceptor verifies that when the
+// [grpcserver.ShutdownStreamInterceptor] is registered, an active streaming RPC's
+// stream.Context() is cancelled as soon as the node's SignalerContext is cancelled.
+// This allows GracefulStop to complete cleanly — well under gracefulStopTimeout —
+// even when the client has not disconnected, so the force-stop fallback is not needed.
+func TestGrpcServerShutdown_ShutdownStreamInterceptor(t *testing.T) {
+	// Give the graceful path a generous window so we can prove that the interceptor —
+	// not the force-stop fallback — is what unblocks shutdown.
+	gracefulStopTimeout := 10 * time.Second
+
+	signalerCtx := atomic.NewPointer[irrecoverable.SignalerContext](nil)
+	rawServer := grpc.NewServer(
+		grpc.ChainStreamInterceptor(grpcserver.ShutdownStreamInterceptor(signalerCtx)),
+	)
+	handler := &blockingStreamServer{started: make(chan struct{})}
+	rawServer.RegisterService(&blockingStreamServiceDesc, handler)
+
+	server := grpcserver.NewGrpcServer(
+		zerolog.Nop(),
+		"localhost:0",
+		rawServer,
+		signalerCtx,
+		gracefulStopTimeout,
+	)
+
+	ctx, cancel := irrecoverable.NewMockSignalerContextWithCancel(t, context.Background())
+	server.Start(ctx)
+	unittest.RequireComponentsReadyBefore(t, 2*time.Second, server)
+
+	conn, err := grpc.NewClient(
+		server.GRPCAddress().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Open a stream and never cancel the client-side context — mimicking a long-lived
+	// subscription that a well-behaved client is happy to keep open indefinitely.
+	clientCtx := t.Context()
+	_, err = conn.NewStream(clientCtx, &grpc.StreamDesc{ServerStreams: true}, "/test.BlockingStream/Stream")
+	require.NoError(t, err)
+
+	unittest.RequireCloseBefore(t, handler.started, 2*time.Second, "stream handler did not start")
+
+	// Trigger node shutdown. The interceptor should cancel the stream's context, the
+	// handler should return, and GracefulStop should complete immediately.
+	cancel()
+
+	// Shutdown must complete well under gracefulStopTimeout; otherwise the force-stop
+	// fallback is what unblocked us, not the interceptor.
+	unittest.RequireComponentsDoneBefore(t, 2*time.Second, server)
+}
+
 // TestGrpcServerShutdown_NoActiveStreams verifies that when no streaming RPCs are active,
 // GrpcServer shuts down promptly via GracefulStop without waiting for the timeout.
 func TestGrpcServerShutdown_NoActiveStreams(t *testing.T) {


### PR DESCRIPTION
Follow-up to #8662. Stacks on top of that branch; will rebase onto master once #8662 merges.

## Motivation

#8662 fixes the shutdown hang by force-stopping the gRPC server after 5s. That resolves the immediate symptom, but the root cause is that streaming RPC handlers never observe the node's shutdown signal — `stream.Context()` is only cancelled when the underlying transport dies, and `GracefulStop` does not cancel it. So on every restart with active subscribers, we rely on the force-stop fallback, which also aborts any in-flight unary RPCs and gives clients a torn connection rather than a clean `Canceled` status.

## Changes

- **`ShutdownStreamInterceptor`**: new stream interceptor that wraps `stream.Context()` so it's cancelled when the `SignalerContext` fires. Registered as the outermost stream interceptor so subsequent interceptors and the handler see the shutdown-aware context. Subscriptions (e.g. `SubscribeBlockDigestsFromLatest`, `SubscribeBlockHeadersFromLatest`) return promptly on shutdown, and `GracefulStop` completes without needing the force-stop backstop.
- **`NewGrpcServer`**: defaults `gracefulStopTimeout` to `DefaultGracefulStopTimeout` when non-positive, so external callers can't accidentally pass 0 and get an instant force-stop.
- **`shutdownWorker`**: switches from `time.After` to `time.NewTimer` + `defer timer.Stop()` so the timer doesn't linger on the fast path.

## Tests

- `TestGrpcServerShutdown_ShutdownStreamInterceptor`: new test that registers the interceptor, opens a streaming RPC with a never-cancelled client context, cancels the SignalerContext, and asserts shutdown completes in well under `gracefulStopTimeout` (10s) — proving the interceptor, not the force-stop fallback, is what unblocks shutdown.
- Existing tests from #8662 continue to pass; they exercise a `grpc.NewServer()` without interceptors, so they still exercise the force-stop backstop path.
- Ran `go test -race -count=5` on the package; stable.

## What this does NOT do

- Does not add a matching unary interceptor. In-flight unary calls should complete quickly; if we ever see a shutdown hang traced to a hung unary handler, we can add one. The 5s force-stop backstop still catches that case.

---

Generated in collaboration with Claude.
