### PR TITLE
docs(fvm): fix transaction verifier comment

### DIFF
--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -179,7 +179,7 @@ func newSignatureEntries(tx *flow.TransactionBody) (
 // TransactionVerifier verifies the content of the transaction by
 // checking there is no double signature
 // all signatures are valid
-// all accounts provides enoguh weights
+// all accounts provide enough weights
 //
 // if KeyWeightThreshold is set to a negative number, signature verification is skipped
 type TransactionVerifier struct {


### PR DESCRIPTION
Correct the grammar and spelling in the FVM transaction-verifier comment so it reads “all accounts provide enough weights.”

This is a comment-only change; account weights and verification behavior are untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790619010&installation_model_id=15376&pr_number=8677&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8677&signature=d867aab6e1c11f9aa12303f0edaff38dd67ab1cba2da7022b463e8e4eae7b7b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the `TransactionVerifier` documentation comment.
  * Clarified the wording describing account weight requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->