### PR TITLE
Fix NewPSMT fabricated register reads via non-inclusion proof payload injection

### DIFF
--- a/ledger/partial/ptrie/partialTrie.go
+++ b/ledger/partial/ptrie/partialTrie.go
@@ -136,10 +136,17 @@ func NewPSMT(
 		}
 
 		currentNode.payload = payload
-		// update node's hash value only for inclusion proofs (for others we assume default value)
-		if pr.Inclusion {
-			currentNode.hashValue = ledger.ComputeCompactValue(hash.Hash(path), payload.Value(), currentNode.height)
-		}
+		// Bind the payload to the node's hash unconditionally, i.e. WITHOUT trusting pr.Inclusion.
+		// The proofs originate from a potentially byzantine source (e.g. an execution node's
+		// ChunkDataPack), so pr.Inclusion is attacker-controlled and must not gate hash computation:
+		// otherwise a non-inclusion proof could carry a fabricated (non-empty) payload while the
+		// node's hash stayed at the honest default, making the fabrication invisible to the root
+		// check below and served by GetSinglePayload/Get as authentic state. Computing the hash from
+		// the payload here mirrors proof.VerifyTrieProof: an empty payload yields the default hash
+		// (so honest non-inclusion proofs are unaffected), while any fabricated payload yields a
+		// non-default hash that fails the root check. This likewise defeats a duplicate-path
+		// overwrite, since the second proof's payload now necessarily changes the node's hash.
+		currentNode.hashValue = ledger.ComputeCompactValue(hash.Hash(path), payload.Value(), currentNode.height)
 		// keep a reference to this node by path (for update purpose)
 		psmt.pathLookUp[path] = currentNode
 	}

--- a/ledger/partial/ptrie/partialTrie.go
+++ b/ledger/partial/ptrie/partialTrie.go
@@ -151,6 +151,19 @@ func NewPSMT(
 		psmt.pathLookUp[path] = currentNode
 	}
 
+	// Every proof's terminal node (leaf node) must remain a leaf of the partial trie. forceComputeHash
+	// recomputes any node with children from its children and discards the payload-derived
+	// hashValue bound above, while pathLookUp would still serve that node's payload. A byzantine
+	// proof with truncated Steps (Steps=0 lands on the root; a short proof lands on an interior
+	// ancestor of another proof's path) would otherwise pass the root check below while
+	// GetSinglePayload/Get serve a fabricated payload from the interior terminal node. Honest
+	// compact proofs always terminate at compact leaves, so no legitimate proof is rejected.
+	for path, n := range psmt.pathLookUp {
+		if n.lChild != nil || n.rChild != nil {
+			return nil, fmt.Errorf("proof for path %x terminates at an interior node", path)
+		}
+	}
+
 	// check if the rootHash matches the root node's hash value of the partial trie
 	if ledger.RootHash(psmt.root.forceComputeHash()) != rootValue {
 		return nil, fmt.Errorf("rootNode hash doesn't match the proofs expected [%x], got [%x]", psmt.root.Hash(), rootValue)

--- a/ledger/partial/ptrie/partialTrie_test.go
+++ b/ledger/partial/ptrie/partialTrie_test.go
@@ -430,7 +430,11 @@ func TestRandomProofs(t *testing.T) {
 // inclusion proofs, so a non-inclusion proof carrying a fabricated payload (or a duplicate proof
 // for an already-proven path) left the node's hash at the honest default and slipped past the
 // root check. NewPSMT now binds the payload to the node hash unconditionally, so any fabricated
-// payload changes the node hash and the root check rejects it.
+// payload changes the node hash and the root check rejects it. That binding only holds for proof
+// terminals that remain leaves: forceComputeHash recomputes interior nodes from their children and
+// discards the payload-derived hash, while pathLookUp still serves their payload. NewPSMT therefore
+// also rejects any proof whose terminal node has children, defeating truncated-Steps proofs that
+// land on the root or on an interior ancestor of another proof's path.
 
 var (
 	// secPathP holds a committed register; secPathP2 is a sibling so the trie has a real branch.
@@ -583,6 +587,66 @@ func TestNewPSMT_RejectsInclusionProofWithForgedPayload(t *testing.T) {
 		bp := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{forgedP, honestQ}}
 		_, err := NewPSMT(rootHash, bp)
 		require.Error(t, err, "NewPSMT must reject an inclusion proof carrying a forged payload")
+	})
+}
+
+// TestNewPSMT_RejectsTruncatedProofOnRoot covers attack variant C: a proof with Steps truncated
+// to 0, so its terminal node is the root itself. forceComputeHash recomputes the root from its
+// children (supplied by the honest proof) and discards the payload-derived hash, so the root
+// check alone cannot detect the fabricated payload. NewPSMT must instead reject the batch
+// because the crafted proof's terminal node is not a leaf.
+func TestNewPSMT_RejectsTruncatedProofOnRoot(t *testing.T) {
+	withForest(t, 32, 10, func(t *testing.T, f *mtrie.Forest) {
+		rootHash := secBuildCommittedState(t, f)
+		honestP, _ := secHonestProofs(t, f, rootHash)
+
+		// Crafted proof for the distinct path secPathQ: Steps=0 makes the walk stop at the root,
+		// so the fabricated payload is attached to the root node and its payload-derived hash is
+		// discarded when the root is recomputed from its children.
+		craftedQ := secCloneProof(honestP)
+		craftedQ.Path = secPathQ
+		craftedQ.Inclusion = false
+		craftedQ.Steps = 0
+		craftedQ.Flags = nil
+		craftedQ.Interims = nil
+		craftedQ.Payload = testutils.LightPayload('X', 'x')
+
+		attackBatch := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{honestP, craftedQ}}
+		decoded, err := ledger.DecodeTrieBatchProof(ledger.EncodeTrieBatchProof(attackBatch))
+		require.NoError(t, err)
+
+		_, err = NewPSMT(rootHash, decoded)
+		require.Error(t, err, "NewPSMT must reject a proof whose terminal node is the root")
+	})
+}
+
+// TestNewPSMT_RejectsTruncatedDuplicateOnInteriorNode covers attack variant D: a duplicate proof
+// for an honestly proven path, but with Steps truncated so its terminal node is an interior
+// ancestor of the honest leaf. The interior node has children (built by the honest proof), so
+// forceComputeHash discards the payload-derived hash and the root check passes. NewPSMT must
+// instead reject the batch because the duplicate's terminal node is not a leaf.
+func TestNewPSMT_RejectsTruncatedDuplicateOnInteriorNode(t *testing.T) {
+	withForest(t, 32, 10, func(t *testing.T, f *mtrie.Forest) {
+		rootHash := secBuildCommittedState(t, f)
+		honestP, honestQ := secHonestProofs(t, f, rootHash)
+
+		// Crafted duplicate of honestP: same Path, but Steps truncated to 1 so the walk stops at
+		// the depth-1 interior node on P's path. Placed after honestP so it wins the pathLookUp
+		// entry for secPathP. Flags carry a single zero byte so the one consumed flag reads as 0
+		// (sibling subtree at the default hash).
+		duplicateP := secCloneProof(honestP)
+		duplicateP.Inclusion = false
+		duplicateP.Steps = 1
+		duplicateP.Flags = []byte{0}
+		duplicateP.Interims = nil
+		duplicateP.Payload = testutils.LightPayload('Z', 'z')
+
+		attackBatch := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{honestP, honestQ, duplicateP}}
+		decoded, err := ledger.DecodeTrieBatchProof(ledger.EncodeTrieBatchProof(attackBatch))
+		require.NoError(t, err)
+
+		_, err = NewPSMT(rootHash, decoded)
+		require.Error(t, err, "NewPSMT must reject a proof whose terminal node is an interior node")
 	})
 }
 

--- a/ledger/partial/ptrie/partialTrie_test.go
+++ b/ledger/partial/ptrie/partialTrie_test.go
@@ -2,6 +2,7 @@ package ptrie
 
 import (
 	"math/rand"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -419,6 +420,171 @@ func TestRandomProofs(t *testing.T) {
 
 // TODO add test for incompatible proofs [Byzantine milestone]
 // TODO add test key not exist [Byzantine milestone]
+
+// These tests guard against fabricated register reads in NewPSMT. A byzantine source of proofs
+// (e.g. an execution node's ChunkDataPack) must not be able to make GetSinglePayload/Get serve a
+// value that differs from the committed state while still passing NewPSMT's root check.
+//
+// The proofs a verifier receives are untrusted: the Inclusion flag and Payload are fully
+// attacker-controlled. Before the fix, NewPSMT computed a node's hash from the payload only for
+// inclusion proofs, so a non-inclusion proof carrying a fabricated payload (or a duplicate proof
+// for an already-proven path) left the node's hash at the honest default and slipped past the
+// root check. NewPSMT now binds the payload to the node hash unconditionally, so any fabricated
+// payload changes the node hash and the root check rejects it.
+
+var (
+	// secPathP holds a committed register; secPathP2 is a sibling so the trie has a real branch.
+	secPathP  = testutils.PathByUint16(1)     // bit 0 = 0
+	secPathP2 = testutils.PathByUint16(3)     // bit 0 = 0
+	secPathQ  = testutils.PathByUint16(32768) // bit 0 = 1, EMPTY register on the opposite subtree
+	secPayVP  = testutils.LightPayload('A', 'a')
+	secPayVP2 = testutils.LightPayload('B', 'b')
+)
+
+// secBuildCommittedState inserts the two honest registers and returns the committed root hash.
+func secBuildCommittedState(t *testing.T, f *mtrie.Forest) ledger.RootHash {
+	u := &ledger.TrieUpdate{
+		RootHash: f.GetEmptyRootHash(),
+		Paths:    []ledger.Path{secPathP, secPathP2},
+		Payloads: []*ledger.Payload{secPayVP, secPayVP2},
+	}
+	rootHash, err := f.Update(u)
+	require.NoError(t, err, "error updating trie")
+	return rootHash
+}
+
+// secHonestProofs returns the honest batch proof for [secPathP, secPathQ]:
+//   - honestP: inclusion proof for the committed register secPathP (payload secPayVP)
+//   - honestQ: proof for the EMPTY register secPathQ (carries an empty payload)
+//
+// f.Proofs permutes its input in place, so proofs are matched by their Path field.
+func secHonestProofs(t *testing.T, f *mtrie.Forest, rootHash ledger.RootHash) (honestP, honestQ *ledger.TrieProof) {
+	r := &ledger.TrieRead{RootHash: rootHash, Paths: []ledger.Path{secPathP, secPathQ}}
+	bp, err := f.Proofs(r)
+	require.NoError(t, err, "error getting batch proof")
+	require.Len(t, bp.Proofs, 2)
+	for _, pr := range bp.Proofs {
+		switch pr.Path {
+		case secPathP:
+			honestP = pr
+		case secPathQ:
+			honestQ = pr
+		}
+	}
+	require.NotNil(t, honestP, "expected a proof for secPathP")
+	require.NotNil(t, honestQ, "expected a proof for secPathQ")
+	require.True(t, honestP.Payload.Equals(secPayVP))
+	require.True(t, honestQ.Payload.IsEmpty(), "proof for the empty register Q carries an empty payload")
+	return honestP, honestQ
+}
+
+// secCloneProof deep-copies a proof so a crafted variant can mutate fields without aliasing.
+func secCloneProof(pr *ledger.TrieProof) *ledger.TrieProof {
+	return &ledger.TrieProof{
+		Path:      pr.Path,
+		Payload:   pr.Payload,
+		Interims:  slices.Clone(pr.Interims),
+		Inclusion: pr.Inclusion,
+		Flags:     slices.Clone(pr.Flags),
+		Steps:     pr.Steps,
+	}
+}
+
+// TestNewPSMT_HonestBatchProof is the honest baseline: an untampered batch proof builds a PSMT
+// whose root check passes and serves the committed value for secPathP and an empty payload for the
+// empty register secPathQ. This pins down that the fix does not reject legitimate proofs.
+func TestNewPSMT_HonestBatchProof(t *testing.T) {
+	withForest(t, 32, 10, func(t *testing.T, f *mtrie.Forest) {
+		rootHash := secBuildCommittedState(t, f)
+		honestP, honestQ := secHonestProofs(t, f, rootHash)
+
+		bp := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{honestP, honestQ}}
+		psmt, err := NewPSMT(rootHash, bp)
+		require.NoError(t, err, "honest batch proof must build the partial trie")
+		ensureRootHash(t, rootHash, psmt)
+
+		gotP, err := psmt.GetSinglePayload(secPathP)
+		require.NoError(t, err)
+		require.True(t, gotP.Equals(secPayVP), "secPathP serves the committed value")
+
+		gotQ, err := psmt.GetSinglePayload(secPathQ)
+		require.NoError(t, err)
+		require.True(t, gotQ.IsEmpty(), "empty register Q serves an empty payload")
+	})
+}
+
+// TestNewPSMT_RejectsStuffedNonInclusionProof covers attack variant A: a non-inclusion proof for
+// an EMPTY register with a fabricated (non-empty) payload. Because the payload now determines the
+// node hash unconditionally, the fabricated payload changes the reconstructed root and NewPSMT
+// rejects the batch.
+func TestNewPSMT_RejectsStuffedNonInclusionProof(t *testing.T) {
+	withForest(t, 32, 10, func(t *testing.T, f *mtrie.Forest) {
+		rootHash := secBuildCommittedState(t, f)
+		honestP, honestQ := secHonestProofs(t, f, rootHash)
+
+		// Craft the malicious non-inclusion proof: honest Path/Steps/Flags/Interims, but with a
+		// fabricated payload and Inclusion flipped to false.
+		stuffed := testutils.LightPayload('X', 'x')
+		require.False(t, stuffed.IsEmpty())
+		craftedQ := secCloneProof(honestQ)
+		craftedQ.Inclusion = false
+		craftedQ.Payload = stuffed
+
+		// The crafted proof still round-trips through the wire format unchanged (the decoder does
+		// no semantic validation); the defense lives in NewPSMT.
+		attackBatch := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{honestP, craftedQ}}
+		decoded, err := ledger.DecodeTrieBatchProof(ledger.EncodeTrieBatchProof(attackBatch))
+		require.NoError(t, err)
+		require.True(t, decoded.Proofs[1].Equals(craftedQ))
+
+		_, err = NewPSMT(rootHash, decoded)
+		require.Error(t, err, "NewPSMT must reject a non-inclusion proof carrying a fabricated payload")
+	})
+}
+
+// TestNewPSMT_RejectsDuplicatePathOverwrite covers attack variant B: an honest inclusion proof for
+// secPathP plus a duplicate proof for the same path carrying a fabricated payload. The duplicate's
+// payload now necessarily changes P's node hash, so the reconstructed root no longer matches and
+// NewPSMT rejects the batch.
+func TestNewPSMT_RejectsDuplicatePathOverwrite(t *testing.T) {
+	withForest(t, 32, 10, func(t *testing.T, f *mtrie.Forest) {
+		rootHash := secBuildCommittedState(t, f)
+		honestP, _ := secHonestProofs(t, f, rootHash)
+
+		// Duplicate proof for secPathP: identical Path/Steps/Flags/Interims, but a fabricated payload.
+		crafted := testutils.LightPayload('Z', 'z')
+		duplicateP := secCloneProof(honestP)
+		duplicateP.Inclusion = false
+		duplicateP.Payload = crafted
+		require.Equal(t, honestP.Path, duplicateP.Path)
+
+		attackBatch := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{honestP, duplicateP}}
+		decoded, err := ledger.DecodeTrieBatchProof(ledger.EncodeTrieBatchProof(attackBatch))
+		require.NoError(t, err)
+		require.Len(t, decoded.Proofs, 2)
+
+		_, err = NewPSMT(rootHash, decoded)
+		require.Error(t, err, "NewPSMT must reject a duplicate proof that overwrites a committed register's payload")
+	})
+}
+
+// TestNewPSMT_RejectsInclusionProofWithForgedPayload is a companion check: even an inclusion proof
+// whose payload was swapped to a fabricated value is rejected, since the fabricated payload no
+// longer hashes to the committed root.
+func TestNewPSMT_RejectsInclusionProofWithForgedPayload(t *testing.T) {
+	withForest(t, 32, 10, func(t *testing.T, f *mtrie.Forest) {
+		rootHash := secBuildCommittedState(t, f)
+		honestP, honestQ := secHonestProofs(t, f, rootHash)
+
+		forgedP := secCloneProof(honestP)
+		forgedP.Payload = testutils.LightPayload('Y', 'y')
+		require.False(t, forgedP.Payload.Equals(secPayVP))
+
+		bp := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{forgedP, honestQ}}
+		_, err := NewPSMT(rootHash, bp)
+		require.Error(t, err, "NewPSMT must reject an inclusion proof carrying a forged payload")
+	})
+}
 
 func ensureRootHash(t *testing.T, expectedRootHash ledger.RootHash, psmt *PSMT) {
 	if expectedRootHash != ledger.RootHash(psmt.root.Hash()) {


### PR DESCRIPTION
NewPSMT conditioned leaf hash computation on pr.Inclusion, which is attacker-controlled. A byzantine EN could supply a ChunkDataPack.Proof with a fabricated payload on a non-inclusion proof (or a duplicate proof for an already-proven path), causing the fabricated value to pass the root check and be served as authentic state by GetSinglePayload/Get.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790445912&installation_model_id=15376&pr_number=8674&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8674&signature=932c0298b2dc0c362c5a7bcb9142f78144f98356ab2f4f06d6bf32e9f6206cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened proof validation to reject fabricated or tampered payloads, including non-inclusion, duplicate-path, and truncated-path cases.
  - Ensured invalid proofs fail root-hash verification instead of being treated as authentic state.
  - Rejected proofs that terminate at trie nodes with unverified child data.
  - Preserved validation of legitimate proofs.

- **Tests**
  - Added regression coverage for fabricated payloads and truncated proofs terminating at the root or an interior trie node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->