### PR TITLE
[Networking] Report message decode failures on staked channels to ALSP

### DIFF
--- a/network/underlay/network.go
+++ b/network/underlay/network.go
@@ -1271,6 +1271,14 @@ func (n *Network) processAuthenticatedMessage(msg *message.Message, peerID peer.
 		}
 		id, ok := n.Identity(peerID)
 		if !ok {
+			// On a staked channel the peer has already cleared sender authorization, so a
+			// missing identity here means it vanished between those checks and now. Log as
+			// suspicious rather than silently skipping the ALSP report.
+			n.logger.Warn().
+				Str("peer_id", p2plogging.PeerId(peerID)).
+				Str("channel", channel.String()).
+				Bool(logging.KeySuspicious, true).
+				Msg("could not resolve identity of authenticated peer on staked channel")
 			return nil
 		}
 		return id

--- a/network/underlay/network.go
+++ b/network/underlay/network.go
@@ -1260,19 +1260,35 @@ func (n *Network) processAuthenticatedMessage(msg *message.Message, peerID peer.
 	}
 
 	channel := channels.Channel(msg.ChannelID)
+
+	// identity lazily resolves the full identity of the authenticated peer for staked channels.
+	// The lookup is deferred so it only runs on violation paths; the slashing consumer uses a nil
+	// Identity to skip ALSP reporting on public channels, where identities are not treated as
+	// staked participants.
+	identity := func() *flow.Identity {
+		if channels.IsPublicChannel(channel) {
+			return nil
+		}
+		id, ok := n.Identity(peerID)
+		if !ok {
+			return nil
+		}
+		return id
+	}
+
 	decodedMsgPayload, err := n.codec.Decode(msg.Payload)
 	switch {
 	case codec.IsErrUnknownMsgCode(err):
 		// slash peer if message contains unknown message code byte
 		violation := &network.Violation{
-			PeerID: p2plogging.PeerId(peerID), OriginID: originId, Channel: channel, Protocol: protocol, Err: err,
+			Identity: identity(), PeerID: p2plogging.PeerId(peerID), OriginID: originId, Channel: channel, Protocol: protocol, Err: err,
 		}
 		n.slashingViolationsConsumer.OnUnknownMsgTypeError(violation)
 		return
 	case codec.IsErrMsgUnmarshal(err) || codec.IsErrInvalidEncoding(err):
 		// slash if peer sent a message that could not be marshalled into the message type denoted by the message code byte
 		violation := &network.Violation{
-			PeerID: p2plogging.PeerId(peerID), OriginID: originId, Channel: channel, Protocol: protocol, Err: err,
+			Identity: identity(), PeerID: p2plogging.PeerId(peerID), OriginID: originId, Channel: channel, Protocol: protocol, Err: err,
 		}
 		n.slashingViolationsConsumer.OnInvalidMsgError(violation)
 		return
@@ -1282,7 +1298,7 @@ func (n *Network) processAuthenticatedMessage(msg *message.Message, peerID peer.
 		// collect slashing data because this could potentially lead to slashing
 		err = fmt.Errorf("unexpected error during message validation: %w", err)
 		violation := &network.Violation{
-			PeerID: p2plogging.PeerId(peerID), OriginID: originId, Channel: channel, Protocol: protocol, Err: err,
+			Identity: identity(), PeerID: p2plogging.PeerId(peerID), OriginID: originId, Channel: channel, Protocol: protocol, Err: err,
 		}
 		n.slashingViolationsConsumer.OnUnexpectedError(violation)
 		return
@@ -1292,7 +1308,7 @@ func (n *Network) processAuthenticatedMessage(msg *message.Message, peerID peer.
 	if err != nil {
 		err = fmt.Errorf("failed to convert message to internal: %w", err)
 		violation := &network.Violation{
-			PeerID: p2plogging.PeerId(peerID), OriginID: originId, Channel: channel, Protocol: protocol, Err: err,
+			Identity: identity(), PeerID: p2plogging.PeerId(peerID), OriginID: originId, Channel: channel, Protocol: protocol, Err: err,
 		}
 		n.slashingViolationsConsumer.OnInvalidMsgError(violation)
 		return

--- a/network/underlay/network_test.go
+++ b/network/underlay/network_test.go
@@ -1,18 +1,27 @@
 package underlay
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/messages"
 	modulemock "github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/network"
+	"github.com/onflow/flow-go/network/alsp"
+	"github.com/onflow/flow-go/network/channels"
+	"github.com/onflow/flow-go/network/codec"
+	"github.com/onflow/flow-go/network/codec/cbor"
 	"github.com/onflow/flow-go/network/message"
 	mockmsg "github.com/onflow/flow-go/network/mock"
 	p2plogging "github.com/onflow/flow-go/network/p2p/logging"
+	"github.com/onflow/flow-go/network/slashing"
 	"github.com/onflow/flow-go/network/validator"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -144,4 +153,137 @@ func TestGetAuthorizedIdentity_ActivePeer(t *testing.T) {
 	identity, ok := net.getAuthorizedIdentity(log, remotePeerID)
 	require.True(t, ok)
 	require.Equal(t, activeIdentity, identity)
+}
+
+// stubIDTranslator implements the p2p.IDTranslator interface used by the Network for tests.
+// It only needs to translate a peer ID back to the configured Flow ID.
+type stubIDTranslator struct {
+	id flow.Identifier
+}
+
+func (t stubIDTranslator) GetPeerID(_ flow.Identifier) (peer.ID, error) {
+	return "", nil
+}
+
+func (t stubIDTranslator) GetFlowID(_ peer.ID) (flow.Identifier, error) {
+	return t.id, nil
+}
+
+// TestProcessAuthenticatedMessage_ReportsDecodeFailureOnStakedChannel verifies that a staked peer
+// sending a message with a valid message-code byte but an undecodable payload is reported to ALSP
+// so that a penalty can be applied.
+func TestProcessAuthenticatedMessage_ReportsDecodeFailureOnStakedChannel(t *testing.T) {
+	attackerIdentity := unittest.IdentityFixture(
+		unittest.WithRole(flow.RoleConsensus),
+		unittest.WithParticipationStatus(flow.EpochParticipationStatusActive),
+	)
+	attackerPeerID := unittest.PeerIdFixture(t)
+	channel := channels.ConsensusCommittee
+
+	// A valid message-code byte followed by undecodable CBOR garbage. This passes the
+	// authorized-sender check (which only looks at the code byte) but fails codec.Decode.
+	payload := append([]byte{codec.CodeBlockProposal.Uint8()}, bytes.Repeat([]byte{0xFF}, 32)...)
+
+	reportConsumer := mockmsg.NewMisbehaviorReportConsumer(t)
+	var reported []network.MisbehaviorReport
+	reportConsumer.On("ReportMisbehaviorOnChannel", channel, mock.Anything).
+		Run(func(args mock.Arguments) {
+			reported = append(reported, args.Get(1).(network.MisbehaviorReport))
+		}).
+		Once()
+
+	metrics := modulemock.NewNetworkSecurityMetrics(t)
+	metrics.On("OnUnauthorizedMessage", attackerIdentity.Role.String(), "unknown", channel.String(), alsp.InvalidMessage.String()).Once()
+
+	idProvider := modulemock.NewIdentityProvider(t)
+	idProvider.On("ByPeerID", attackerPeerID).Return(attackerIdentity, true).Once()
+
+	net := &Network{
+		logger:                     unittest.Logger(),
+		identityProvider:           idProvider,
+		identityTranslator:         stubIDTranslator{id: attackerIdentity.NodeID},
+		codec:                      cbor.NewCodec(),
+		slashingViolationsConsumer: slashing.NewSlashingViolationsConsumer(unittest.Logger(), metrics, reportConsumer),
+	}
+
+	net.processAuthenticatedMessage(&message.Message{ChannelID: channel.String(), Payload: payload}, attackerPeerID, message.ProtocolTypePubSub)
+
+	require.Len(t, reported, 1, "ALSP report must be submitted for a staked peer that sends an undecodable message")
+	require.Equal(t, attackerIdentity.NodeID, reported[0].OriginId())
+	require.Equal(t, alsp.InvalidMessage, reported[0].Reason())
+}
+
+// TestProcessAuthenticatedMessage_ReportsToInternalFailureOnStakedChannel verifies that a staked
+// peer sending well-formed CBOR that fails structural validation in ToInternal (e.g. a proposal
+// with a zero parent ID) is also reported to ALSP.
+func TestProcessAuthenticatedMessage_ReportsToInternalFailureOnStakedChannel(t *testing.T) {
+	attackerIdentity := unittest.IdentityFixture(
+		unittest.WithRole(flow.RoleConsensus),
+		unittest.WithParticipationStatus(flow.EpochParticipationStatusActive),
+	)
+	attackerPeerID := unittest.PeerIdFixture(t)
+	channel := channels.ConsensusCommittee
+
+	// Well-formed CBOR that decodes into a proposal but fails structural validation
+	// (empty proposer signature). The payload must carry the message-code byte.
+	cborCodec := cbor.NewCodec()
+	encodedProposal, err := cborCodec.Encode(&messages.Proposal{})
+	require.NoError(t, err)
+	payload := append([]byte{codec.CodeBlockProposal.Uint8()}, encodedProposal...)
+
+	reportConsumer := mockmsg.NewMisbehaviorReportConsumer(t)
+	var reported []network.MisbehaviorReport
+	reportConsumer.On("ReportMisbehaviorOnChannel", channel, mock.Anything).
+		Run(func(args mock.Arguments) {
+			reported = append(reported, args.Get(1).(network.MisbehaviorReport))
+		}).
+		Once()
+
+	metrics := modulemock.NewNetworkSecurityMetrics(t)
+	metrics.On("OnUnauthorizedMessage", attackerIdentity.Role.String(), "unknown", channel.String(), alsp.InvalidMessage.String()).Once()
+
+	idProvider := modulemock.NewIdentityProvider(t)
+	idProvider.On("ByPeerID", attackerPeerID).Return(attackerIdentity, true).Once()
+
+	net := &Network{
+		logger:                     unittest.Logger(),
+		identityProvider:           idProvider,
+		identityTranslator:         stubIDTranslator{id: attackerIdentity.NodeID},
+		codec:                      cbor.NewCodec(),
+		slashingViolationsConsumer: slashing.NewSlashingViolationsConsumer(unittest.Logger(), metrics, reportConsumer),
+	}
+
+	net.processAuthenticatedMessage(&message.Message{ChannelID: channel.String(), Payload: payload}, attackerPeerID, message.ProtocolTypePubSub)
+
+	require.Len(t, reported, 1, "ALSP report must be submitted for a staked peer that sends a structurally invalid message")
+	require.Equal(t, attackerIdentity.NodeID, reported[0].OriginId())
+	require.Equal(t, alsp.InvalidMessage, reported[0].Reason())
+}
+
+// TestProcessAuthenticatedMessage_SkipsPublicChannelDecodeFailure verifies that decode failures on
+// public channels are not reported to ALSP, preserving the existing exemption for the public network.
+func TestProcessAuthenticatedMessage_SkipsPublicChannelDecodeFailure(t *testing.T) {
+	peerID := unittest.PeerIdFixture(t)
+	channel := channels.PublicReceiveBlocks
+
+	// Same undecodable payload as the staked-channel test.
+	payload := append([]byte{codec.CodeBlockProposal.Uint8()}, bytes.Repeat([]byte{0xFF}, 32)...)
+
+	reportConsumer := mockmsg.NewMisbehaviorReportConsumer(t)
+	// No ReportMisbehaviorOnChannel expectation: mock strictness is the assertion that the
+	// violation must be skipped for public channels.
+
+	metrics := modulemock.NewNetworkSecurityMetrics(t)
+	metrics.On("OnUnauthorizedMessage", "unknown", "unknown", channel.String(), alsp.InvalidMessage.String()).Once()
+	metrics.On("OnViolationReportSkipped").Once()
+
+	net := &Network{
+		logger:                     unittest.Logger(),
+		identityProvider:           modulemock.NewIdentityProvider(t),
+		identityTranslator:         stubIDTranslator{id: unittest.IdentifierFixture()},
+		codec:                      cbor.NewCodec(),
+		slashingViolationsConsumer: slashing.NewSlashingViolationsConsumer(unittest.Logger(), metrics, reportConsumer),
+	}
+
+	net.processAuthenticatedMessage(&message.Message{ChannelID: channel.String(), Payload: payload}, peerID, message.ProtocolTypePubSub)
 }

--- a/network/underlay/network_test.go
+++ b/network/underlay/network_test.go
@@ -169,6 +169,24 @@ func (t stubIDTranslator) GetFlowID(_ peer.ID) (flow.Identifier, error) {
 	return t.id, nil
 }
 
+// newTestNetwork returns a Network with the minimal field set needed to drive
+// processAuthenticatedMessage in tests.
+func newTestNetwork(
+	t *testing.T,
+	idProvider *modulemock.IdentityProvider,
+	metrics *modulemock.NetworkSecurityMetrics,
+	reportConsumer *mockmsg.MisbehaviorReportConsumer,
+	originID flow.Identifier,
+) *Network {
+	return &Network{
+		logger:                     unittest.Logger(),
+		identityProvider:           idProvider,
+		identityTranslator:         stubIDTranslator{id: originID},
+		codec:                      cbor.NewCodec(),
+		slashingViolationsConsumer: slashing.NewSlashingViolationsConsumer(unittest.Logger(), metrics, reportConsumer),
+	}
+}
+
 // TestProcessAuthenticatedMessage_ReportsDecodeFailureOnStakedChannel verifies that a staked peer
 // sending a message with a valid message-code byte but an undecodable payload is reported to ALSP
 // so that a penalty can be applied.
@@ -198,13 +216,7 @@ func TestProcessAuthenticatedMessage_ReportsDecodeFailureOnStakedChannel(t *test
 	idProvider := modulemock.NewIdentityProvider(t)
 	idProvider.On("ByPeerID", attackerPeerID).Return(attackerIdentity, true).Once()
 
-	net := &Network{
-		logger:                     unittest.Logger(),
-		identityProvider:           idProvider,
-		identityTranslator:         stubIDTranslator{id: attackerIdentity.NodeID},
-		codec:                      cbor.NewCodec(),
-		slashingViolationsConsumer: slashing.NewSlashingViolationsConsumer(unittest.Logger(), metrics, reportConsumer),
-	}
+	net := newTestNetwork(t, idProvider, metrics, reportConsumer, attackerIdentity.NodeID)
 
 	net.processAuthenticatedMessage(&message.Message{ChannelID: channel.String(), Payload: payload}, attackerPeerID, message.ProtocolTypePubSub)
 
@@ -214,8 +226,8 @@ func TestProcessAuthenticatedMessage_ReportsDecodeFailureOnStakedChannel(t *test
 }
 
 // TestProcessAuthenticatedMessage_ReportsToInternalFailureOnStakedChannel verifies that a staked
-// peer sending well-formed CBOR that fails structural validation in ToInternal (e.g. a proposal
-// with a zero parent ID) is also reported to ALSP.
+// peer sending well-formed CBOR that decodes successfully but fails structural validation in
+// ToInternal (e.g. a proposal with an empty chain ID) is also reported to ALSP.
 func TestProcessAuthenticatedMessage_ReportsToInternalFailureOnStakedChannel(t *testing.T) {
 	attackerIdentity := unittest.IdentityFixture(
 		unittest.WithRole(flow.RoleConsensus),
@@ -224,12 +236,19 @@ func TestProcessAuthenticatedMessage_ReportsToInternalFailureOnStakedChannel(t *
 	attackerPeerID := unittest.PeerIdFixture(t)
 	channel := channels.ConsensusCommittee
 
-	// Well-formed CBOR that decodes into a proposal but fails structural validation
-	// (empty proposer signature). The payload must carry the message-code byte.
+	// Well-formed CBOR that decodes into a proposal but fails structural validation in
+	// ToInternal (the empty proposal has an empty chain ID). Codec.Encode already prepends
+	// the message-code byte, so no manual prepend here.
 	cborCodec := cbor.NewCodec()
-	encodedProposal, err := cborCodec.Encode(&messages.Proposal{})
+	payload, err := cborCodec.Encode(&messages.Proposal{})
 	require.NoError(t, err)
-	payload := append([]byte{codec.CodeBlockProposal.Uint8()}, encodedProposal...)
+
+	// Pin the payload's properties: it must decode cleanly and fail in ToInternal, otherwise
+	// this test silently covers the unmarshal branch instead.
+	decoded, err := cborCodec.Decode(payload)
+	require.NoError(t, err, "payload must decode; this test covers the ToInternal branch")
+	_, err = decoded.ToInternal()
+	require.Error(t, err, "payload must fail structural validation in ToInternal")
 
 	reportConsumer := mockmsg.NewMisbehaviorReportConsumer(t)
 	var reported []network.MisbehaviorReport
@@ -245,13 +264,7 @@ func TestProcessAuthenticatedMessage_ReportsToInternalFailureOnStakedChannel(t *
 	idProvider := modulemock.NewIdentityProvider(t)
 	idProvider.On("ByPeerID", attackerPeerID).Return(attackerIdentity, true).Once()
 
-	net := &Network{
-		logger:                     unittest.Logger(),
-		identityProvider:           idProvider,
-		identityTranslator:         stubIDTranslator{id: attackerIdentity.NodeID},
-		codec:                      cbor.NewCodec(),
-		slashingViolationsConsumer: slashing.NewSlashingViolationsConsumer(unittest.Logger(), metrics, reportConsumer),
-	}
+	net := newTestNetwork(t, idProvider, metrics, reportConsumer, attackerIdentity.NodeID)
 
 	net.processAuthenticatedMessage(&message.Message{ChannelID: channel.String(), Payload: payload}, attackerPeerID, message.ProtocolTypePubSub)
 
@@ -277,13 +290,7 @@ func TestProcessAuthenticatedMessage_SkipsPublicChannelDecodeFailure(t *testing.
 	metrics.On("OnUnauthorizedMessage", "unknown", "unknown", channel.String(), alsp.InvalidMessage.String()).Once()
 	metrics.On("OnViolationReportSkipped").Once()
 
-	net := &Network{
-		logger:                     unittest.Logger(),
-		identityProvider:           modulemock.NewIdentityProvider(t),
-		identityTranslator:         stubIDTranslator{id: unittest.IdentifierFixture()},
-		codec:                      cbor.NewCodec(),
-		slashingViolationsConsumer: slashing.NewSlashingViolationsConsumer(unittest.Logger(), metrics, reportConsumer),
-	}
+	net := newTestNetwork(t, modulemock.NewIdentityProvider(t), metrics, reportConsumer, unittest.IdentifierFixture())
 
 	net.processAuthenticatedMessage(&message.Message{ChannelID: channel.String(), Payload: payload}, peerID, message.ProtocolTypePubSub)
 }


### PR DESCRIPTION
Messages received on staked channels that fail to decode, or that fail structural validation in `ToInternal`, were not being reported to the application-layer spam prevention manager because the violation carried a nil `Identity`.

Changes:
- In `processAuthenticatedMessage`, populate `Violation.Identity` for all four decode/validation failure branches (unknown message code, unmarshal/invalid encoding, unexpected decode error, and `ToInternal` failure).
- The identity lookup is done lazily via a closure so it only runs on violation paths, not on the hot path for well-formed messages.
- Public channels keep the nil `Identity`, preserving the existing exemption where the slashing consumer skips reporting.

Tests added to `network/underlay/network_test.go` covering:
- Undecodable payload on a staked channel is reported to ALSP.
- Well-formed CBOR that fails `ToInternal` structural validation on a staked channel is reported to ALSP.
- Decode failure on a public channel is skipped (not reported).

The related nil-identity sites on the unicast path (`handleIncomingStream` no-subscription and max-size branches) are left for a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791583087&installation_model_id=15376&pr_number=8696&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8696&signature=7c9d4dac1a49325067d768398c31513f84276e965987d2ba8394094260d79824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security violation reporting for invalid or undecodable messages on staked channels by including the peer’s identity.
  - Public-channel decode failures continue to be excluded from security violation reporting while still being recorded in security metrics.

- **Tests**
  - Added coverage for invalid payloads, structural validation failures, and public-channel behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->