### PR TITLE
fix(ledger/partial/ptrie): reject structurally inconsistent proofs in NewPSMT

### DIFF
--- a/ledger/partial/ptrie/partialTrie.go
+++ b/ledger/partial/ptrie/partialTrie.go
@@ -2,11 +2,35 @@ package ptrie
 
 import (
 	"fmt"
+	"math/bits"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/bitutils"
 	"github.com/onflow/flow-go/ledger/common/hash"
 )
+
+// countFlagBits returns the number of bits set in the first `steps` bits of
+// `flags` (big-endian bit ordering, matching bitutils.ReadBit). It returns an
+// error if `flags` does not contain enough bytes to cover `steps` bits.
+func countFlagBits(flags []byte, steps uint8) (int, error) {
+	if int(steps) > len(flags)*8 {
+		return 0, fmt.Errorf("flags (%d bytes) only cover %d bits but proof has %d steps", len(flags), len(flags)*8, steps)
+	}
+
+	fullBytes := int(steps / 8)
+	remainder := int(steps % 8)
+
+	count := 0
+	for i := range fullBytes {
+		count += bits.OnesCount8(flags[i])
+	}
+	if remainder > 0 {
+		// big-endian: the first `remainder` bits are the high bits of the byte.
+		mask := byte(0xFF << (8 - remainder))
+		count += bits.OnesCount8(flags[fullBytes] & mask)
+	}
+	return count, nil
+}
 
 // PSMT (Partial Sparse Merkle Tree) holds a subset of an sparse merkle tree at specific
 // state (no historic views). Instead of keeping any unneeded branch, it only keeps
@@ -93,6 +117,17 @@ func NewPSMT(
 		}
 		path := pr.Path
 		payload := pr.Payload
+
+		// Validate structural consistency of the proof before indexing into
+		// Flags or Interims. A malformed proof (e.g. from a byzantine Execution
+		// Node) must be rejected with an error instead of panicking.
+		flagCount, err := countFlagBits(pr.Flags, pr.Steps)
+		if err != nil {
+			return nil, fmt.Errorf("proof at index %d has invalid flags: %w", i, err)
+		}
+		if flagCount != len(pr.Interims) {
+			return nil, fmt.Errorf("proof at index %d has %d flag bits set but %d interims", i, flagCount, len(pr.Interims))
+		}
 
 		// we process the path, bit by bit, until we reach the end of the proof (due to compactness)
 		prValueIndex := 0        // we keep track of our progress through proofs by prValueIndex

--- a/ledger/partial/ptrie/partialTrie_test.go
+++ b/ledger/partial/ptrie/partialTrie_test.go
@@ -417,6 +417,67 @@ func TestRandomProofs(t *testing.T) {
 	}
 }
 
+// TestMalformedProofRejected verifies that structurally inconsistent
+// Steps/Flags/Interims fields in a ledger.TrieProof are rejected by NewPSMT
+// with an error instead of panicking. A byzantine Execution Node can craft such
+// proofs, and a Verification Node must not crash while processing them.
+func TestMalformedProofRejected(t *testing.T) {
+	root := ledger.RootHash(ledger.GetDefaultHashForHeight(ledger.NodeMaxHeight))
+	path := testutils.PathByUint16(0)
+	payload := testutils.LightPayload('A', 'a')
+
+	t.Run("steps exceed flags length", func(t *testing.T) {
+		proof := &ledger.TrieProof{
+			Steps:     8,
+			Flags:     []byte{},
+			Path:      path,
+			Payload:   payload,
+			Inclusion: true,
+			Interims:  nil,
+		}
+		batchProof := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{proof}}
+
+		psmt, err := NewPSMT(root, batchProof)
+		require.Error(t, err)
+		require.Nil(t, psmt)
+	})
+
+	t.Run("set flags exceed interims length", func(t *testing.T) {
+		// One flag byte covers 8 steps, but all 8 bits are set while no
+		// interims are supplied. This triggers the popcount-vs-interims check
+		// after the flags-length check has passed.
+		proof := &ledger.TrieProof{
+			Steps:     8,
+			Flags:     []byte{0xFF},
+			Path:      path,
+			Payload:   payload,
+			Inclusion: true,
+			Interims:  nil,
+		}
+		batchProof := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{proof}}
+
+		psmt, err := NewPSMT(root, batchProof)
+		require.Error(t, err)
+		require.Nil(t, psmt)
+	})
+
+	t.Run("no panic on malformed proof", func(t *testing.T) {
+		proof := &ledger.TrieProof{
+			Steps:     8,
+			Flags:     []byte{},
+			Path:      path,
+			Payload:   payload,
+			Inclusion: true,
+			Interims:  nil,
+		}
+		batchProof := &ledger.TrieBatchProof{Proofs: []*ledger.TrieProof{proof}}
+
+		require.NotPanics(t, func() {
+			_, _ = NewPSMT(root, batchProof)
+		})
+	})
+}
+
 // TODO add test for incompatible proofs [Byzantine milestone]
 // TODO add test key not exist [Byzantine milestone]
 


### PR DESCRIPTION
## Problem
A malformed `ledger.TrieProof` with inconsistent `Steps`/`Flags`/`Interims` fields could panic `NewPSMT` when `bitutils.ReadBit` indexed past the end of `Flags` or when `Interims` was indexed without enough elements.

## Changes
- Add `countFlagBits` helper to count set flag bits in the first `Steps` bits and detect insufficient `Flags` length.
- Validate each proof's structural consistency before walking it.
- Return an error instead of panicking.
- Move the regression tests into the existing `partialTrie_test.go` file.

## Labels
Bug, Protocol

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791157937&installation_model_id=15376&pr_number=8692&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8692&signature=0b5ed94a8c6b3259b163f23ac09c42b71921de1c5b59b2da79ef4d27f80f7359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed trie proofs are now rejected with a clear error instead of causing crashes or out-of-range access.
  - Structural inconsistencies between proof steps, flags, and intermediate data are detected before processing.

- **Tests**
  - Added coverage for malformed proofs, including oversized steps, insufficient intermediate data, and panic prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->