### PR TITLE
[AN] Remove readiness blocking on `gracefulDone` channel

### DIFF
--- a/module/grpcserver/server.go
+++ b/module/grpcserver/server.go
@@ -137,5 +137,4 @@ func (g *GrpcServer) shutdownWorker(ctx irrecoverable.SignalerContext, ready com
 			Msg("graceful stop timed out; force-stopping gRPC server")
 		g.server.Stop()
 	}
-	<-gracefulDone
 }

--- a/module/grpcserver/server_test.go
+++ b/module/grpcserver/server_test.go
@@ -48,6 +48,10 @@ var _ blockingStreamService = (*blockingStreamServer)(nil)
 func (s *blockingStreamServer) Stream(stream grpc.ServerStream) error {
 	close(s.started)
 	if s.blockDuration > 0 {
+		// this is to simulate the case that after `grpcServer.Stop()` is called, 
+		// `<-gracefulDone` channel is still blocking, so that we can verify
+		// the caller is not waiting for `<-gracefulDone` return before shutdown,
+		// otherwise, the waiting might be still blocking for longer or indefinitely.
 		time.Sleep(s.blockDuration)
 	}
 	<-stream.Context().Done()

--- a/module/grpcserver/server_test.go
+++ b/module/grpcserver/server_test.go
@@ -48,7 +48,7 @@ var _ blockingStreamService = (*blockingStreamServer)(nil)
 func (s *blockingStreamServer) Stream(stream grpc.ServerStream) error {
 	close(s.started)
 	if s.blockDuration > 0 {
-		// this is to simulate the case that after `grpcServer.Stop()` is called, 
+		// this is to simulate the case that after `grpcServer.Stop()` is called,
 		// `<-gracefulDone` channel is still blocking, so that we can verify
 		// the caller is not waiting for `<-gracefulDone` return before shutdown,
 		// otherwise, the waiting might be still blocking for longer or indefinitely.

--- a/module/grpcserver/server_test.go
+++ b/module/grpcserver/server_test.go
@@ -39,12 +39,17 @@ var blockingStreamServiceDesc = grpc.ServiceDesc{
 type blockingStreamServer struct {
 	// started is closed when the stream handler has been entered.
 	started chan struct{}
+	// blockDuration will cause `Stream` to block for the set duration
+	blockDuration time.Duration
 }
 
 var _ blockingStreamService = (*blockingStreamServer)(nil)
 
 func (s *blockingStreamServer) Stream(stream grpc.ServerStream) error {
 	close(s.started)
+	if s.blockDuration > 0 {
+		time.Sleep(s.blockDuration)
+	}
 	<-stream.Context().Done()
 	return nil
 }
@@ -60,7 +65,10 @@ func TestGrpcServerShutdown_WithActiveStream(t *testing.T) {
 	gracefulStopTimeout := 200 * time.Millisecond
 
 	rawServer := grpc.NewServer()
-	handler := &blockingStreamServer{started: make(chan struct{})}
+	handler := &blockingStreamServer{
+		started:       make(chan struct{}),
+		blockDuration: gracefulStopTimeout * 10,
+	}
 	rawServer.RegisterService(&blockingStreamServiceDesc, handler)
 
 	signalerCtx := atomic.NewPointer[irrecoverable.SignalerContext](nil)
@@ -114,7 +122,10 @@ func TestGrpcServerShutdown_ShutdownStreamInterceptor(t *testing.T) {
 	rawServer := grpc.NewServer(
 		grpc.ChainStreamInterceptor(grpcserver.ShutdownStreamInterceptor(signalerCtx)),
 	)
-	handler := &blockingStreamServer{started: make(chan struct{})}
+	handler := &blockingStreamServer{
+		started:       make(chan struct{}),
+		blockDuration: time.Second,
+	}
 	rawServer.RegisterService(&blockingStreamServiceDesc, handler)
 
 	server := grpcserver.NewGrpcServer(
@@ -159,7 +170,13 @@ func TestGrpcServerShutdown_NoActiveStreams(t *testing.T) {
 	gracefulStopTimeout := 5 * time.Second
 
 	rawServer := grpc.NewServer()
-	rawServer.RegisterService(&blockingStreamServiceDesc, &blockingStreamServer{started: make(chan struct{})})
+	rawServer.RegisterService(
+		&blockingStreamServiceDesc,
+		&blockingStreamServer{
+			started:       make(chan struct{}),
+			blockDuration: gracefulStopTimeout * 10,
+		},
+	)
 
 	signalerCtx := atomic.NewPointer[irrecoverable.SignalerContext](nil)
 	server := grpcserver.NewGrpcServer(


### PR DESCRIPTION
Follow-up on https://github.com/onflow/flow-go/pull/8662 .

On https://github.com/onflow/flow-go/pull/8662#discussion_r3832427816, I suggested that `<-gracefulDone` is better to be moved outside the `select`, but after carefully revisiting the unit tests, it should in fact be removed entirely, as it can still block after the timeout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790086978&installation_model_id=15376&pr_number=8664&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8664&signature=f838ec80716484b5b82ca6f881c08f153f1498003f398d27d94d7b327291207d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown behavior when active streams exceed the graceful shutdown timeout.
  * Prevented shutdown from waiting unnecessarily after forced termination.
  * Reduced delays when terminating servers with streams that do not complete promptly.
  * Improved cancellation handling for delayed streaming operations during shutdown.

* **Tests**
  * Expanded shutdown coverage for delayed active streams, interceptor cancellation, and immediate shutdown with no active streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->