### PR TITLE
Add access node beacon observability component from finalized blocks

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -41,6 +41,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/verification"
 	recovery "github.com/onflow/flow-go/consensus/recovery/protocol"
 	"github.com/onflow/flow-go/engine"
+	"github.com/onflow/flow-go/engine/access/beaconobservability"
 	"github.com/onflow/flow-go/engine/access/index"
 	"github.com/onflow/flow-go/engine/access/ingestion"
 	"github.com/onflow/flow-go/engine/access/ingestion/collections"
@@ -192,6 +193,7 @@ type AccessNodeConfig struct {
 	versionControlEnabled                bool
 	storeTxResultErrorMessages           bool
 	stopControlEnabled                   bool
+	beaconObservabilityEnabled           bool
 	registerDBPruneThreshold             uint64
 }
 
@@ -303,6 +305,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		versionControlEnabled:                true,
 		storeTxResultErrorMessages:           false,
 		stopControlEnabled:                   false,
+		beaconObservabilityEnabled:           false,
 		registerDBPruneThreshold:             0,
 	}
 }
@@ -1461,6 +1464,10 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"stop-control-enabled",
 			defaultConfig.stopControlEnabled,
 			"whether to enable the stop control feature. Default value is false")
+		flags.BoolVar(&builder.beaconObservabilityEnabled,
+			"beacon-observability-enabled",
+			defaultConfig.beaconObservabilityEnabled,
+			"whether to enable the beacon observability feature that exports per-proposer signature type metrics from finalized blocks. Default value is false")
 		// ExecutionDataRequester config
 		flags.BoolVar(&builder.executionDataSyncEnabled,
 			"execution-data-sync-enabled",
@@ -1880,6 +1887,7 @@ func (builder *FlowAccessNodeBuilder) enqueueRelayNetwork() {
 func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 	var processedFinalizedBlockHeightInitializer storage.ConsumerProgressInitializer
 	var processedTxErrorMessagesBlockHeightInitializer storage.ConsumerProgressInitializer
+	var processedBeaconObservabilityBlockHeightInitializer storage.ConsumerProgressInitializer
 
 	if builder.executionDataSyncEnabled {
 		builder.BuildExecutionSyncComponents()
@@ -2004,12 +2012,17 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			return nil
 		}).
 		Module("access metrics", func(node *cmd.NodeConfig) error {
-			builder.AccessMetrics = metrics.NewAccessCollector(
+			opts := []metrics.AccessCollectorOpts{
 				metrics.WithTransactionMetrics(builder.TransactionMetrics),
 				metrics.WithTransactionValidationMetrics(builder.TransactionValidationMetrics),
 				metrics.WithBackendScriptsMetrics(builder.TransactionMetrics),
 				metrics.WithRestMetrics(builder.RestMetrics),
-			)
+			}
+			if builder.beaconObservabilityEnabled {
+				opts = append(opts, metrics.WithBeaconObservabilityMetrics(
+					metrics.NewBeaconObservabilityCollector(node.MetricsRegisterer)))
+			}
+			builder.AccessMetrics = metrics.NewAccessCollector(opts...)
 			return nil
 		}).
 		Module("collection metrics", func(node *cmd.NodeConfig) error {
@@ -2105,6 +2118,13 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 		}).
 		Module("processed finalized block height consumer progress", func(node *cmd.NodeConfig) error {
 			processedFinalizedBlockHeightInitializer = store.NewConsumerProgress(builder.ProtocolDB, module.ConsumeProgressIngestionEngineBlockHeight)
+			return nil
+		}).
+		Module("processed beacon observability block height consumer progress", func(node *cmd.NodeConfig) error {
+			if !builder.beaconObservabilityEnabled {
+				return nil
+			}
+			processedBeaconObservabilityBlockHeightInitializer = store.NewConsumerProgress(builder.ProtocolDB, module.ConsumeProgressBeaconObservabilityBlockHeight)
 			return nil
 		}).
 		Module("processed last full block height monotonic consumer progress", func(node *cmd.NodeConfig) error {
@@ -2498,6 +2518,40 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			ingestionDependable.Init(builder.IngestEng)
 
 			return builder.IngestEng, nil
+		}).
+		Component("beacon observability", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+			if !builder.beaconObservabilityEnabled {
+				return &module.NoopReadyDoneAware{}, nil
+			}
+
+			// Start walking finalized blocks from the latest finalized block known at startup, so the
+			// component does not need to catch up from the root block. The progress index is initialized
+			// to one less than the latest finalized height so that the latest finalized block itself is
+			// the first job processed. For a node at the root block, progress starts at the root height.
+			rootHeight := node.SealedRootBlock.Height
+			startHeight := builder.Finalized.Height
+			if startHeight > rootHeight {
+				startHeight--
+			}
+			processedBeaconObservabilityBlockHeight, err := processedBeaconObservabilityBlockHeightInitializer.Initialize(startHeight)
+			if err != nil {
+				return nil, fmt.Errorf("could not initialize processed beacon observability block height: %w", err)
+			}
+
+			beaconObservability, err := beaconobservability.New(
+				node.Logger,
+				node.State,
+				node.Storage.Blocks,
+				builder.AccessMetrics,
+				processedBeaconObservabilityBlockHeight,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("could not create beacon observability component: %w", err)
+			}
+
+			node.ProtocolEvents.AddConsumer(beaconObservability)
+
+			return beaconObservability, nil
 		})
 
 	if builder.storeTxResultErrorMessages {

--- a/engine/access/beaconobservability/beacon_observability.go
+++ b/engine/access/beaconobservability/beacon_observability.go
@@ -1,0 +1,306 @@
+// Package beaconobservability implements an access node component that walks finalized blocks and
+// exports Prometheus metrics about the proposer signature types observed in each block. Under the
+// V2 consensus signature scheme, a 48-byte proposer signature indicates a staking-only (fallback)
+// proposal, while a 96-byte signature indicates a combined staking + random-beacon share proposal.
+// The component also tracks the random beacon threshold and committee membership at epoch boundaries.
+//
+// The metrics are raw facts only; alerting thresholds and derived ratios are intentionally left to
+// Prometheus recording rules.
+package beaconobservability
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/engine"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/filter"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/component"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/module/jobqueue"
+	"github.com/onflow/flow-go/module/signature"
+	"github.com/onflow/flow-go/module/util"
+	"github.com/onflow/flow-go/state/protocol"
+	psEvents "github.com/onflow/flow-go/state/protocol/events"
+	"github.com/onflow/flow-go/storage"
+)
+
+const (
+	// workersCount defines the number of workers that concurrently process finalized block jobs.
+	// Sequential processing is required because the metrics depend on block order.
+	workersCount = 1
+
+	// searchAhead defines how many blocks the job consumer may look ahead. A value of 1 keeps the
+	// consumer strictly sequential.
+	searchAhead = 1
+)
+
+const (
+	// sigTypeStaking is the label value for a bare staking-only proposer signature.
+	sigTypeStaking = "staking"
+	// sigTypeBeacon is the label value for a combined staking + beacon share proposer signature.
+	sigTypeBeacon = "beacon"
+)
+
+// BeaconObservability walks finalized blocks from local storage and exports raw facts about the
+// proposer signature type observed in each block. It also maintains per-committee-member metric
+// series and updates the random beacon threshold at epoch boundaries.
+//
+// The component is safe for concurrent use. It implements protocol.Consumer so that the protocol
+// events distributor can deliver epoch transition notifications.
+type BeaconObservability struct {
+	*component.ComponentManager
+	psEvents.Noop
+
+	log     zerolog.Logger
+	state   protocol.State
+	blocks  storage.Blocks
+	metrics module.BeaconObservabilityMetrics
+
+	finalizedBlockConsumer *jobqueue.ComponentConsumer
+	finalizedBlockNotifier engine.Notifier
+
+	epochEvents chan epochTransition
+
+	mu        sync.RWMutex
+	committee map[flow.Identifier]struct{}
+}
+
+// epochTransition carries the information needed to update committee membership on an epoch change.
+type epochTransition struct {
+	counter      uint64
+	firstBlockID flow.Identifier
+}
+
+var _ protocol.Consumer = (*BeaconObservability)(nil)
+var _ component.Component = (*BeaconObservability)(nil)
+
+// New creates a new BeaconObservability component.
+//
+// Expected error returns during normal operation:
+//   - [storage.ErrNotFound] if the current finalized state or a required proposal is unavailable
+//   - generic error in case of unexpected failure from the protocol state or storage layers
+func New(
+	log zerolog.Logger,
+	state protocol.State,
+	blocks storage.Blocks,
+	metrics module.BeaconObservabilityMetrics,
+	finalizedProcessedHeight storage.ConsumerProgress,
+) (*BeaconObservability, error) {
+	b := &BeaconObservability{
+		log:                    log.With().Str("component", "beacon_observability").Logger(),
+		state:                  state,
+		blocks:                 blocks,
+		metrics:                metrics,
+		finalizedBlockNotifier: engine.NewNotifier(),
+		epochEvents:            make(chan epochTransition, 1),
+		committee:              make(map[flow.Identifier]struct{}),
+	}
+
+	if err := b.initializeCommittee(); err != nil {
+		return nil, fmt.Errorf("could not initialize committee: %w", err)
+	}
+
+	finalizedBlockReader := jobqueue.NewFinalizedBlockReader(state, blocks)
+	var err error
+	b.finalizedBlockConsumer, err = jobqueue.NewComponentConsumer(
+		b.log.With().Str("module", "beacon_observability_block_consumer").Logger(),
+		b.finalizedBlockNotifier.Channel(),
+		finalizedProcessedHeight,
+		finalizedBlockReader,
+		b.processFinalizedBlockJob,
+		workersCount,
+		searchAhead,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not create finalized block consumer: %w", err)
+	}
+
+	builder := component.NewComponentManagerBuilder().
+		AddWorker(b.runFinalizedBlockConsumer).
+		AddWorker(b.handleEpochEvents)
+
+	b.ComponentManager = builder.Build()
+
+	return b, nil
+}
+
+// BlockFinalized is called by the protocol events distributor when a block is finalized. It notifies
+// the internal job queue consumer that a new finalized block is available for processing.
+func (b *BeaconObservability) BlockFinalized(h *flow.Header) {
+	b.finalizedBlockNotifier.Notify()
+}
+
+// EpochTransition is called by the protocol events distributor when the network transitions to a new
+// epoch. It queues the event for the internal epoch handling worker.
+func (b *BeaconObservability) EpochTransition(newEpochCounter uint64, first *flow.Header) {
+	select {
+	case b.epochEvents <- epochTransition{counter: newEpochCounter, firstBlockID: first.ID()}:
+	default:
+		b.log.Warn().
+			Uint64("epoch_counter", newEpochCounter).
+			Msg("epoch event channel full, dropping epoch transition event")
+	}
+}
+
+// handleEpochEvents is the worker goroutine that processes epoch transition events. It updates the
+// committee membership tracked by the component.
+//
+// No errors are expected during normal operation.
+func (b *BeaconObservability) handleEpochEvents(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+	ready()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt := <-b.epochEvents:
+			if err := b.updateCommitteeAtBlockID(evt.firstBlockID); err != nil {
+				ctx.Throw(fmt.Errorf("could not update committee for epoch %d: %w", evt.counter, err))
+				return
+			}
+		}
+	}
+}
+
+// runFinalizedBlockConsumer runs the job queue consumer that processes finalized blocks.
+//
+// No errors are expected during normal operation.
+func (b *BeaconObservability) runFinalizedBlockConsumer(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+	b.finalizedBlockConsumer.Start(ctx)
+
+	if err := util.WaitClosed(ctx, b.finalizedBlockConsumer.Ready()); err != nil {
+		return
+	}
+
+	ready()
+
+	<-b.finalizedBlockConsumer.Done()
+}
+
+// processFinalizedBlockJob processes a single finalized block job. It reads the corresponding
+// proposal from storage, classifies the proposer signature type, and updates the metrics.
+//
+// Expected error returns during normal operation:
+//   - [storage.ErrNotFound] if the proposal for the finalized block is not available in storage
+//   - generic error in case of unexpected failure from the storage layer
+func (b *BeaconObservability) processFinalizedBlockJob(ctx irrecoverable.SignalerContext, job module.Job, done func()) {
+	block, err := jobqueue.JobToBlock(job)
+	if err != nil {
+		ctx.Throw(fmt.Errorf("failed to convert job to block: %w", err))
+		return
+	}
+
+	proposal, err := b.blocks.ProposalByHeight(block.Height)
+	if err != nil {
+		ctx.Throw(fmt.Errorf("could not get proposal by height %d: %w", block.Height, err))
+		return
+	}
+
+	sigType, err := classifySigType(proposal.ProposerSigData)
+	if err != nil {
+		b.log.Warn().
+			Err(err).
+			Uint64("height", block.Height).
+			Hex("proposer_id", block.ToHeader().ProposerID[:]).
+			Msg("skipping block with non-V2 proposer signature")
+		done()
+		return
+	}
+
+	proposerID := block.ToHeader().ProposerID
+	b.metrics.NetworkFinalizedProposerSigType(proposerID, sigType)
+	b.metrics.NetworkFinalizedLastProposalHeight(proposerID, block.Height)
+
+	done()
+}
+
+// classifySigType classifies the proposer signature data as staking-only or combined based on its
+// length. This is the V2 discriminator: a bare BLS staking signature is 48 bytes, while a combined
+// staking + beacon share signature is 96 bytes.
+//
+// Expected error returns during normal operation:
+//   - [signature.ErrInvalidSignatureFormat] if the signature data length is neither 48 nor 96 bytes
+func classifySigType(sigData []byte) (string, error) {
+	switch len(sigData) {
+	case signature.SigLen:
+		return sigTypeStaking, nil
+	case 2 * signature.SigLen:
+		return sigTypeBeacon, nil
+	default:
+		return "", fmt.Errorf("unexpected proposer sig data length %d: %w", len(sigData), signature.ErrInvalidSignatureFormat)
+	}
+}
+
+// initializeCommittee reads the current consensus committee and DKG information from the finalized
+// protocol state and initializes the per-member metric series.
+//
+// Expected error returns during normal operation:
+//   - [storage.ErrNotFound] if the current epoch is not available
+//   - generic error in case of unexpected failure from the protocol state or storage layers
+func (b *BeaconObservability) initializeCommittee() error {
+	return b.updateCommitteeAtSnapshot(b.state.Final())
+}
+
+// updateCommitteeAtBlockID reads the consensus committee and DKG information from the protocol state
+// at the given block and updates the tracked membership.
+//
+// Expected error returns during normal operation:
+//   - [storage.ErrNotFound] if the epoch at the given block is not available
+//   - generic error in case of unexpected failure from the protocol state or storage layers
+func (b *BeaconObservability) updateCommitteeAtBlockID(blockID flow.Identifier) error {
+	return b.updateCommitteeAtSnapshot(b.state.AtBlockID(blockID))
+}
+
+// updateCommitteeAtSnapshot updates the tracked committee membership from the given protocol snapshot.
+// It deletes metric series for nodes that left the committee and pre-initializes series for new
+// members so that silent nodes remain visible in Prometheus.
+//
+// Expected error returns during normal operation:
+//   - [storage.ErrNotFound] if the current epoch is not available
+//   - generic error in case of unexpected failure from the protocol state or storage layers
+func (b *BeaconObservability) updateCommitteeAtSnapshot(snapshot protocol.Snapshot) error {
+	epoch, err := snapshot.Epochs().Current()
+	if err != nil {
+		return fmt.Errorf("could not get current epoch: %w", err)
+	}
+
+	dkg, err := epoch.DKG()
+	if err != nil {
+		return fmt.Errorf("could not get dkg: %w", err)
+	}
+
+	threshold := uint64(signature.RandomBeaconThreshold(int(dkg.Size())) + 1)
+	b.metrics.NetworkDKGBeaconThreshold(threshold)
+
+	identities := epoch.InitialIdentities()
+	committeeMembers := identities.Filter(filter.IsConsensusCommitteeMember)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	newCommittee := make(map[flow.Identifier]struct{}, len(committeeMembers))
+	for _, identity := range committeeMembers {
+		newCommittee[identity.NodeID] = struct{}{}
+	}
+
+	// Delete series for nodes that left the committee.
+	for nodeID := range b.committee {
+		if _, ok := newCommittee[nodeID]; !ok {
+			b.metrics.NetworkFinalizedDeleteProposerMetrics(nodeID)
+		}
+	}
+
+	// Pre-initialize series for new members so that silent nodes are visible in Prometheus.
+	for nodeID := range newCommittee {
+		if _, ok := b.committee[nodeID]; !ok {
+			b.metrics.NetworkFinalizedInitProposerMetrics(nodeID)
+		}
+	}
+
+	b.committee = newCommittee
+	return nil
+}

--- a/engine/access/beaconobservability/beacon_observability_test.go
+++ b/engine/access/beaconobservability/beacon_observability_test.go
@@ -1,0 +1,252 @@
+package beaconobservability
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/module/jobqueue"
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/signature"
+	protocolmock "github.com/onflow/flow-go/state/protocol/mock"
+	storagemock "github.com/onflow/flow-go/storage/mock"
+	"github.com/onflow/flow-go/storage/operation/pebbleimpl"
+	"github.com/onflow/flow-go/storage/store"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestClassifySigType(t *testing.T) {
+	t.Run("staking-only signature", func(t *testing.T) {
+		sigData := unittest.SignatureFixture()
+		require.Len(t, sigData, signature.SigLen)
+
+		sigType, err := classifySigType(sigData)
+		require.NoError(t, err)
+		require.Equal(t, sigTypeStaking, sigType)
+	})
+
+	t.Run("combined staking + beacon signature", func(t *testing.T) {
+		stakingSig := unittest.SignatureFixture()
+		beaconSig := unittest.SignatureFixture()
+		sigData := append(stakingSig, beaconSig...)
+		require.Len(t, sigData, 2*signature.SigLen)
+
+		sigType, err := classifySigType(sigData)
+		require.NoError(t, err)
+		require.Equal(t, sigTypeBeacon, sigType)
+	})
+
+	t.Run("unexpected length returns error", func(t *testing.T) {
+		sigData := make([]byte, signature.SigLen+1)
+
+		_, err := classifySigType(sigData)
+		require.Error(t, err)
+		require.ErrorIs(t, err, signature.ErrInvalidSignatureFormat)
+	})
+}
+
+func TestBeaconObservabilityCollector(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	collector := metrics.NewBeaconObservabilityCollector(registry)
+
+	nodeID := unittest.IdentifierFixture()
+
+	collector.NetworkFinalizedInitProposerMetrics(nodeID)
+	collector.NetworkFinalizedProposerSigType(nodeID, sigTypeBeacon)
+	collector.NetworkFinalizedProposerSigType(nodeID, sigTypeBeacon)
+	collector.NetworkFinalizedProposerSigType(nodeID, sigTypeStaking)
+	collector.NetworkFinalizedLastProposalHeight(nodeID, 42)
+	collector.NetworkDKGBeaconThreshold(6)
+
+	family, err := registry.Gather()
+	require.NoError(t, err)
+
+	metricMap := make(map[string]float64)
+	for _, fam := range family {
+		for _, m := range fam.Metric {
+			labels := labelString(m.GetLabel())
+			key := fam.GetName() + labels
+			metricMap[key] = m.GetCounter().GetValue()
+			if m.GetGauge() != nil {
+				metricMap[key] = m.GetGauge().GetValue()
+			}
+		}
+	}
+
+	require.Equal(t, 2.0, metricMap["network_finalized_proposer_sig_type_total{nodeid="+nodeID.String()+",type=beacon}"])
+	require.Equal(t, 1.0, metricMap["network_finalized_proposer_sig_type_total{nodeid="+nodeID.String()+",type=staking}"])
+	require.Equal(t, 42.0, metricMap["network_finalized_last_proposal_height{nodeid="+nodeID.String()+"}"])
+	require.Equal(t, 6.0, metricMap["network_finalized_dkg_beacon_threshold"])
+
+	collector.NetworkFinalizedDeleteProposerMetrics(nodeID)
+
+	family, err = registry.Gather()
+	require.NoError(t, err)
+
+	for _, fam := range family {
+		if fam.GetName() == "network_finalized_proposer_sig_type_total" ||
+			fam.GetName() == "network_finalized_last_proposal_height" {
+			for _, m := range fam.Metric {
+				for _, label := range m.GetLabel() {
+					if label.GetName() == "nodeid" && label.GetValue() == nodeID.String() {
+						t.Fatalf("metric series for deleted node should not exist: %s", fam.GetName())
+					}
+				}
+			}
+		}
+	}
+}
+
+func labelString(labels []*dto.LabelPair) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	result := "{"
+	for i, label := range labels {
+		if i > 0 {
+			result += ","
+		}
+		result += label.GetName() + "=" + label.GetValue()
+	}
+	result += "}"
+	return result
+}
+
+// mockMetrics is a minimal in-memory implementation of module.BeaconObservabilityMetrics for testing
+// the component without Prometheus.
+type mockMetrics struct {
+	proposerSigTypes    map[flow.Identifier]map[string]uint64
+	lastProposalHeights map[flow.Identifier]uint64
+	beaconThreshold     uint64
+	deletedNodeIDs      []flow.Identifier
+	initializedNodeIDs  []flow.Identifier
+}
+
+func newMockMetrics() *mockMetrics {
+	return &mockMetrics{
+		proposerSigTypes:    make(map[flow.Identifier]map[string]uint64),
+		lastProposalHeights: make(map[flow.Identifier]uint64),
+	}
+}
+
+func (m *mockMetrics) NetworkFinalizedProposerSigType(nodeID flow.Identifier, sigType string) {
+	if m.proposerSigTypes[nodeID] == nil {
+		m.proposerSigTypes[nodeID] = make(map[string]uint64)
+	}
+	m.proposerSigTypes[nodeID][sigType]++
+}
+
+func (m *mockMetrics) NetworkFinalizedLastProposalHeight(nodeID flow.Identifier, height uint64) {
+	m.lastProposalHeights[nodeID] = height
+}
+
+func (m *mockMetrics) NetworkDKGBeaconThreshold(threshold uint64) {
+	m.beaconThreshold = threshold
+}
+
+func (m *mockMetrics) NetworkFinalizedDeleteProposerMetrics(nodeID flow.Identifier) {
+	m.deletedNodeIDs = append(m.deletedNodeIDs, nodeID)
+	delete(m.proposerSigTypes, nodeID)
+	delete(m.lastProposalHeights, nodeID)
+}
+
+func (m *mockMetrics) NetworkFinalizedInitProposerMetrics(nodeID flow.Identifier) {
+	m.initializedNodeIDs = append(m.initializedNodeIDs, nodeID)
+}
+
+func newTestComponent(t *testing.T, state *protocolmock.State, blocks *storagemock.Blocks, metrics *mockMetrics) *BeaconObservability {
+	var component *BeaconObservability
+	var err error
+	unittest.RunWithPebbleDB(t, func(db *pebble.DB) {
+		processedHeight, initErr := store.NewConsumerProgress(pebbleimpl.ToDB(db), "test-beacon-obs").Initialize(0)
+		require.NoError(t, initErr)
+
+		component, err = New(zerolog.Nop(), state, blocks, metrics, processedHeight)
+	})
+	require.NoError(t, err)
+	return component
+}
+
+func TestProcessFinalizedBlockJob(t *testing.T) {
+	state := protocolmock.NewState(t)
+	snapshot := protocolmock.NewSnapshot(t)
+	epochQuery := protocolmock.NewEpochQuery(t)
+	committedEpoch := protocolmock.NewCommittedEpoch(t)
+	dkg := protocolmock.NewDKG(t)
+
+	state.On("Final").Return(snapshot).Maybe()
+	snapshot.On("Epochs").Return(epochQuery)
+	epochQuery.On("Current").Return(committedEpoch, nil)
+	committedEpoch.On("DKG").Return(dkg, nil)
+	dkg.On("Size").Return(uint(11))
+	committedEpoch.On("InitialIdentities").Return(flow.IdentitySkeletonList{}, nil)
+
+	blocks := storagemock.NewBlocks(t)
+	metrics := newMockMetrics()
+	component := newTestComponent(t, state, blocks, metrics)
+
+	nodeID := unittest.IdentifierFixture()
+	block := unittest.FullBlockFixture()
+	block.HeaderBody.ProposerID = nodeID
+
+	proposal := &flow.Proposal{
+		Block:           *block,
+		ProposerSigData: append(unittest.SignatureFixture(), unittest.SignatureFixture()...),
+	}
+
+	blocks.On("ProposalByHeight", block.Height).Return(proposal, nil)
+
+	ctx := irrecoverable.NewMockSignalerContext(t, t.Context())
+	job := jobqueue.BlockToJob(block)
+	doneCalled := false
+	done := func() { doneCalled = true }
+
+	component.processFinalizedBlockJob(ctx, job, done)
+
+	require.True(t, doneCalled)
+	require.Equal(t, uint64(1), metrics.proposerSigTypes[nodeID][sigTypeBeacon])
+	require.Equal(t, block.Height, metrics.lastProposalHeights[nodeID])
+}
+
+func TestUpdateCommitteeMembership(t *testing.T) {
+	state := protocolmock.NewState(t)
+	snapshot := protocolmock.NewSnapshot(t)
+	epochQuery := protocolmock.NewEpochQuery(t)
+	committedEpoch := protocolmock.NewCommittedEpoch(t)
+	dkg := protocolmock.NewDKG(t)
+
+	state.On("Final").Return(snapshot)
+	snapshot.On("Epochs").Return(epochQuery)
+	epochQuery.On("Current").Return(committedEpoch, nil)
+	committedEpoch.On("DKG").Return(dkg, nil)
+	dkg.On("Size").Return(uint(11))
+
+	nodeA := unittest.IdentityFixture(unittest.WithRole(flow.RoleConsensus))
+	nodeB := unittest.IdentityFixture(unittest.WithRole(flow.RoleConsensus))
+	nodeC := unittest.IdentityFixture(unittest.WithRole(flow.RoleCollection))
+
+	identities := flow.IdentitySkeletonList{
+		&nodeA.IdentitySkeleton,
+		&nodeB.IdentitySkeleton,
+		&nodeC.IdentitySkeleton,
+	}
+
+	committedEpoch.On("InitialIdentities").Return(identities, nil)
+
+	blocks := storagemock.NewBlocks(t)
+	metrics := newMockMetrics()
+	component := newTestComponent(t, state, blocks, metrics)
+
+	require.Equal(t, uint64(6), metrics.beaconThreshold) // RandomBeaconThreshold(11)+1 = 5+1
+	require.ElementsMatch(t, []flow.Identifier{nodeA.NodeID, nodeB.NodeID}, metrics.initializedNodeIDs)
+	require.Len(t, component.committee, 2)
+	require.Contains(t, component.committee, nodeA.NodeID)
+	require.Contains(t, component.committee, nodeB.NodeID)
+	require.NotContains(t, component.committee, nodeC.NodeID)
+}

--- a/module/jobqueue.go
+++ b/module/jobqueue.go
@@ -16,6 +16,7 @@ const (
 	ConsumeProgressIngestionEngineBlockHeight       = "ConsumeProgressIngestionEngineBlockHeight"
 	ConsumeProgressEngineTxErrorMessagesBlockHeight = "ConsumeProgressEngineTxErrorMessagesBlockHeight"
 	ConsumeProgressLastFullBlockHeight              = "ConsumeProgressLastFullBlockHeight"
+	ConsumeProgressBeaconObservabilityBlockHeight   = "ConsumeProgressBeaconObservabilityBlockHeight"
 )
 
 // JobID is a unique ID of the job.

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -951,12 +951,42 @@ type GRPCConnectionPoolMetrics interface {
 	ConnectionFromPoolEvicted()
 }
 
+// BeaconObservabilityMetrics encapsulates the metrics exported by the access node beacon observability
+// component. The component walks finalized blocks and exposes per-proposer signature type facts,
+// committee freshness gauges, and the random beacon threshold for the current epoch.
+//
+// All methods are safe for concurrent use.
+type BeaconObservabilityMetrics interface {
+	// NetworkFinalizedProposerSigType records a finalized block whose proposer signature was of the
+	// given type. The sigType is either "staking" (48-byte bare staking signature) or "beacon"
+	// (96-byte combined staking + beacon share signature).
+	NetworkFinalizedProposerSigType(nodeID flow.Identifier, sigType string)
+
+	// NetworkFinalizedLastProposalHeight updates the latest finalized block height at which the given
+	// node was observed as the proposer.
+	NetworkFinalizedLastProposalHeight(nodeID flow.Identifier, height uint64)
+
+	// NetworkDKGBeaconThreshold updates the random beacon threshold (t+1) for the current epoch.
+	NetworkDKGBeaconThreshold(threshold uint64)
+
+	// NetworkFinalizedDeleteProposerMetrics deletes the per-proposer metric series for the given node.
+	// It is used at epoch boundaries to remove series for nodes that left the consensus committee.
+	NetworkFinalizedDeleteProposerMetrics(nodeID flow.Identifier)
+
+	// NetworkFinalizedInitProposerMetrics pre-initializes the per-proposer metric series for the
+	// given node so that silent committee members are still visible in Prometheus.
+	NetworkFinalizedInitProposerMetrics(nodeID flow.Identifier)
+}
+
+// AccessMetrics is a composed interface of all metrics interfaces required by the access node.
+
 type AccessMetrics interface {
 	RestMetrics
 	GRPCConnectionPoolMetrics
 	TransactionMetrics
 	TransactionValidationMetrics
 	BackendScriptsMetrics
+	BeaconObservabilityMetrics
 
 	// UpdateExecutionReceiptMaxHeight is called whenever we store an execution receipt from a block from a newer height
 	UpdateExecutionReceiptMaxHeight(height uint64)

--- a/module/metrics/access.go
+++ b/module/metrics/access.go
@@ -34,11 +34,18 @@ func WithRestMetrics(m module.RestMetrics) AccessCollectorOpts {
 	}
 }
 
+func WithBeaconObservabilityMetrics(m module.BeaconObservabilityMetrics) AccessCollectorOpts {
+	return func(ac *AccessCollector) {
+		ac.BeaconObservabilityMetrics = m
+	}
+}
+
 type AccessCollector struct {
 	module.RestMetrics
 	module.TransactionMetrics
 	module.TransactionValidationMetrics
 	module.BackendScriptsMetrics
+	module.BeaconObservabilityMetrics
 
 	connectionReused              prometheus.Counter
 	connectionsInPool             *prometheus.GaugeVec
@@ -124,6 +131,10 @@ func NewAccessCollector(opts ...AccessCollectorOpts) *AccessCollector {
 
 	for _, opt := range opts {
 		opt(ac)
+	}
+
+	if ac.BeaconObservabilityMetrics == nil {
+		ac.BeaconObservabilityMetrics = NewNoopCollector()
 	}
 
 	return ac

--- a/module/metrics/beacon_observability.go
+++ b/module/metrics/beacon_observability.go
@@ -1,0 +1,100 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+)
+
+const (
+	// sigTypeStaking is the label value for a bare staking-only proposer signature.
+	sigTypeStaking = "staking"
+	// sigTypeBeacon is the label value for a combined staking + beacon share proposer signature.
+	sigTypeBeacon = "beacon"
+)
+
+// BeaconObservabilityCollector implements the Prometheus metrics exported by the access node
+// beacon observability component. It tracks proposer signature types observed in finalized blocks,
+// per-proposer freshness, and the random beacon threshold for the current epoch.
+//
+// All methods are safe for concurrent use.
+type BeaconObservabilityCollector struct {
+	proposerSigType    *prometheus.CounterVec
+	lastProposalHeight *prometheus.GaugeVec
+	beaconThreshold    prometheus.Gauge
+}
+
+var _ module.BeaconObservabilityMetrics = (*BeaconObservabilityCollector)(nil)
+
+// NewBeaconObservabilityCollector creates a new BeaconObservabilityCollector and registers the
+// metrics with the provided registerer.
+//
+// No errors are expected during normal operation.
+func NewBeaconObservabilityCollector(registerer prometheus.Registerer) *BeaconObservabilityCollector {
+	proposerSigType := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:      "proposer_sig_type_total",
+		Namespace: namespaceNetwork,
+		Subsystem: subsystemFinalized,
+		Help:      "counter for proposer signature types observed in finalized blocks",
+	}, []string{LabelNodeID, "type"})
+	lastProposalHeight := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "last_proposal_height",
+		Namespace: namespaceNetwork,
+		Subsystem: subsystemFinalized,
+		Help:      "gauge for the latest height at which each node proposed a finalized block",
+	}, []string{LabelNodeID})
+	beaconThreshold := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "dkg_beacon_threshold",
+		Namespace: namespaceNetwork,
+		Subsystem: subsystemFinalized,
+		Help:      "gauge for the random beacon threshold (t+1) in the current epoch",
+	})
+
+	registerer.MustRegister(
+		proposerSigType,
+		lastProposalHeight,
+		beaconThreshold,
+	)
+
+	return &BeaconObservabilityCollector{
+		proposerSigType:    proposerSigType,
+		lastProposalHeight: lastProposalHeight,
+		beaconThreshold:    beaconThreshold,
+	}
+}
+
+// NetworkFinalizedProposerSigType records a finalized block whose proposer signature was of the
+// given type.
+func (c *BeaconObservabilityCollector) NetworkFinalizedProposerSigType(nodeID flow.Identifier, sigType string) {
+	c.proposerSigType.WithLabelValues(nodeID.String(), sigType).Inc()
+}
+
+// NetworkFinalizedLastProposalHeight updates the latest finalized block height at which the given
+// node was observed as the proposer.
+func (c *BeaconObservabilityCollector) NetworkFinalizedLastProposalHeight(nodeID flow.Identifier, height uint64) {
+	c.lastProposalHeight.WithLabelValues(nodeID.String()).Set(float64(height))
+}
+
+// NetworkDKGBeaconThreshold updates the random beacon threshold (t+1) for the current epoch.
+func (c *BeaconObservabilityCollector) NetworkDKGBeaconThreshold(threshold uint64) {
+	c.beaconThreshold.Set(float64(threshold))
+}
+
+// NetworkFinalizedDeleteProposerMetrics deletes the per-proposer metric series for the given node.
+// It is used at epoch boundaries to remove series for nodes that left the consensus committee.
+func (c *BeaconObservabilityCollector) NetworkFinalizedDeleteProposerMetrics(nodeID flow.Identifier) {
+	nodeIDString := nodeID.String()
+	_ = c.proposerSigType.DeleteLabelValues(nodeIDString, sigTypeStaking)
+	_ = c.proposerSigType.DeleteLabelValues(nodeIDString, sigTypeBeacon)
+	_ = c.lastProposalHeight.DeleteLabelValues(nodeIDString)
+}
+
+// NetworkFinalizedInitProposerMetrics pre-initializes the per-proposer metric series for the given
+// node so that silent committee members are still visible in Prometheus.
+func (c *BeaconObservabilityCollector) NetworkFinalizedInitProposerMetrics(nodeID flow.Identifier) {
+	nodeIDString := nodeID.String()
+	c.proposerSigType.WithLabelValues(nodeIDString, sigTypeStaking).Add(0)
+	c.proposerSigType.WithLabelValues(nodeIDString, sigTypeBeacon).Add(0)
+	c.lastProposalHeight.WithLabelValues(nodeIDString).Set(0)
+}

--- a/module/metrics/namespaces.go
+++ b/module/metrics/namespaces.go
@@ -33,6 +33,11 @@ const (
 	subsystemSecurity     = "security"
 )
 
+// Finalized subsystems represent network-wide observability metrics derived from finalized blocks.
+const (
+	subsystemFinalized = "finalized"
+)
+
 // Storage subsystems represent the various components of the storage layer.
 const (
 	subsystemBadger  = "badger"

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -178,96 +178,101 @@ func (nc *NoopCollector) ExecutionBlockExecutionEffortVectorComponent(_ string, 
 func (nc *NoopCollector) ExecutionBlockCachedPrograms(programs int)                       {}
 func (nc *NoopCollector) ExecutionTransactionExecuted(_ time.Duration, _ module.TransactionExecutionResultStats, _ module.TransactionExecutionResultInfo) {
 }
-func (nc *NoopCollector) ExecutionChunkDataPackGenerated(_, _ int)                              {}
-func (nc *NoopCollector) ExecutionScriptExecuted(dur time.Duration, compUsed, _, _ uint64)      {}
-func (nc *NoopCollector) ExecutionScheduledTransactionsExecuted(int, uint64, uint64)            {}
-func (nc *NoopCollector) ForestApproxMemorySize(bytes uint64)                                   {}
-func (nc *NoopCollector) ForestNumberOfTrees(number uint64)                                     {}
-func (nc *NoopCollector) LatestTrieRegCount(number uint64)                                      {}
-func (nc *NoopCollector) LatestTrieRegCountDiff(number int64)                                   {}
-func (nc *NoopCollector) LatestTrieRegSize(size uint64)                                         {}
-func (nc *NoopCollector) LatestTrieRegSizeDiff(size int64)                                      {}
-func (nc *NoopCollector) LatestTrieMaxDepthTouched(maxDepth uint16)                             {}
-func (nc *NoopCollector) UpdateCount()                                                          {}
-func (nc *NoopCollector) ProofSize(bytes uint32)                                                {}
-func (nc *NoopCollector) UpdateValuesNumber(number uint64)                                      {}
-func (nc *NoopCollector) UpdateValuesSize(byte uint64)                                          {}
-func (nc *NoopCollector) UpdateDuration(duration time.Duration)                                 {}
-func (nc *NoopCollector) UpdateDurationPerItem(duration time.Duration)                          {}
-func (nc *NoopCollector) ReadValuesNumber(number uint64)                                        {}
-func (nc *NoopCollector) ReadValuesSize(byte uint64)                                            {}
-func (nc *NoopCollector) ReadDuration(duration time.Duration)                                   {}
-func (nc *NoopCollector) ReadDurationPerItem(duration time.Duration)                            {}
-func (nc *NoopCollector) ExecutionCollectionRequestSent()                                       {}
-func (nc *NoopCollector) RuntimeTransactionParsed(dur time.Duration)                            {}
-func (nc *NoopCollector) RuntimeTransactionChecked(dur time.Duration)                           {}
-func (nc *NoopCollector) RuntimeTransactionInterpreted(dur time.Duration)                       {}
-func (nc *NoopCollector) RuntimeSetNumberOfAccounts(count uint64)                               {}
-func (nc *NoopCollector) RuntimeTransactionProgramsCacheMiss()                                  {}
-func (nc *NoopCollector) RuntimeTransactionProgramsCacheHit()                                   {}
-func (nc *NoopCollector) SetNumberOfDeployedCOAs(_ uint64)                                      {}
-func (nc *NoopCollector) EVMTransactionExecuted(_ uint64, _ bool, _ bool)                       {}
-func (nc *NoopCollector) EVMBlockExecuted(_ int, _ uint64, _ float64)                           {}
-func (nc *NoopCollector) ScriptExecuted(dur time.Duration, size int)                            {}
-func (nc *NoopCollector) ScriptExecutionErrorLocal()                                            {}
-func (nc *NoopCollector) ScriptExecutionErrorOnExecutionNode()                                  {}
-func (nc *NoopCollector) ScriptExecutionResultMismatch()                                        {}
-func (nc *NoopCollector) ScriptExecutionResultMatch()                                           {}
-func (nc *NoopCollector) ScriptExecutionErrorMismatch()                                         {}
-func (nc *NoopCollector) ScriptExecutionErrorMatch()                                            {}
-func (nc *NoopCollector) ScriptExecutionNotIndexed()                                            {}
-func (nc *NoopCollector) TransactionResultFetched(dur time.Duration, size int)                  {}
-func (nc *NoopCollector) TransactionReceived(txID flow.Identifier, when time.Time)              {}
-func (nc *NoopCollector) TransactionFinalized(txID flow.Identifier, when time.Time)             {}
-func (nc *NoopCollector) TransactionSealed(txID flow.Identifier, when time.Time)                {}
-func (nc *NoopCollector) TransactionExecuted(txID flow.Identifier, when time.Time)              {}
-func (nc *NoopCollector) TransactionExpired(txID flow.Identifier)                               {}
-func (nc *NoopCollector) TransactionValidated()                                                 {}
-func (nc *NoopCollector) TransactionValidationFailed(reason string)                             {}
-func (nc *NoopCollector) TransactionValidationSkipped()                                         {}
-func (nc *NoopCollector) TransactionSubmissionFailed()                                          {}
-func (nc *NoopCollector) UpdateExecutionReceiptMaxHeight(height uint64)                         {}
-func (nc *NoopCollector) UpdateLastFullBlockHeight(height uint64)                               {}
-func (nc *NoopCollector) UpdateIngestionFinalizedBlockHeight(height uint64)                     {}
-func (nc *NoopCollector) ChunkDataPackRequestProcessed()                                        {}
-func (nc *NoopCollector) ExecutionSync(syncing bool)                                            {}
-func (nc *NoopCollector) ExecutionBlockDataUploadStarted()                                      {}
-func (nc *NoopCollector) ExecutionBlockDataUploadFinished(dur time.Duration)                    {}
-func (nc *NoopCollector) ExecutionComputationResultUploaded()                                   {}
-func (nc *NoopCollector) ExecutionComputationResultUploadRetried()                              {}
-func (nc *NoopCollector) RootIDComputed(duration time.Duration, numberOfChunks int)             {}
-func (nc *NoopCollector) AddBlobsSucceeded(duration time.Duration, totalSize uint64)            {}
-func (nc *NoopCollector) AddBlobsFailed()                                                       {}
-func (nc *NoopCollector) FulfilledHeight(blockHeight uint64)                                    {}
-func (nc *NoopCollector) ReceiptSkipped()                                                       {}
-func (nc *NoopCollector) RequestSucceeded(uint64, time.Duration, uint64, int)                   {}
-func (nc *NoopCollector) RequestFailed(duration time.Duration, retryable bool)                  {}
-func (nc *NoopCollector) RequestCanceled()                                                      {}
-func (nc *NoopCollector) ResponseDropped()                                                      {}
-func (nc *NoopCollector) Pruned(height uint64, duration time.Duration)                          {}
-func (nc *NoopCollector) UpdateCollectionMaxHeight(height uint64)                               {}
-func (nc *NoopCollector) BucketAvailableSlots(uint64, uint64)                                   {}
-func (nc *NoopCollector) OnKeyPutSuccess(uint32)                                                {}
-func (nc *NoopCollector) OnEntityEjectionDueToFullCapacity()                                    {}
-func (nc *NoopCollector) OnEntityEjectionDueToEmergency()                                       {}
-func (nc *NoopCollector) OnKeyGetSuccess()                                                      {}
-func (nc *NoopCollector) OnKeyGetFailure()                                                      {}
-func (nc *NoopCollector) OnKeyPutAttempt(uint32)                                                {}
-func (nc *NoopCollector) OnKeyPutDrop()                                                         {}
-func (nc *NoopCollector) OnKeyPutDeduplicated()                                                 {}
-func (nc *NoopCollector) OnKeyRemoved(uint32)                                                   {}
-func (nc *NoopCollector) ExecutionDataFetchStarted()                                            {}
-func (nc *NoopCollector) ExecutionDataFetchFinished(_ time.Duration, _ bool, _ uint64)          {}
-func (nc *NoopCollector) NotificationSent(height uint64)                                        {}
-func (nc *NoopCollector) FetchRetried()                                                         {}
-func (nc *NoopCollector) RoutingTablePeerAdded()                                                {}
-func (nc *NoopCollector) RoutingTablePeerRemoved()                                              {}
-func (nc *NoopCollector) PrunedBlockById(status *chainsync.Status)                              {}
-func (nc *NoopCollector) PrunedBlockByHeight(status *chainsync.Status)                          {}
-func (nc *NoopCollector) PrunedBlocks(totalByHeight, totalById, storedByHeight, storedById int) {}
-func (nc *NoopCollector) RangeRequested(ran chainsync.Range)                                    {}
-func (nc *NoopCollector) BatchRequested(batch chainsync.Batch)                                  {}
-func (nc *NoopCollector) OnUnauthorizedMessage(role, msgType, topic, offense string)            {}
+func (nc *NoopCollector) ExecutionChunkDataPackGenerated(_, _ int)                                 {}
+func (nc *NoopCollector) ExecutionScriptExecuted(dur time.Duration, compUsed, _, _ uint64)         {}
+func (nc *NoopCollector) ExecutionScheduledTransactionsExecuted(int, uint64, uint64)               {}
+func (nc *NoopCollector) ForestApproxMemorySize(bytes uint64)                                      {}
+func (nc *NoopCollector) ForestNumberOfTrees(number uint64)                                        {}
+func (nc *NoopCollector) LatestTrieRegCount(number uint64)                                         {}
+func (nc *NoopCollector) LatestTrieRegCountDiff(number int64)                                      {}
+func (nc *NoopCollector) LatestTrieRegSize(size uint64)                                            {}
+func (nc *NoopCollector) LatestTrieRegSizeDiff(size int64)                                         {}
+func (nc *NoopCollector) LatestTrieMaxDepthTouched(maxDepth uint16)                                {}
+func (nc *NoopCollector) UpdateCount()                                                             {}
+func (nc *NoopCollector) ProofSize(bytes uint32)                                                   {}
+func (nc *NoopCollector) UpdateValuesNumber(number uint64)                                         {}
+func (nc *NoopCollector) UpdateValuesSize(byte uint64)                                             {}
+func (nc *NoopCollector) UpdateDuration(duration time.Duration)                                    {}
+func (nc *NoopCollector) UpdateDurationPerItem(duration time.Duration)                             {}
+func (nc *NoopCollector) ReadValuesNumber(number uint64)                                           {}
+func (nc *NoopCollector) ReadValuesSize(byte uint64)                                               {}
+func (nc *NoopCollector) ReadDuration(duration time.Duration)                                      {}
+func (nc *NoopCollector) ReadDurationPerItem(duration time.Duration)                               {}
+func (nc *NoopCollector) ExecutionCollectionRequestSent()                                          {}
+func (nc *NoopCollector) RuntimeTransactionParsed(dur time.Duration)                               {}
+func (nc *NoopCollector) RuntimeTransactionChecked(dur time.Duration)                              {}
+func (nc *NoopCollector) RuntimeTransactionInterpreted(dur time.Duration)                          {}
+func (nc *NoopCollector) RuntimeSetNumberOfAccounts(count uint64)                                  {}
+func (nc *NoopCollector) RuntimeTransactionProgramsCacheMiss()                                     {}
+func (nc *NoopCollector) RuntimeTransactionProgramsCacheHit()                                      {}
+func (nc *NoopCollector) SetNumberOfDeployedCOAs(_ uint64)                                         {}
+func (nc *NoopCollector) EVMTransactionExecuted(_ uint64, _ bool, _ bool)                          {}
+func (nc *NoopCollector) EVMBlockExecuted(_ int, _ uint64, _ float64)                              {}
+func (nc *NoopCollector) ScriptExecuted(dur time.Duration, size int)                               {}
+func (nc *NoopCollector) ScriptExecutionErrorLocal()                                               {}
+func (nc *NoopCollector) ScriptExecutionErrorOnExecutionNode()                                     {}
+func (nc *NoopCollector) ScriptExecutionResultMismatch()                                           {}
+func (nc *NoopCollector) ScriptExecutionResultMatch()                                              {}
+func (nc *NoopCollector) ScriptExecutionErrorMismatch()                                            {}
+func (nc *NoopCollector) ScriptExecutionErrorMatch()                                               {}
+func (nc *NoopCollector) ScriptExecutionNotIndexed()                                               {}
+func (nc *NoopCollector) TransactionResultFetched(dur time.Duration, size int)                     {}
+func (nc *NoopCollector) TransactionReceived(txID flow.Identifier, when time.Time)                 {}
+func (nc *NoopCollector) TransactionFinalized(txID flow.Identifier, when time.Time)                {}
+func (nc *NoopCollector) TransactionSealed(txID flow.Identifier, when time.Time)                   {}
+func (nc *NoopCollector) TransactionExecuted(txID flow.Identifier, when time.Time)                 {}
+func (nc *NoopCollector) TransactionExpired(txID flow.Identifier)                                  {}
+func (nc *NoopCollector) TransactionValidated()                                                    {}
+func (nc *NoopCollector) TransactionValidationFailed(reason string)                                {}
+func (nc *NoopCollector) TransactionValidationSkipped()                                            {}
+func (nc *NoopCollector) TransactionSubmissionFailed()                                             {}
+func (nc *NoopCollector) UpdateExecutionReceiptMaxHeight(height uint64)                            {}
+func (nc *NoopCollector) UpdateLastFullBlockHeight(height uint64)                                  {}
+func (nc *NoopCollector) UpdateIngestionFinalizedBlockHeight(height uint64)                        {}
+func (nc *NoopCollector) NetworkFinalizedProposerSigType(nodeID flow.Identifier, sigType string)   {}
+func (nc *NoopCollector) NetworkFinalizedLastProposalHeight(nodeID flow.Identifier, height uint64) {}
+func (nc *NoopCollector) NetworkDKGBeaconThreshold(threshold uint64)                               {}
+func (nc *NoopCollector) NetworkFinalizedDeleteProposerMetrics(nodeID flow.Identifier)             {}
+func (nc *NoopCollector) NetworkFinalizedInitProposerMetrics(nodeID flow.Identifier)               {}
+func (nc *NoopCollector) ChunkDataPackRequestProcessed()                                           {}
+func (nc *NoopCollector) ExecutionSync(syncing bool)                                               {}
+func (nc *NoopCollector) ExecutionBlockDataUploadStarted()                                         {}
+func (nc *NoopCollector) ExecutionBlockDataUploadFinished(dur time.Duration)                       {}
+func (nc *NoopCollector) ExecutionComputationResultUploaded()                                      {}
+func (nc *NoopCollector) ExecutionComputationResultUploadRetried()                                 {}
+func (nc *NoopCollector) RootIDComputed(duration time.Duration, numberOfChunks int)                {}
+func (nc *NoopCollector) AddBlobsSucceeded(duration time.Duration, totalSize uint64)               {}
+func (nc *NoopCollector) AddBlobsFailed()                                                          {}
+func (nc *NoopCollector) FulfilledHeight(blockHeight uint64)                                       {}
+func (nc *NoopCollector) ReceiptSkipped()                                                          {}
+func (nc *NoopCollector) RequestSucceeded(uint64, time.Duration, uint64, int)                      {}
+func (nc *NoopCollector) RequestFailed(duration time.Duration, retryable bool)                     {}
+func (nc *NoopCollector) RequestCanceled()                                                         {}
+func (nc *NoopCollector) ResponseDropped()                                                         {}
+func (nc *NoopCollector) Pruned(height uint64, duration time.Duration)                             {}
+func (nc *NoopCollector) UpdateCollectionMaxHeight(height uint64)                                  {}
+func (nc *NoopCollector) BucketAvailableSlots(uint64, uint64)                                      {}
+func (nc *NoopCollector) OnKeyPutSuccess(uint32)                                                   {}
+func (nc *NoopCollector) OnEntityEjectionDueToFullCapacity()                                       {}
+func (nc *NoopCollector) OnEntityEjectionDueToEmergency()                                          {}
+func (nc *NoopCollector) OnKeyGetSuccess()                                                         {}
+func (nc *NoopCollector) OnKeyGetFailure()                                                         {}
+func (nc *NoopCollector) OnKeyPutAttempt(uint32)                                                   {}
+func (nc *NoopCollector) OnKeyPutDrop()                                                            {}
+func (nc *NoopCollector) OnKeyPutDeduplicated()                                                    {}
+func (nc *NoopCollector) OnKeyRemoved(uint32)                                                      {}
+func (nc *NoopCollector) ExecutionDataFetchStarted()                                               {}
+func (nc *NoopCollector) ExecutionDataFetchFinished(_ time.Duration, _ bool, _ uint64)             {}
+func (nc *NoopCollector) NotificationSent(height uint64)                                           {}
+func (nc *NoopCollector) FetchRetried()                                                            {}
+func (nc *NoopCollector) RoutingTablePeerAdded()                                                   {}
+func (nc *NoopCollector) RoutingTablePeerRemoved()                                                 {}
+func (nc *NoopCollector) PrunedBlockById(status *chainsync.Status)                                 {}
+func (nc *NoopCollector) PrunedBlockByHeight(status *chainsync.Status)                             {}
+func (nc *NoopCollector) PrunedBlocks(totalByHeight, totalById, storedByHeight, storedById int)    {}
+func (nc *NoopCollector) RangeRequested(ran chainsync.Range)                                       {}
+func (nc *NoopCollector) BatchRequested(batch chainsync.Batch)                                     {}
+func (nc *NoopCollector) OnUnauthorizedMessage(role, msgType, topic, offense string)               {}
 func (nc *NoopCollector) ObserveHTTPRequestDuration(context.Context, httpmetrics.HTTPReqProperties, time.Duration) {
 }
 func (nc *NoopCollector) ObserveHTTPResponseSize(context.Context, httpmetrics.HTTPReqProperties, int64) {


### PR DESCRIPTION
Fix https://github.com/onflow/flow-go/issues/8686

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791148227&installation_model_id=15376&pr_number=8687&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8687&signature=3a92cd5f9d7aab31eece515f482330a66f3637e043c81f0cfc30793b3edbb029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->