### PR TITLE
Remove obsolete TODOs in fvm and apply small fixes

### DIFF
--- a/fvm/blueprints/contracts.go
+++ b/fvm/blueprints/contracts.go
@@ -93,7 +93,6 @@ func SetIsContractDeploymentRestrictedTransaction(serviceAccount flow.Address, r
 		Build()
 }
 
-// TODO (ramtin) get rid of authorizers
 func DeployContractTransaction(address flow.Address, contract []byte, contractName string) *flow.TransactionBodyBuilder {
 	return flow.NewTransactionBodyBuilder().
 		SetScript(DeployContractTransactionTemplate).

--- a/fvm/errors/base.go
+++ b/fvm/errors/base.go
@@ -24,8 +24,7 @@ func NewInvalidAddressErrorf(
 // transaction includes invalid arguments. This error is the result of failure
 // in any of the following conditions:
 // - number of arguments doesn't match the template
-//
-// TODO add more cases like argument size
+// - argument is not json decodable
 func NewInvalidArgumentErrorf(msg string, args ...any) CodedError {
 	return NewCodedError(
 		ErrCodeInvalidArgumentError,

--- a/fvm/evm/emulator/state/collection.go
+++ b/fvm/evm/emulator/state/collection.go
@@ -52,10 +52,7 @@ func (cp *CollectionProvider) CollectionByID(collectionID []byte) (*Collection, 
 		return nil, err
 	}
 
-	// TODO: expose SlabID.Address() in atree
-
-	var address atree.Address
-	binary.BigEndian.PutUint64(address[:], slabID.AddressAsUint64())
+	address := slabID.Address()
 
 	// sanity check the storage ID address
 	if address != cp.rootAddr {

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -77,7 +77,7 @@ func NewContractHandler(
 }
 
 // ResetCaches resets caches. It is called by the runtime pool via
-// SwappableEnvironment.onSwap when the runtime is borrowed or returned.
+// swappableEnvironment.onSwap when the runtime is borrowed or returned.
 func (h *ContractHandler) ResetCaches() {
 	h.evmDryCallCache = nil
 }

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -709,8 +709,6 @@ func TestHandler_COA(t *testing.T) {
 			})
 		})
 	})
-
-	// TODO add test with test emulator for unhappy cases (emulator)
 }
 
 func TestHandler_TransactionRun(t *testing.T) {

--- a/fvm/evm/types/precompiled.go
+++ b/fvm/evm/types/precompiled.go
@@ -59,8 +59,6 @@ func (apc AggregatedPrecompiledCalls) IsEmpty() bool {
 // Encode encodes the aggregated precompile calls using rlp encoding
 // if there is no underlying call, we encode to empty bytes to save
 // space on transaction results (common case)
-// TODO: In the future versions of the encoding we might skip encoding the inputs
-// given it just takes space and not needed during execution time
 func (apc AggregatedPrecompiledCalls) Encode() ([]byte, error) {
 	if apc.IsEmpty() {
 		return []byte{}, nil

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -3347,7 +3347,7 @@ func TestEVM(t *testing.T) {
 					}`,
 					sc.FungibleToken.Address.HexWithPrefix(),
 					sc.FlowToken.Address.HexWithPrefix(),
-					sc.FlowServiceAccount.Address.HexWithPrefix(), // TODO this should be sc.EVM.Address not found there???
+					sc.EVMContract.Address.HexWithPrefix(),
 				)).
 				SetProposalKey(chain.ServiceAddress(), 0, 0).
 				AddAuthorizer(chain.ServiceAddress()).

--- a/fvm/runtime/cadence_function_declarations.go
+++ b/fvm/runtime/cadence_function_declarations.go
@@ -23,7 +23,7 @@ var randomSourceFunctionType = &sema.FunctionType{
 }
 
 // BlockRandomSourceDeclaration returns a declaration for the `randomSource` function.
-// if the environment is a SwappableEnvironment the underlying environment can be swapped without causing issues.
+// if the environment is a swappableEnvironment the underlying environment can be swapped without causing issues.
 func BlockRandomSourceDeclaration(fvmEnv environment.Environment) stdlib.StandardLibraryValue {
 	// Declare the `randomSourceHistory` function. This function is **only** used by the
 	// System transaction, to fill the `RandomBeaconHistory` contract via the heartbeat
@@ -61,7 +61,7 @@ var transactionIndexFunctionType = &sema.FunctionType{
 }
 
 // TransactionIndexDeclaration returns a declaration for the `getTransactionIndex` function.
-// if the environment is a SwappableEnvironment the underlying environment can be swapped without causing issues.
+// if the environment is a swappableEnvironment the underlying environment can be swapped without causing issues.
 func TransactionIndexDeclaration(fvmEnv environment.Environment) stdlib.StandardLibraryValue {
 	return stdlib.StandardLibraryValue{
 		Name:      "getTransactionIndex",
@@ -82,7 +82,7 @@ func TransactionIndexDeclaration(fvmEnv environment.Environment) stdlib.Standard
 }
 
 // EVMInternalEVMContractValue creates an internal EVM contract value based on the specified ChainID and environment.
-// if the environment is a SwappableEnvironment the underlying environment can be swapped without causing issues.
+// if the environment is a swappableEnvironment the underlying environment can be swapped without causing issues.
 func EVMInternalEVMContractValue(chainID flow.ChainID, fvmEnv environment.Environment) *interpreter.SimpleCompositeValue {
 	if fvmEnv == nil {
 		return nil
@@ -107,11 +107,11 @@ func EVMInternalEVMContractValue(chainID flow.ChainID, fvmEnv environment.Enviro
 		evmEmulator,
 	)
 
-	// Register cache cleanup callback on the SwappableEnvironment.
+	// Register cache cleanup callback on the swappableEnvironment.
 	// This ensures the cache is cleared whenever the runtime is
 	// borrowed for a new transaction or returned to the pool.
-	if se, ok := fvmEnv.(*SwappableEnvironment); ok {
-		se.RegisterOnSwapCallback(contractHandler.ResetCaches)
+	if se, ok := fvmEnv.(*swappableEnvironment); ok {
+		se.registerOnSwapCallback(contractHandler.ResetCaches)
 	}
 
 	return impl.NewInternalEVMContractValue(

--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -12,9 +12,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// TODO(JanezP): unexport all types in this file
-// They are just used by some test
-
 // reusableCadenceRuntime is a wrapper around cadence Runtime and cadence Environment
 // with pre-injected cadence context for: EVM, getTransactionIndex, ...
 // it can be reused by changing the fvmEnv. The reuse happens accross blocks and between scripts and transactions
@@ -36,21 +33,21 @@ type reusableCadenceRuntime struct {
 	TxRuntimeEnv     runtime.Environment
 	ScriptRuntimeEnv runtime.Environment
 
-	fvmEnv *SwappableEnvironment
+	fvmEnv *swappableEnvironment
 }
 
-// SwappableEnvironment is a wrapper type that extends the functionality of environment.Environment.
+// swappableEnvironment is a wrapper type that extends the functionality of environment.Environment.
 // It is designed to allow dynamic replacement of the underlying environment implementation.
-type SwappableEnvironment struct {
+type swappableEnvironment struct {
 	environment.Environment
 	onSwap []func() // Callbacks triggered on every SetFvmEnvironment call.
 }
 
-// RegisterOnSwapCallback registers a callback that is invoked whenever
+// registerOnSwapCallback registers a callback that is invoked whenever
 // the underlying Environment is swapped (during pool Borrow and Return).
 // This enables long-lived, reusable objects to clear per-transaction
 // caches at transaction boundaries.
-func (se *SwappableEnvironment) RegisterOnSwapCallback(cb func()) {
+func (se *swappableEnvironment) registerOnSwapCallback(cb func()) {
 	se.onSwap = append(se.onSwap, cb)
 }
 
@@ -64,7 +61,7 @@ func newReusableCadenceRuntime(
 		chain:            chain,
 		TxRuntimeEnv:     runtime.NewBaseInterpreterEnvironment(config),
 		ScriptRuntimeEnv: runtime.NewScriptInterpreterEnvironment(config),
-		fvmEnv:           &SwappableEnvironment{},
+		fvmEnv:           &swappableEnvironment{},
 	}
 
 	reusable.declareStandardLibraryFunctions()

--- a/fvm/transactionPayerBalanceChecker_test.go
+++ b/fvm/transactionPayerBalanceChecker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/common"
 
 	"github.com/onflow/flow-go/fvm"
 	fvmmock "github.com/onflow/flow-go/fvm/environment/mock"
@@ -16,11 +17,11 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+// verifyPayerBalanceResultType mirrors the VerifyPayerBalanceResult struct
+// defined in the FlowFees contract.
 var verifyPayerBalanceResultType = cadence.NewStructType(
-	// TODO: location
-	nil,
-	// TODO: qualified identifier
-	"",
+	common.NewAddressLocation(nil, common.Address(flow.HexToAddress("1")), "FlowFees"),
+	"A.0000000000000001.FlowFees.VerifyPayerBalanceResult",
 	[]cadence.Field{
 		{
 			Identifier: fvm.VerifyPayerBalanceResultTypeCanExecuteTransactionFieldName,


### PR DESCRIPTION
Reviewed the TODO comments in the fvm package and investigated each one
against the current code. This PR removes 5 obsolete TODOs and resolves
3 more with small fixes.

## Removed (obsolete)

- `blueprints/contracts.go`: "get rid of authorizers". Under Cadence 1.0 the
  authorizer is required: the deploy template takes an
  `auth(AddContract) &Account` signer, obtainable only from a transaction
  authorizer.
- `evm/emulator/state/collection.go`: "expose SlabID.Address() in atree".
  atree v0.16.1 exports it; replaced the `AddressAsUint64` workaround with
  `slabID.Address()`.
- `evm/types/precompiled.go`: "skip encoding inputs in future versions".
  Already done: encoding v2 (current) dropped the input fields.
- `fvm_test.go`: "this should be sc.EVM.Address not found there???". The
  field exists as `sc.EVMContract`; switched to it (value-identical by
  design, `EVMContract.Address == FlowServiceAccount.Address`).
- `evm/handler/handler_test.go`: "add unhappy-case emulator tests". They
  exist: withdraw/deposit unhappy cases with injected emulator failures.

## Fixed

- `errors/base.go`: `NewInvalidArgumentErrorf` doc now lists the actual
  failure cases instead of a TODO.
- `runtime/reusable_cadence_runtime.go`: unexported `SwappableEnvironment`
  (now `swappableEnvironment`), the last exported type flagged by the TODO.
  All uses were in-package.
- `transactionPayerBalanceChecker_test.go`: filled in the fixture location
  and qualified identifier to match the real FlowFees
  `VerifyPayerBalanceResult` type.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onflow/codesmith/flow-go/pr/8698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791639272&installation_model_id=15376&pr_number=8698&repository=onflow%2Fflow-go&return_to=https%3A%2F%2Fgithub.com%2Fonflow%2Fflow-go%2Fpull%2F8698&signature=a3a9c8f2c865bdcb0007451c4e68b54e2d0203d2b92f05055417871aad0f8c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified when invalid argument errors can occur, including arguments that cannot be decoded as JSON.

- **Refactor**
  - Improved internal runtime encapsulation and collection address handling without changing externally visible behavior.

- **Tests**
  - Updated contract deployment and payer balance test setup to use more accurate contract and address information.

- **Maintenance**
  - Removed outdated implementation notes and TODO comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->