### PR TITLE
flow.NewPayload to reject nil elements in Guarantees, Seals etc

### DIFF
--- a/model/flow/payload.go
+++ b/model/flow/payload.go
@@ -45,6 +45,26 @@ func NewPayload(untrusted UntrustedPayload) (*Payload, error) {
 	if untrusted.ProtocolStateID == ZeroID {
 		return nil, fmt.Errorf("ProtocolStateID must not be zero")
 	}
+	for i, g := range untrusted.Guarantees {
+		if g == nil {
+			return nil, fmt.Errorf("guarantee at index %d is nil", i)
+		}
+	}
+	for i, s := range untrusted.Seals {
+		if s == nil {
+			return nil, fmt.Errorf("seal at index %d is nil", i)
+		}
+	}
+	for i, r := range untrusted.Receipts {
+		if r == nil {
+			return nil, fmt.Errorf("receipt at index %d is nil", i)
+		}
+	}
+	for i, r := range untrusted.Results {
+		if r == nil {
+			return nil, fmt.Errorf("result at index %d is nil", i)
+		}
+	}
 
 	return &Payload{
 		Guarantees:      untrusted.Guarantees,

--- a/model/flow/payload_test.go
+++ b/model/flow/payload_test.go
@@ -65,15 +65,6 @@ func TestPayloadEncodingMsgpack(t *testing.T) {
 }
 
 // TestNewPayload verifies the behavior of the NewPayload constructor.
-// It ensures proper handling of both valid and invalid untrusted input fields.
-//
-// Test Cases:
-//
-// 1. Valid input:
-//   - Verifies that a properly populated UntrustedPayload results in a valid Payload.
-//
-// 2. Valid input with zero ProtocolStateID:
-//   - Ensures that an error is returned when ProtocolStateID is flow.ZeroID.
 func TestNewPayload(t *testing.T) {
 	t.Run("valid input", func(t *testing.T) {
 		payload := unittest.PayloadFixture(
@@ -85,7 +76,7 @@ func TestNewPayload(t *testing.T) {
 		require.NotNil(t, res)
 	})
 
-	t.Run("valid input with zero ProtocolStateID", func(t *testing.T) {
+	t.Run("zero ProtocolStateID rejected", func(t *testing.T) {
 		payload := unittest.PayloadFixture()
 		payload.ProtocolStateID = flow.ZeroID
 
@@ -93,5 +84,53 @@ func TestNewPayload(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, res)
 		require.Contains(t, err.Error(), "ProtocolStateID must not be zero")
+	})
+
+	t.Run("nil Guarantee element rejected", func(t *testing.T) {
+		untrusted := flow.UntrustedPayload(unittest.PayloadFixture(
+			unittest.WithProtocolStateID(unittest.IdentifierFixture()),
+		))
+		untrusted.Guarantees = []*flow.CollectionGuarantee{nil}
+
+		res, err := flow.NewPayload(untrusted)
+		require.Error(t, err)
+		require.Nil(t, res)
+		require.Contains(t, err.Error(), "guarantee at index 0 is nil")
+	})
+
+	t.Run("nil Seal element rejected", func(t *testing.T) {
+		untrusted := flow.UntrustedPayload(unittest.PayloadFixture(
+			unittest.WithProtocolStateID(unittest.IdentifierFixture()),
+		))
+		untrusted.Seals = []*flow.Seal{nil}
+
+		res, err := flow.NewPayload(untrusted)
+		require.Error(t, err)
+		require.Nil(t, res)
+		require.Contains(t, err.Error(), "seal at index 0 is nil")
+	})
+
+	t.Run("nil Receipt element rejected", func(t *testing.T) {
+		untrusted := flow.UntrustedPayload(unittest.PayloadFixture(
+			unittest.WithProtocolStateID(unittest.IdentifierFixture()),
+		))
+		untrusted.Receipts = flow.ExecutionReceiptStubList{nil}
+
+		res, err := flow.NewPayload(untrusted)
+		require.Error(t, err)
+		require.Nil(t, res)
+		require.Contains(t, err.Error(), "receipt at index 0 is nil")
+	})
+
+	t.Run("nil Result element rejected", func(t *testing.T) {
+		untrusted := flow.UntrustedPayload(unittest.PayloadFixture(
+			unittest.WithProtocolStateID(unittest.IdentifierFixture()),
+		))
+		untrusted.Results = flow.ExecutionResultList{nil}
+
+		res, err := flow.NewPayload(untrusted)
+		require.Error(t, err)
+		require.Nil(t, res)
+		require.Contains(t, err.Error(), "result at index 0 is nil")
 	})
 }


### PR DESCRIPTION
## Problem
`flow.NewPayload` (`model/flow/payload.go`) validates only `ProtocolStateID` but does not check the elements of the `Guarantees`, `Seals`, `Receipts`, and `Results` slices for `nil`. A CBOR-decoded block payload with a `null` array element yields a `nil` pointer that passes construction and propagates into a trusted `*flow.Payload`.

## Fix
Added nil-element validation for all four slices in `NewPayload`, mirroring the existing pattern in `NewCollection`. Since `NewProposal` calls `NewBlock`, which calls `NewPayload`, fixing the constructor covers all ingestion paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790359671&installation_model_id=15376&pr_number=8667&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8667&signature=d1a3d107222708144739e3f4f93386450dad8fd02c69c38b961174fb8bd456a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payload validation now reports clear, indexed errors when invalid empty entries are included in guarantees, seals, receipts, or results.
  * Improved handling of missing protocol state identifiers during payload validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->