### PR TITLE
Validate participant roles in IsValidEpochSetup

### DIFF
--- a/state/protocol/validity.go
+++ b/state/protocol/validity.go
@@ -59,6 +59,7 @@ func IsValidEpochSetup(setup *flow.EpochSetup, verifyNetworkAddress bool) error 
 	// (a) each has a unique node ID,
 	// (b) each has a unique network address (if `verifyNetworkAddress` is true),
 	// (c) participants are sorted in canonical order.
+	// (d) each has a valid role.
 	//     Note that the system smart contracts manage the identity table as an unordered set! For the protocol state, we desire a fixed
 	//     ordering to simplify various implementation details, like the DKG. Therefore, we order identities in `flow.EpochSetup` during
 	//     conversion from cadence to Go in the function `convert.ServiceEvent(flow.ChainID, flow.Event)` in package `model/convert`
@@ -84,6 +85,13 @@ func IsValidEpochSetup(setup *flow.EpochSetup, verifyNetworkAddress bool) error 
 
 	if !setup.Participants.Sorted(flow.Canonical[flow.IdentitySkeleton]) { // (c) enforce canonical ordering
 		return fmt.Errorf("participants are not canonically ordered")
+	}
+
+	// (d) each participant has a valid role
+	for _, participant := range setup.Participants {
+		if !participant.Role.Valid() {
+			return fmt.Errorf("invalid participant role (%d) for node (%x)", participant.Role, participant.NodeID)
+		}
 	}
 
 	// 3. CHECK: Enforce sufficient number of nodes for each role

--- a/state/protocol/validity_test.go
+++ b/state/protocol/validity_test.go
@@ -68,6 +68,22 @@ func TestEpochSetupValidity(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("invalid participant role", func(t *testing.T) {
+		_, result, _ := unittest.BootstrapFixture(participants)
+		setup := result.ServiceEvents[0].Event.(*flow.EpochSetup)
+
+		// mutate a consensus node (not a collector, so cluster assignment stays valid)
+		for i, p := range setup.Participants {
+			if p.Role == flow.RoleConsensus {
+				setup.Participants[i].Role = flow.Role(42)
+				break
+			}
+		}
+
+		err := protocol.IsValidEpochSetup(setup, true)
+		require.Error(t, err)
+	})
+
 	t.Run("network addresses are not unique", func(t *testing.T) {
 		_, result, _ := unittest.BootstrapFixture(participants)
 		setup := result.ServiceEvents[0].Event.(*flow.EpochSetup)


### PR DESCRIPTION
## Problem
`IsValidEpochSetup` already checked that an EpochSetup has enough active nodes for each known role, but it never rejected participants whose `Role` field was not a valid `flow.Role`. An invalid role (e.g. 0 or 42) would be accepted as long as the real roles were still represented, and later code paths that call `Role.String()` would panic on the bogus value.

## Changes
- Add a defense-in-depth check that calls `Role.Valid()` for every participant and rejects the setup with an error if any participant has an invalid role.
- Add a regression test that mutates a consensus participant to an invalid role and asserts that `IsValidEpochSetup` returns an error.

Labels: Bug, S-Epochs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791159294&installation_model_id=15376&pr_number=8693&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8693&signature=e56fb99e7674a441098cd0d01e7de04d2a527825dbeaec283e8268c7d14c7b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Epoch setup validation now rejects participants with invalid roles.
  * Validation errors identify the invalid role and associated node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->