### PR TITLE
[v0.51] [Flow EVM] Backport ExecutionErrorCode() fix (#8679)

### DIFF
--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -1844,7 +1844,7 @@ func TestEVMBatchRun(t *testing.T) {
 									assert(res.errorMessage == "", message: "unexpected error msg")
 								} else {
 									assert(res.status == EVM.Status.failed, message: "\(res.errorMessage)")
-									assert(res.errorCode == 400, message: "unexpected error code")
+									assert(res.errorCode == 301, message: "unexpected error code: \(res.errorCode)")
 								}
 							}
 						}

--- a/fvm/evm/offchain/sync/replay.go
+++ b/fvm/evm/offchain/sync/replay.go
@@ -166,10 +166,14 @@ func ValidateResult(
 		return fmt.Errorf("gas consumption mismatch %d != %d", res.GasConsumed, txEvent.GasConsumed)
 	}
 
-	// check error code
-	txEventErrorCode := types.ErrorCode(txEvent.ErrorCode)
-	if errorCode := res.ResultSummary().ErrorCode; errorCode != txEventErrorCode {
-		return fmt.Errorf("error code mismatch %d != %d", errorCode, txEventErrorCode)
+	// check tx status according to tx event error code
+	// If `txEvent.ErrorCode != 0`, the original tx had `failed`
+	// If `txEvent.ErrorCode == 0`, the original tx was `successful`
+	if res.Successful() && txEvent.ErrorCode != 0 {
+		return fmt.Errorf("tx status mismatch: expected %s, got %s", "failed", "successful")
+	}
+	if res.Failed() && txEvent.ErrorCode == 0 {
+		return fmt.Errorf("tx status mismatch: expected %s, got %s", "successful", "failed")
 	}
 
 	// check encoded logs

--- a/fvm/evm/types/codeFinder.go
+++ b/fvm/evm/types/codeFinder.go
@@ -68,8 +68,6 @@ func ExecutionErrorCode(err error) ErrorCode {
 		return ExecutionErrCodeContractAddressCollision
 	case errors.Is(err, gethVM.ErrExecutionReverted):
 		return ExecutionErrCodeExecutionReverted
-	case errors.Is(err, gethVM.ErrMaxInitCodeSizeExceeded):
-		return ExecutionErrCodeMaxInitCodeSizeExceeded
 	case errors.Is(err, gethVM.ErrMaxCodeSizeExceeded):
 		return ExecutionErrCodeMaxCodeSizeExceeded
 	case errors.Is(err, gethVM.ErrInvalidJump):

--- a/fvm/evm/types/codeFinder.go
+++ b/fvm/evm/types/codeFinder.go
@@ -54,35 +54,35 @@ func ValidationErrorCode(err error) ErrorCode {
 }
 
 func ExecutionErrorCode(err error) ErrorCode {
-	// execution VM errors are never wrapped
-	switch err {
-	case gethVM.ErrOutOfGas:
+	// the returned execution VM errors can be wrapped
+	switch {
+	case errors.Is(err, gethVM.ErrOutOfGas):
 		return ExecutionErrCodeOutOfGas
-	case gethVM.ErrCodeStoreOutOfGas:
+	case errors.Is(err, gethVM.ErrCodeStoreOutOfGas):
 		return ExecutionErrCodeCodeStoreOutOfGas
-	case gethVM.ErrDepth:
+	case errors.Is(err, gethVM.ErrDepth):
 		return ExecutionErrCodeDepth
-	case gethVM.ErrInsufficientBalance:
+	case errors.Is(err, gethVM.ErrInsufficientBalance):
 		return ExecutionErrCodeInsufficientBalance
-	case gethVM.ErrContractAddressCollision:
+	case errors.Is(err, gethVM.ErrContractAddressCollision):
 		return ExecutionErrCodeContractAddressCollision
-	case gethVM.ErrExecutionReverted:
+	case errors.Is(err, gethVM.ErrExecutionReverted):
 		return ExecutionErrCodeExecutionReverted
-	case gethVM.ErrMaxInitCodeSizeExceeded:
+	case errors.Is(err, gethVM.ErrMaxInitCodeSizeExceeded):
 		return ExecutionErrCodeMaxInitCodeSizeExceeded
-	case gethVM.ErrMaxCodeSizeExceeded:
+	case errors.Is(err, gethVM.ErrMaxCodeSizeExceeded):
 		return ExecutionErrCodeMaxCodeSizeExceeded
-	case gethVM.ErrInvalidJump:
+	case errors.Is(err, gethVM.ErrInvalidJump):
 		return ExecutionErrCodeInvalidJump
-	case gethVM.ErrWriteProtection:
+	case errors.Is(err, gethVM.ErrWriteProtection):
 		return ExecutionErrCodeWriteProtection
-	case gethVM.ErrReturnDataOutOfBounds:
+	case errors.Is(err, gethVM.ErrReturnDataOutOfBounds):
 		return ExecutionErrCodeReturnDataOutOfBounds
-	case gethVM.ErrGasUintOverflow:
+	case errors.Is(err, gethVM.ErrGasUintOverflow):
 		return ExecutionErrCodeGasUintOverflow
-	case gethVM.ErrInvalidCode:
+	case errors.Is(err, gethVM.ErrInvalidCode):
 		return ExecutionErrCodeInvalidCode
-	case gethVM.ErrNonceUintOverflow:
+	case errors.Is(err, gethVM.ErrNonceUintOverflow):
 		return ExecutionErrCodeNonceUintOverflow
 	default:
 		return ExecutionErrCodeMisc

--- a/fvm/evm/types/codeFinder_test.go
+++ b/fvm/evm/types/codeFinder_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	gethVM "github.com/ethereum/go-ethereum/core/vm"
 	gethParams "github.com/ethereum/go-ethereum/params"
+
 	"github.com/onflow/flow-go/fvm/evm/types"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_ExecutionErrorCode(t *testing.T) {

--- a/fvm/evm/types/codeFinder_test.go
+++ b/fvm/evm/types/codeFinder_test.go
@@ -1,0 +1,43 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	gethVM "github.com/ethereum/go-ethereum/core/vm"
+	gethParams "github.com/ethereum/go-ethereum/params"
+	"github.com/onflow/flow-go/fvm/evm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExecutionErrorCode(t *testing.T) {
+
+	t.Run("should handle unwrapped errors", func(t *testing.T) {
+		// plain unwrapped error
+		err := gethVM.ErrMaxCodeSizeExceeded
+
+		errorCode := types.ExecutionErrorCode(err)
+		require.Equal(
+			t,
+			types.ExecutionErrCodeMaxCodeSizeExceeded,
+			errorCode,
+		)
+	})
+
+	t.Run("should handle wrapped errors", func(t *testing.T) {
+		// wrapped error as returned by Geth
+		err := fmt.Errorf(
+			"%w: code size %v limit %v",
+			gethVM.ErrMaxCodeSizeExceeded,
+			15_000,
+			gethParams.MaxCodeSizeAmsterdam,
+		)
+
+		errorCode := types.ExecutionErrorCode(err)
+		require.Equal(
+			t,
+			types.ExecutionErrCodeMaxCodeSizeExceeded,
+			errorCode,
+		)
+	})
+}


### PR DESCRIPTION
Backports #8679 to the `v0.51` release branch.

Original issue: #8678

## Summary
- Fixes `ExecutionErrorCode()` to correctly recognize wrapped Geth VM errors (in addition to unwrapped ones), so failed EVM transactions report the correct execution error code.
- Removes `ErrMaxInitCodeSizeExceeded` from execution errors — it is a validation error.
- Adjusts transaction replay validation to avoid direct `errorCode` comparisons and instead detect mismatches between the transaction outcome and the recorded event status.
- Adds unit tests covering wrapped and unwrapped execution errors.

Produced in collaboration with claude.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950543&installation_model_id=15376&pr_number=8681&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8681&signature=bc1ffc671064034c118772c168d5a986b6c27d2bc6e4b38e236edf76a3fe1a8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->