### PR TITLE
Roll back dedup cache entry when inbound queue insertion fails

### DIFF
--- a/module/metrics.go
+++ b/module/metrics.go
@@ -411,6 +411,8 @@ type NetworkCoreMetrics interface {
 	InboundMessageReceived(sizeBytes int, topic string, protocol string, messageType string)
 	// DuplicateInboundMessagesDropped increments the metric tracking the number of duplicate messages dropped by the node.
 	DuplicateInboundMessagesDropped(topic string, protocol string, messageType string)
+	// QueueFullInboundMessagesDropped increments the metric tracking the number of inbound messages dropped because the queue is full.
+	QueueFullInboundMessagesDropped(topic string, protocol string, messageType string)
 	// UnicastMessageSendingStarted increments the metric tracking the number of unicast messages sent by the node.
 	UnicastMessageSendingStarted(topic string)
 	// UnicastMessageSendingCompleted decrements the metric tracking the number of unicast messages sent by the node.

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -33,6 +33,7 @@ type NetworkCollector struct {
 	outboundMessageSize          *prometheus.HistogramVec
 	inboundMessageSize           *prometheus.HistogramVec
 	duplicateMessagesDropped     *prometheus.CounterVec
+	queueFullMessagesDropped     *prometheus.CounterVec
 	queueSize                    *prometheus.GaugeVec
 	queueDuration                *prometheus.HistogramVec
 	numMessagesProcessing        *prometheus.GaugeVec
@@ -108,6 +109,15 @@ func NewNetworkCollector(logger zerolog.Logger, opts ...NetworkCollectorOpt) *Ne
 			Subsystem: subsystemGossip,
 			Name:      nc.prefix + "duplicate_messages_dropped",
 			Help:      "number of duplicate messages dropped",
+		}, []string{LabelChannel, LabelProtocol, LabelMessage},
+	)
+
+	nc.queueFullMessagesDropped = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespaceNetwork,
+			Subsystem: subsystemGossip,
+			Name:      nc.prefix + "queue_full_messages_dropped",
+			Help:      "number of inbound messages dropped because the queue is full",
 		}, []string{LabelChannel, LabelProtocol, LabelMessage},
 	)
 
@@ -276,6 +286,12 @@ func (nc *NetworkCollector) InboundMessageReceived(sizeBytes int, topic, protoco
 // Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
 func (nc *NetworkCollector) DuplicateInboundMessagesDropped(topic, protocol, messageType string) {
 	nc.duplicateMessagesDropped.WithLabelValues(channels.NormalizeTopicForMetrics(topic), protocol, messageType).Add(1)
+}
+
+// QueueFullInboundMessagesDropped increments the metric tracking the number of inbound messages dropped because the queue is full.
+// Cluster topics are normalized to their prefix to prevent unbounded cardinality growth.
+func (nc *NetworkCollector) QueueFullInboundMessagesDropped(topic, protocol, messageType string) {
+	nc.queueFullMessagesDropped.WithLabelValues(channels.NormalizeTopicForMetrics(topic), protocol, messageType).Add(1)
 }
 
 func (nc *NetworkCollector) MessageAdded(priority int) {

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -28,6 +28,7 @@ func NewNoopCollector() *NoopCollector {
 func (nc *NoopCollector) OutboundMessageSent(int, string, string, string)        {}
 func (nc *NoopCollector) InboundMessageReceived(int, string, string, string)     {}
 func (nc *NoopCollector) DuplicateInboundMessagesDropped(string, string, string) {}
+func (nc *NoopCollector) QueueFullInboundMessagesDropped(string, string, string) {}
 func (nc *NoopCollector) UnicastMessageSendingStarted(topic string)              {}
 func (nc *NoopCollector) UnicastMessageSendingCompleted(topic string)            {}
 func (nc *NoopCollector) BlockProposed(*flow.Block)                              {}

--- a/module/mock/network_core_metrics.go
+++ b/module/mock/network_core_metrics.go
@@ -619,6 +619,58 @@ func (_c *NetworkCoreMetrics_QueueDuration_Call) RunAndReturn(run func(duration 
 	return _c
 }
 
+// QueueFullInboundMessagesDropped provides a mock function for the type NetworkCoreMetrics
+func (_mock *NetworkCoreMetrics) QueueFullInboundMessagesDropped(topic string, protocol string, messageType string) {
+	_mock.Called(topic, protocol, messageType)
+	return
+}
+
+// NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueueFullInboundMessagesDropped'
+type NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call struct {
+	*mock.Call
+}
+
+// QueueFullInboundMessagesDropped is a helper method to define mock.On call
+//   - topic string
+//   - protocol string
+//   - messageType string
+func (_e *NetworkCoreMetrics_Expecter) QueueFullInboundMessagesDropped(topic interface{}, protocol interface{}, messageType interface{}) *NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call {
+	return &NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call{Call: _e.mock.On("QueueFullInboundMessagesDropped", topic, protocol, messageType)}
+}
+
+func (_c *NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call) Run(run func(topic string, protocol string, messageType string)) *NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call) Return() *NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call) RunAndReturn(run func(topic string, protocol string, messageType string)) *NetworkCoreMetrics_QueueFullInboundMessagesDropped_Call {
+	_c.Run(run)
+	return _c
+}
+
 // UnicastMessageSendingCompleted provides a mock function for the type NetworkCoreMetrics
 func (_mock *NetworkCoreMetrics) UnicastMessageSendingCompleted(topic string) {
 	_mock.Called(topic)

--- a/module/mock/network_metrics.go
+++ b/module/mock/network_metrics.go
@@ -4074,6 +4074,58 @@ func (_c *NetworkMetrics_QueueDuration_Call) RunAndReturn(run func(duration time
 	return _c
 }
 
+// QueueFullInboundMessagesDropped provides a mock function for the type NetworkMetrics
+func (_mock *NetworkMetrics) QueueFullInboundMessagesDropped(topic string, protocol1 string, messageType string) {
+	_mock.Called(topic, protocol1, messageType)
+	return
+}
+
+// NetworkMetrics_QueueFullInboundMessagesDropped_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueueFullInboundMessagesDropped'
+type NetworkMetrics_QueueFullInboundMessagesDropped_Call struct {
+	*mock.Call
+}
+
+// QueueFullInboundMessagesDropped is a helper method to define mock.On call
+//   - topic string
+//   - protocol1 string
+//   - messageType string
+func (_e *NetworkMetrics_Expecter) QueueFullInboundMessagesDropped(topic interface{}, protocol1 interface{}, messageType interface{}) *NetworkMetrics_QueueFullInboundMessagesDropped_Call {
+	return &NetworkMetrics_QueueFullInboundMessagesDropped_Call{Call: _e.mock.On("QueueFullInboundMessagesDropped", topic, protocol1, messageType)}
+}
+
+func (_c *NetworkMetrics_QueueFullInboundMessagesDropped_Call) Run(run func(topic string, protocol1 string, messageType string)) *NetworkMetrics_QueueFullInboundMessagesDropped_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *NetworkMetrics_QueueFullInboundMessagesDropped_Call) Return() *NetworkMetrics_QueueFullInboundMessagesDropped_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *NetworkMetrics_QueueFullInboundMessagesDropped_Call) RunAndReturn(run func(topic string, protocol1 string, messageType string)) *NetworkMetrics_QueueFullInboundMessagesDropped_Call {
+	_c.Run(run)
+	return _c
+}
+
 // RoutingTablePeerAdded provides a mock function for the type NetworkMetrics
 func (_mock *NetworkMetrics) RoutingTablePeerAdded() {
 	_mock.Called()

--- a/network/cache/rcvcache.go
+++ b/network/cache/rcvcache.go
@@ -47,3 +47,8 @@ func NewReceiveCache(sizeLimit uint, opts ...func(cache *ReceiveCache)) *Receive
 func (r *ReceiveCache) Add(eventID []byte) bool {
 	return r.Backend.Add(flow.HashToID(eventID), struct{}{}) // ignore eviction status
 }
+
+// Remove removes the eventID from the cache. Returns true if the eventID was present and removed, false otherwise.
+func (r *ReceiveCache) Remove(eventID []byte) bool {
+	return r.Backend.Remove(flow.HashToID(eventID))
+}

--- a/network/cache/rcvcache_test.go
+++ b/network/cache/rcvcache_test.go
@@ -62,6 +62,21 @@ func (r *ReceiveCacheTestSuite) TestSingleElementAdd() {
 	assert.False(r.Suite.T(), r.c.Add(eventID3))
 }
 
+// TestRemove verifies that an event ID can be explicitly removed from the cache,
+// allowing future messages with the same event ID to be added again.
+func (r *ReceiveCacheTestSuite) TestRemove() {
+	eventID, err := message.EventId(channels.Channel("0"), []byte("event-1"))
+	require.NoError(r.T(), err)
+
+	assert.True(r.Suite.T(), r.c.Add(eventID))
+	assert.False(r.Suite.T(), r.c.Add(eventID))
+
+	assert.True(r.Suite.T(), r.c.Remove(eventID))
+	assert.False(r.Suite.T(), r.c.Remove(eventID))
+
+	assert.True(r.Suite.T(), r.c.Add(eventID))
+}
+
 // TestNoneExistence evaluates the correctness of cache operation against non-existing element
 func (r *ReceiveCacheTestSuite) TestNoneExistence() {
 	eventID, err := message.EventId(channels.Channel("1"), []byte("non-existing event"))

--- a/network/underlay/network.go
+++ b/network/underlay/network.go
@@ -615,6 +615,18 @@ func (n *Network) processNetworkMessage(msg network.IncomingMessageScope) error 
 	// insert the message in the queue
 	err := n.queue.Insert(qm)
 	if err != nil {
+		// Roll back the dedup cache entry so that a later retransmission of the same
+		// payload is not dropped as a duplicate because of a momentary queue-full
+		// window. The goroutine that successfully added the event ID exclusively owns
+		// the entry until this removal, so this cannot remove another goroutine's entry.
+		n.receiveCache.Remove(msg.EventID())
+
+		if errors.Is(err, queue.ErrQueueFull) {
+			// Queue-full drops are back-pressure events; record a metric so they are
+			// observable instead of only logged.
+			n.metrics.QueueFullInboundMessagesDropped(msg.Channel().String(), msg.Protocol().String(), msg.PayloadType())
+		}
+
 		return fmt.Errorf("failed to insert message in queue: %w", err)
 	}
 

--- a/network/underlay/network_test.go
+++ b/network/underlay/network_test.go
@@ -1,6 +1,7 @@
 package underlay
 
 import (
+	"context"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -8,11 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/metrics"
 	modulemock "github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/network"
+	netcache "github.com/onflow/flow-go/network/cache"
+	"github.com/onflow/flow-go/network/channels"
 	"github.com/onflow/flow-go/network/message"
 	mockmsg "github.com/onflow/flow-go/network/mock"
 	p2plogging "github.com/onflow/flow-go/network/p2p/logging"
+	"github.com/onflow/flow-go/network/queue"
 	"github.com/onflow/flow-go/network/validator"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -144,4 +149,79 @@ func TestGetAuthorizedIdentity_ActivePeer(t *testing.T) {
 	identity, ok := net.getAuthorizedIdentity(log, remotePeerID)
 	require.True(t, ok)
 	require.Equal(t, activeIdentity, identity)
+}
+
+// TestProcessNetworkMessage_QueueFullDropRollsBackDedupCache verifies that when a message is
+// dropped because the inbound queue is full, its dedup cache entry is rolled back, so a later
+// retransmission of the same payload is accepted. The dedup event ID is sender-independent
+// (a hash of channel and payload), so a stale entry would drop identical payloads from any sender.
+func TestProcessNetworkMessage_QueueFullDropRollsBackDedupCache(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel) // unblocks the queue's shutdown goroutine
+
+	metricsCollector := modulemock.NewNetworkCoreMetrics(t)
+
+	// Only the fields touched by processNetworkMessage (receiveCache, queue, metrics, logger)
+	// are needed; this mirrors a Network built with MessageQueueSize=1.
+	n := &Network{
+		logger:       zerolog.Nop(),
+		metrics:      metricsCollector,
+		receiveCache: netcache.NewReceiveCache(1000),
+		queue:        queue.NewMessageQueue(ctx, queue.GetEventPriority, metrics.NewNoopCollector(), 1),
+	}
+
+	channel := channels.ConsensusCommittee
+	payload := []byte("dropped-then-retransmitted-payload")
+
+	// Two scopes carrying the identical channel+payload but from different origins:
+	// originA's delivery attempt hits the queue-full window; originB is a different,
+	// honest publisher retransmitting the same payload afterwards.
+	newScope := func(origin flow.Identifier, p []byte) *message.IncomingMessageScope {
+		scope, err := message.NewIncomingScope(
+			origin,
+			message.ProtocolTypePubSub,
+			&message.Message{ChannelID: channel.String(), Payload: p},
+			p)
+		require.NoError(t, err)
+		return scope
+	}
+	victimFromA := newScope(unittest.IdentifierFixture(), payload)
+	victimFromB := newScope(unittest.IdentifierFixture(), payload)
+	filler := newScope(unittest.IdentifierFixture(), []byte("filler-payload"))
+
+	// The dedup event ID is sender-independent.
+	require.Equal(t, victimFromA.EventID(), victimFromB.EventID(),
+		"identical channel+payload from different senders yields the identical event ID")
+	require.NotEqual(t, filler.EventID(), victimFromA.EventID())
+
+	// Step 1: occupy the single queue slot.
+	require.NoError(t, n.processNetworkMessage(filler))
+	require.Equal(t, 1, n.queue.Len())
+
+	// Step 2: the victim message arrives during the queue-full window and is dropped.
+	metricsCollector.On("QueueFullInboundMessagesDropped", channel.String(), message.ProtocolTypePubSub.String(), victimFromA.PayloadType()).Once()
+	err := n.processNetworkMessage(victimFromA)
+	require.ErrorIs(t, err, queue.ErrQueueFull,
+		"victim message is rejected because the inbound queue is full")
+	require.Equal(t, 1, n.queue.Len(), "only the filler remains queued")
+
+	// Step 3: the failed enqueue rolled back the dedup cache entry, so the event ID of the
+	// dropped message is no longer present. Probing the cache with Add returns true (unseen).
+	require.True(t, n.receiveCache.Add(victimFromA.EventID()),
+		"event ID of a queue-full-dropped message must not remain in the dedup cache")
+
+	// The cache Add above is just a probe; remove it to restore the prior cache state.
+	require.True(t, n.receiveCache.Remove(victimFromA.EventID()),
+		"probe entry must be removable")
+
+	// Step 4: a queue worker drains the filler.
+	require.NotNil(t, n.queue.Remove())
+	require.Equal(t, 0, n.queue.Len())
+
+	// Step 5: the identical payload is retransmitted by a different publisher and accepted.
+	err = n.processNetworkMessage(victimFromB)
+	require.NoError(t, err,
+		"retransmission of a previously dropped message must be accepted")
+	require.Equal(t, 1, n.queue.Len(),
+		"retransmission must be enqueued so the engine can process it")
 }


### PR DESCRIPTION
## Problem

`processNetworkMessage` adds an incoming message's event ID to the dedup (receive) cache before inserting it into the inbound queue. If the queue is full, insertion fails but the cache entry is never rolled back. Since the event ID is a hash of channel and payload only (no sender), a later retransmission of the same payload — from any publisher — is dropped as a duplicate and never reaches its engine. The entry eventually ages out via LRU eviction, so the effect is bounded, but the message is incorrectly treated as seen until then.

Queue-full drops are also currently only visible as a Warn log; there is no metric.

## Changes

- `ReceiveCache.Remove`: new method so a dedup entry can be rolled back.
- `processNetworkMessage`: on queue insertion failure, remove the event ID from the dedup cache. The goroutine that successfully added the entry exclusively owns it until removal (concurrent duplicates get `false` from `Add` and drop), so the rollback cannot remove another goroutine's entry.
- New `QueueFullInboundMessagesDropped` metric (channel/protocol/message-type labels, cluster topics normalized) emitted on queue-full drops, making inbound back-pressure observable.

## Tests

- `network/cache`: `TestRemove` covers the new `ReceiveCache.Remove`.
- `network/underlay`: regression test asserting that after a queue-full drop, the event ID does not remain in the dedup cache, the metric is emitted, and a retransmission of the same payload from a different publisher is accepted. Verified to fail at the rollback assertion without the fix; passes with `-race`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791592106&installation_model_id=15376&pr_number=8697&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8697&signature=555df66175dcb83e07a913d8f941adb47a4b13c783c7ece6e5a5765ea468ac10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics for inbound messages dropped when the receiving queue is full, categorized by channel, protocol, and message type.

* **Bug Fixes**
  * Messages rejected because the inbound queue is full can now be retransmitted successfully instead of being incorrectly treated as duplicates.
  * Queue-full drops are now recorded for improved monitoring and troubleshooting.

* **Tests**
  * Added coverage for queue-full handling, deduplication rollback, and retransmission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->